### PR TITLE
Theme prop has no effect — CSS custom properties resolved at :root before --pptx-* vars are set

### DIFF
--- a/packages/shared/src/theme/css-vars.test.ts
+++ b/packages/shared/src/theme/css-vars.test.ts
@@ -19,6 +19,22 @@ describe('themeToCssVars', () => {
 		expect(vars['--pptx-primary']).toBe('#FF0000');
 	});
 
+	it('should also emit --color-* alongside --pptx-* for each color', () => {
+		const vars = themeToCssVars({
+			colors: { primary: '#FF0000', background: '#FFFFFF' },
+		});
+		expect(vars['--color-primary']).toBe('#FF0000');
+		expect(vars['--color-background']).toBe('#FFFFFF');
+	});
+
+	it('should not emit --color-* for colors that are omitted via omitDefaults', () => {
+		const vars = themeToCssVars(
+			{ colors: { primary: defaultThemeColors.primary } },
+			true,
+		);
+		expect(vars['--color-primary']).toBeUndefined();
+	});
+
 	it('should convert camelCase keys to kebab-case CSS properties', () => {
 		const vars = themeToCssVars({
 			colors: {
@@ -35,6 +51,20 @@ describe('themeToCssVars', () => {
 	it('should include radius when specified', () => {
 		const vars = themeToCssVars({ radius: '0.75rem' });
 		expect(vars['--pptx-radius']).toBe('0.75rem');
+	});
+
+	it('should emit derived --radius-* tokens alongside --pptx-radius', () => {
+		const vars = themeToCssVars({ radius: '0.75rem' });
+		expect(vars['--radius-sm']).toBe('calc(0.75rem - 4px)');
+		expect(vars['--radius-md']).toBe('calc(0.75rem - 2px)');
+		expect(vars['--radius-lg']).toBe('0.75rem');
+		expect(vars['--radius-xl']).toBe('calc(0.75rem + 4px)');
+	});
+
+	it('should not emit --radius-* tokens when radius is omitted via omitDefaults', () => {
+		const vars = themeToCssVars({ radius: defaultRadius }, true);
+		expect(vars['--radius-sm']).toBeUndefined();
+		expect(vars['--radius-lg']).toBeUndefined();
 	});
 
 	it('should include escape-hatch cssVars', () => {

--- a/packages/shared/src/theme/css-vars.ts
+++ b/packages/shared/src/theme/css-vars.ts
@@ -57,6 +57,9 @@ export function themeToCssVars(
 				continue;
 			}
 			vars[`--pptx-${cssSuffix}`] = value;
+			// Also set the Tailwind semantic token directly so it overrides the
+			// @theme :root declaration, which cannot see vars set on a child element.
+			vars[`--color-${cssSuffix}`] = value;
 		}
 	}
 
@@ -64,6 +67,12 @@ export function themeToCssVars(
 	if (theme.radius !== undefined) {
 		if (!omitDefaults || theme.radius !== defaultRadius) {
 			vars['--pptx-radius'] = theme.radius;
+			// Mirror the @theme derived tokens directly for the same reason as colors.
+			const r = theme.radius;
+			vars['--radius-sm'] = `calc(${r} - 4px)`;
+			vars['--radius-md'] = `calc(${r} - 2px)`;
+			vars['--radius-lg'] = r;
+			vars['--radius-xl'] = `calc(${r} + 4px)`;
 		}
 	}
 


### PR DESCRIPTION
The theme prop is documented as the way to customise colours, but it has no effect in any browser. The viewer always renders with the dark defaults regardless of what values are passed.

##  Root cause

The stylesheet defines the semantic colour tokens on `:root` inside `@layer` theme:
```
  @layer theme {
    :root, :host {
      --color-background: var(--pptx-background, #030712);
      --color-secondary:  var(--pptx-secondary,  #1f2937);
      /* … */
    }
  }
```
The theme prop works by setting --pptx-* as inline styles on the [data-pptx-viewer] root element. The intention is that children resolve var(--color-background) → var(--pptx-background, …) → the overridden value.

However, CSS custom property computed values are resolved at the element where they are declared. Because --color-background is declared on :root, the browser substitutes `var(--pptx-background, #030712)` there — where `--pptx-background` is not set — producing the concrete dark fallback `#030712`. That resolved value is what inherits to all descendants. By the time `--pptx-background` is set on [data-pptx-viewer], `--color-background` is already a baked-in dark value and the inline style is ignored.

## Fix
Fix by emitting the Tailwind semantic tokens (`--color-*`, `--radius-*`) as
inline styles alongside `--pptx-*`. Inline styles beat all author stylesheet
rules unconditionally, so the theme prop now takes effect without touching
the CSS or breaking multi-instance isolation.