### PR TITLE
fix(core): preserve bullets and boundary whitespace on save

### DIFF
--- a/packages/core/src/__tests__/integration/bullet-info-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/bullet-info-roundtrip.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { PresentationBuilder } from '../../core/builders/sdk/PresentationBuilder';
+import { PptxHandler } from '../../core/PptxHandler';
+import type { PptxTextElement } from '../../core/types';
+
+function asArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function findTextElement(handlerData: Awaited<ReturnType<PptxHandler['load']>>): PptxTextElement {
+	const element = handlerData.slides[0]?.elements.find(
+		(candidate): candidate is PptxTextElement =>
+			candidate.type === 'text' && candidate.text?.includes('Plain paragraph') === true,
+	);
+	expect(element, 'plain text element missing after round-trip').toBeTruthy();
+	return element!;
+}
+
+function expectNativeBullet(element: PptxTextElement): void {
+	expect(element.textSegments?.[0]?.bulletInfo?.char).toBe('•');
+	const contentText = element.textSegments
+		?.filter((segment) => !segment.bulletInfo)
+		.map((segment) => segment.text)
+		.join('');
+	expect(contentText).not.toMatch(/^•/);
+}
+
+describe('bulletInfo round-trip', () => {
+	it('preserves a native bullet added to an existing plain paragraph', async () => {
+		const {
+			handler: seedHandler,
+			data: seedData,
+			createSlide,
+		} = await PresentationBuilder.create();
+		seedData.slides.push(
+			createSlide('Blank')
+				.addText('Plain paragraph', { x: 40, y: 40, width: 240, height: 40 })
+				.build(),
+		);
+		const source = await seedHandler.save(seedData.slides);
+
+		const handler = new PptxHandler();
+		const loaded = await handler.load(asArrayBuffer(source));
+		const edited = findTextElement(loaded);
+		expect(edited.textSegments?.[0]?.bulletInfo).toBeUndefined();
+		edited.textSegments![0]!.bulletInfo = { char: '•' };
+
+		const firstSave = await handler.save(loaded.slides);
+		const firstReload = await handler.load(asArrayBuffer(firstSave));
+		const firstResult = findTextElement(firstReload);
+		expectNativeBullet(firstResult);
+
+		const secondSave = await handler.save(firstReload.slides);
+		const secondReload = await handler.load(asArrayBuffer(secondSave));
+		const secondResult = findTextElement(secondReload);
+		expectNativeBullet(secondResult);
+	});
+});

--- a/packages/core/src/__tests__/integration/whitespace-only-run-preserved.test.ts
+++ b/packages/core/src/__tests__/integration/whitespace-only-run-preserved.test.ts
@@ -89,4 +89,44 @@ describe('whitespace-only run text is preserved on load', () => {
 		expect(el, 'text element should have been parsed').toBeDefined();
 		expect(textOf(el!)).toBe('so we immediately start');
 	});
+
+	it('marks boundary whitespace for preservation when saving a native bullet', async () => {
+		const {
+			handler: seedHandler,
+			data: seedData,
+			createSlide,
+		} = await PresentationBuilder.create();
+		seedData.slides.push(
+			createSlide('Blank').addText('test', { x: 40, y: 40, width: 240, height: 40 }).build(),
+		);
+		const source = await seedHandler.save(seedData.slides);
+
+		const handler = new PptxHandler();
+		const loaded = await handler.load(source.buffer as ArrayBuffer);
+		const element = loaded.slides[0]?.elements.find(
+			(candidate) => candidate.type === 'text' && candidate.text?.includes('test'),
+		);
+		expect(element?.type).toBe('text');
+		if (element?.type !== 'text' || !element.textSegments?.[0]) {
+			return;
+		}
+		element.textSegments[0].text = '   test ';
+		element.textSegments[0].bulletInfo = { char: '-' };
+
+		const saved = await handler.save(loaded.slides);
+		const zip = await JSZip.loadAsync(saved);
+		const slideXml = await zip.file('ppt/slides/slide1.xml')?.async('string');
+		expect(slideXml).toContain('<a:t xml:space="preserve">   test </a:t>');
+
+		const reloaded = await handler.load(saved.buffer as ArrayBuffer);
+		const reloadedElement = reloaded.slides[0]?.elements.find(
+			(candidate) => candidate.type === 'text' && candidate.text?.includes('test'),
+		);
+		expect(reloadedElement?.type).toBe('text');
+		if (reloadedElement?.type === 'text') {
+			expect(reloadedElement.textSegments?.find((segment) => !segment.bulletInfo)?.text).toBe(
+				'   test ',
+			);
+		}
+	});
 });

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphs.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphs.ts
@@ -9,6 +9,21 @@ import type { ParagraphSpacingConfig } from './PptxHandlerRuntimeSaveParagraphHe
 import { PptxHandlerRuntime as PptxHandlerRuntimeBase } from './PptxHandlerRuntimeSaveRunProperties';
 
 export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
+	private isRenderedBulletMarker(segment: TextSegment): boolean {
+		const bullet = segment.bulletInfo;
+		if (!bullet) {
+			return false;
+		}
+		const marker = bullet.char
+			? `${bullet.char} `
+			: bullet.imageRelId || bullet.imageDataUrl
+				? '\u{1F4CE} '
+				: bullet.autoNumType
+					? undefined
+					: '• ';
+		return marker ? segment.text === marker : bullet.paragraphIndex !== undefined;
+	}
+
 	protected createParagraphsFromTextContent(
 		text: string | undefined,
 		textStyle: TextStyle | undefined,
@@ -47,9 +62,12 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			return assembleParagraphXml(runs, paragraphProps, endParaRunProperties);
 		};
 
+		const createTextNode = (value: string): string | XmlObject =>
+			/^[\t\n\r ]|[\t\n\r ]$/.test(value) ? { '@_xml:space': 'preserve', '#text': value } : value;
+
 		const createRun = (runText: string, style: TextStyle | undefined) => ({
 			'a:rPr': this.createRunPropertiesFromTextStyle(style, resolveHyperlinkRelationshipId),
-			'a:t': runText,
+			'a:t': createTextNode(runText),
 		});
 
 		const createFieldRun = (
@@ -75,7 +93,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			if (fieldParagraphPropertiesXml && typeof fieldParagraphPropertiesXml === 'object') {
 				fld['a:pPr'] = fieldParagraphPropertiesXml;
 			}
-			fld['a:t'] = runText;
+			fld['a:t'] = createTextNode(runText);
 			return fld;
 		};
 
@@ -99,7 +117,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			);
 			const rtRun = {
 				'a:rPr': rtRunProps,
-				'a:t': segment.rubyText ?? '',
+				'a:t': createTextNode(segment.rubyText ?? ''),
 			};
 			// Base text run
 			const baseRunProps = this.createRunPropertiesFromTextStyle(
@@ -108,7 +126,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			);
 			const baseRun = {
 				'a:rPr': baseRunProps,
-				'a:t': segment.text,
+				'a:t': createTextNode(segment.text),
 			};
 			return {
 				'a:rPr': this.createRunPropertiesFromTextStyle(style, resolveHyperlinkRelationshipId),
@@ -179,7 +197,13 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 					capturedParagraphMeta = true;
 				}
 
-				// Soft line break (`a:br`) — emit a single br node inside the
+				// Parsed bullet markers are display-only segments. The native
+				// paragraph properties above already represent them in OOXML.
+				if (this.isRenderedBulletMarker(segment)) {
+					return;
+				}
+
+				// Soft line break (`a:br`): emit a single br node inside the
 				// current paragraph and never split into a new paragraph.
 				if (segment.isLineBreak) {
 					const brNode: XmlObject = {};
@@ -196,7 +220,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 					return;
 				}
 
-				// Math equation segments — re-emit the original m:oMath /
+				// Math equation segments: re-emit the original m:oMath /
 				// m:oMathPara / mc:AlternateContent subtree captured at parse time.
 				if (segment.equationXml && typeof segment.equationXml === 'object') {
 					const eqNode = {
@@ -212,7 +236,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 
 				lineParts.forEach((linePart, lineIndex) => {
 					if (segment.rubyText !== undefined) {
-						// Ruby segment — emit as a:ruby structure
+						// Ruby segment: emit as a:ruby structure
 						const rubySeg = { ...segment, text: linePart };
 						currentRuns.push(createRubyRun(rubySeg, segmentStyle));
 					} else if (segment.fieldType) {

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.ts
@@ -1,4 +1,5 @@
 import { XmlObject, TextSegment, TextStyle } from '../../types';
+import { xmlText } from '../../utils';
 import { PptxHandlerRuntime as PptxHandlerRuntimeBase } from './PptxHandlerRuntimeShapeTextParsing';
 import type { ShapeTextParsingContext, ParagraphContentResult } from './PptxHandlerRuntimeTypes';
 
@@ -103,8 +104,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 				}
 			}
 
-			const runText =
-				typeof r['a:t'] === 'string' ? r['a:t'] : r['a:t'] !== undefined ? String(r['a:t']) : '';
+			const runText = xmlText(r['a:t']) ?? '';
 			appendRun(runText, r['a:rPr'] as XmlObject | undefined);
 		};
 
@@ -112,12 +112,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			if (!field) {
 				return;
 			}
-			const fieldText =
-				typeof field['a:t'] === 'string'
-					? field['a:t']
-					: field['a:t'] !== undefined
-						? String(field['a:t'])
-						: '';
+			const fieldText = xmlText(field['a:t']) ?? '';
 			const fieldRunStyle = {
 				...mergedDefaultRunStyle,
 				...this.extractTextRunStyle(
@@ -364,7 +359,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 				const rtRunObj = rtRun as XmlObject;
 				const t = rtRunObj['a:t'];
 				if (t !== undefined) {
-					rtParts.push(typeof t === 'string' ? t : String(t));
+					rtParts.push(xmlText(t) ?? '');
 				}
 				// Parse style from the first ruby text run
 				if (!rubyStyle) {
@@ -398,7 +393,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 				const baseRunObj = baseRun as XmlObject;
 				const t = baseRunObj['a:t'];
 				if (t !== undefined) {
-					baseParts.push(typeof t === 'string' ? t : String(t));
+					baseParts.push(xmlText(t) ?? '');
 				}
 				// Use style from the first base run
 				if (baseParts.length === 1) {

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeTextStyleUtils.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeTextStyleUtils.ts
@@ -150,19 +150,22 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 	/**
 	 * Whether a segment carries run-level content that the flat `el.text` string
 	 * cannot represent: an OOXML field (`a:fld`), an inline equation, or a ruby
-	 * (phonetic) annotation. Such segments must survive a save: collapsing them
-	 * to the plain-text path silently downgrades a field to static text (e.g. a
-	 * slide-number field becomes a frozen number) or drops the equation/ruby.
+	 * (phonetic) annotation, or paragraph bullet metadata. Such segments must
+	 * survive a save: collapsing them to the plain-text path silently downgrades
+	 * a field to static text (e.g. a slide-number field becomes a frozen number)
+	 * or drops the equation, ruby, or bullet.
 	 */
 	protected isStructuralTextSegment(segment: TextSegment): boolean {
-		return Boolean(segment.fieldType || segment.equationXml || segment.rubyText);
+		return Boolean(
+			segment.fieldType || segment.equationXml || segment.rubyText || segment.bulletInfo,
+		);
 	}
 
 	protected areTextSegmentsUniform(textSegments: TextSegment[] | undefined): boolean {
 		if (!textSegments || textSegments.length === 0) {
 			return true;
 		}
-		// Even a single segment can be a field/equation/ruby that the flat text
+		// Even a single segment can contain structure that the flat text
 		// string cannot round-trip, so it must not be treated as uniform.
 		if (textSegments.some((segment) => this.isStructuralTextSegment(segment))) {
 			return false;


### PR DESCRIPTION
## Problem

Text segments carrying `bulletInfo` were flattened as uniform text, so native bullets disappeared on save. Boundary whitespace in text runs was emitted without `xml:space="preserve"`, allowing PowerPoint to normalize it.

## Solution

- treat `bulletInfo` as structural text metadata
- skip synthetic rendered bullet-marker segments on subsequent saves
- emit and reload `xml:space="preserve"` for boundary whitespace
- add regression coverage for bullet and whitespace round-trips

## Verification

- core tests: 9,339 passed
- core typecheck passed
- core build passed
- Svelte demo save/reload round-trip passed
- local `act` completed lint, formatting, package builds, and demo builds; the GitHub Pages setup step cannot authenticate to the Pages API outside GitHub Actions