### PR TITLE
feat(shared): morph matching heuristics for media, twins, and group twins

### DIFF
--- a/packages/shared/src/render/morph-flatten.ts
+++ b/packages/shared/src/render/morph-flatten.ts
@@ -184,8 +184,11 @@ function childrenPair(a: PptxElement, b: PptxElement): boolean {
  * Returns the one-for-one correspondence itself, not just a yes/no, because
  * that IS the pairing the matcher then has to honour: see
  * {@link morphGroupChildPairs}.
+ *
+ * Exported for the matcher's group-twin pass, which needs the same evidence
+ * read the same way when it pairs two WHOLE groups whose ids all differ.
  */
-function correspondingChildren(
+export function correspondingChildren(
 	a: readonly PptxElement[],
 	b: readonly PptxElement[],
 ): Array<[PptxElement, PptxElement]> | undefined {

--- a/packages/shared/src/render/morph-heuristics.test.ts
+++ b/packages/shared/src/render/morph-heuristics.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for the appearance/media morph matching heuristics
+ * (`morph-heuristics.ts`): the same-media picture pass and the
+ * identical-twin and group-twin passes, plus the vetoes they share.
+ *
+ * The motivating scenario parks a full-bleed photo off the slide's LEFT edge
+ * and a full-slide black overlay off the RIGHT edge, then morphs both
+ * on-screen while the title recolours. PowerPoint pairs the photo with its
+ * same-named twin (every id differs: the slides were authored
+ * independently), the overlay with its identical-paint twin (same type, box,
+ * fill and line, different name), and a rotated title group with its
+ * un-rotated landing spot (same box, same words, corresponding casts).
+ */
+import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
+import { describe, expect, it } from 'vitest';
+
+import {
+	appearanceSignature,
+	differentText,
+	matchGroupTwins,
+	matchIdenticalTwins,
+	matchSameMedia,
+} from './morph-heuristics';
+import { matchMorphElementsFull } from './morph-matching';
+
+function makeElement(
+	overrides: Partial<PptxElement> & { id: string; type: PptxElement['type'] },
+): PptxElement {
+	return {
+		x: 0,
+		y: 0,
+		width: 100,
+		height: 50,
+		...overrides,
+	} as PptxElement;
+}
+
+function makeSlide(elements: PptxElement[], id = 'slide-1'): PptxSlide {
+	return { id, elements } as PptxSlide;
+}
+
+/** Full-slide overlay with declared paint. */
+function overlay(id: string, x: number, name?: string): PptxElement {
+	return makeElement({
+		id,
+		type: 'shape',
+		name,
+		x,
+		y: 0,
+		width: 1279,
+		height: 720,
+		shapeType: 'rect',
+		shapeStyle: {
+			fillMode: 'solid',
+			fillColor: '#000000',
+			fillOpacity: 0.58824,
+			strokeColor: '#000000',
+			strokeWidth: 2,
+			strokeOpacity: 0.50196,
+		},
+	});
+}
+
+function picture(id: string, x: number, overrides: Partial<PptxElement> = {}): PptxElement {
+	return makeElement({
+		id,
+		type: 'picture',
+		name: 'Picture 2',
+		x,
+		y: 0,
+		width: 1279,
+		height: 720,
+		imagePath: 'ppt/media/image1.jpeg',
+		...overrides,
+	});
+}
+
+describe('differentText', () => {
+	it('flags two wordful elements that say different things', () => {
+		const a = makeElement({ id: 'a', type: 'text', text: 'Hello' });
+		const b = makeElement({ id: 'b', type: 'text', text: 'World' });
+		expect(differentText(a, b)).toBeTruthy();
+	});
+
+	it('ignores whitespace differences and wordless elements', () => {
+		const a = makeElement({ id: 'a', type: 'text', text: 'Hello  world' });
+		const b = makeElement({ id: 'b', type: 'text', text: 'Hello world' });
+		expect(differentText(a, b)).toBeFalsy();
+		expect(differentText(makeElement({ id: 'c', type: 'text' }), b)).toBeFalsy();
+	});
+});
+
+describe('appearanceSignature', () => {
+	it('separates shapes by their declared paint', () => {
+		const black = overlay('a', 0);
+		const white = overlay('b', 0);
+		(white as { shapeStyle: Record<string, unknown> }).shapeStyle.fillColor = '#FFFFFF';
+		expect(appearanceSignature(black)).not.toBe(appearanceSignature(white));
+	});
+
+	it('separates pictures by their media part', () => {
+		expect(appearanceSignature(picture('a', 0))).not.toBe(
+			appearanceSignature(picture('b', 0, { imagePath: 'ppt/media/image2.png' })),
+		);
+		expect(appearanceSignature(picture('a', 0))).toBe(appearanceSignature(picture('b', 500)));
+	});
+});
+
+describe('matchSameMedia', () => {
+	it('pairs same-named pictures carrying the same media across the slide', () => {
+		const from = makeSlide([picture('a', -1279)]);
+		const to = makeSlide([picture('b', 1)], 'slide-2');
+		const usedFrom = new Set<string>();
+		const usedTo = new Set<string>();
+		const pairs = matchSameMedia(from.elements, to.elements, usedFrom, usedTo);
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].fromElement.id).toBe('a');
+		expect(pairs[0].toElement.id).toBe('b');
+	});
+
+	it('refuses the same name when the media differs', () => {
+		const from = makeSlide([picture('a', -1279)]);
+		const to = makeSlide(
+			[picture('b', 1, { imagePath: 'ppt/media/image2.png', name: 'Picture 2' })],
+			'slide-2',
+		);
+		expect(matchSameMedia(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('pairs the same media even when the names differ', () => {
+		const from = makeSlide([picture('a', -729, { name: 'Picture 12' })]);
+		const to = makeSlide([picture('b', 0, { name: 'Picture 8' })], 'slide-2');
+		const pairs = matchSameMedia(from.elements, to.elements, new Set(), new Set());
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].fromElement.id).toBe('a');
+	});
+
+	it('pairs unnamed pictures carrying the same media', () => {
+		const from = makeSlide([picture('a', -1279, { name: undefined })]);
+		const to = makeSlide([picture('b', 1, { name: undefined })], 'slide-2');
+		expect(matchSameMedia(from.elements, to.elements, new Set(), new Set())).toHaveLength(1);
+	});
+
+	it('does not cross-path two same-named pictures', () => {
+		// The same thumbnail sits off the LEFT edge (520 wide) and off the RIGHT
+		// edge (457 wide); each morphs into the nearest on-slide copy. A
+		// first-in-order pairing would cross them and read as a speed mismatch.
+		const from = makeSlide([
+			picture('a-left', -1148, { width: 520, height: 297, x: -1148 }),
+			picture('a-right', 1966, { width: 457, height: 297, x: 1966 }),
+		]);
+		const to = makeSlide(
+			[
+				picture('b-right', 671, { width: 457, height: 297, x: 671 }),
+				picture('b-left', 152, { width: 520, height: 297, x: 152 }),
+			],
+			'slide-2',
+		);
+		const pairs = matchSameMedia(from.elements, to.elements, new Set(), new Set());
+		const byFrom = new Map(pairs.map((p) => [p.fromElement.id, p.toElement.id]));
+		expect(byFrom.get('a-left')).toBe('b-left');
+		expect(byFrom.get('a-right')).toBe('b-right');
+	});
+
+	it('refuses conflicting !! names', () => {
+		const from = makeSlide([picture('a', -1279, { name: '!!hero' })]);
+		const to = makeSlide([picture('b', 1, { name: '!!villain' })], 'slide-2');
+		expect(matchSameMedia(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+});
+
+describe('matchGroupTwins', () => {
+	/** A staged title panel: backdrop + title, rotated. */
+	function titlePanel(
+		id: string,
+		x: number,
+		y: number,
+		rotation: number,
+		overrides: Partial<PptxElement> = {},
+	): PptxElement {
+		return makeElement({
+			id,
+			type: 'group',
+			name: overrides.name ?? `Group ${id}`,
+			x,
+			y,
+			width: 1280,
+			height: 720,
+			rotation,
+			children: [
+				makeElement({ id: `${id}-backdrop`, type: 'shape', width: 1280, height: 720 }),
+				makeElement({
+					id: `${id}-title`,
+					type: 'text',
+					name: 'Title 1',
+					text: overrides.text ?? 'Panel headline',
+				}),
+			],
+		} as Partial<PptxElement>);
+	}
+
+	it('pairs same-size groups with corresponding casts however far apart they sit', () => {
+		const from = makeSlide([titlePanel('a', -411, -1009, 327.1)]);
+		const to = makeSlide([titlePanel('b', 0, 0, 0)], 'slide-2');
+		const pairs = matchGroupTwins(from.elements, to.elements, new Set(), new Set());
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].fromElement.id).toBe('a');
+		expect(pairs[0].toElement.id).toBe('b');
+	});
+
+	it('refuses groups whose words differ (issue #144 drifting text)', () => {
+		const from = makeSlide([titlePanel('a', 533, 285, 0, { text: 'Secure Data Movement' })]);
+		const to = makeSlide([titlePanel('b', 717, 283, 0, { text: 'Possumus continer' })], 'slide-2');
+		expect(matchGroupTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses groups of different sizes', () => {
+		const from = makeSlide([titlePanel('a', -411, -1009, 327.1)]);
+		const to = makeSlide(
+			[makeElement({ id: 'b', type: 'group', x: 0, y: 0, width: 640, height: 360, children: [] })],
+			'slide-2',
+		);
+		expect(matchGroupTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses groups whose casts do not line up one for one', () => {
+		const from = makeSlide([titlePanel('a', -411, -1009, 327.1)]);
+		const to = makeSlide(
+			[
+				makeElement({
+					id: 'b',
+					type: 'group',
+					x: 0,
+					y: 0,
+					width: 1280,
+					height: 720,
+					children: [makeElement({ id: 'b-only', type: 'shape', width: 1280, height: 720 })],
+				}),
+			],
+			'slide-2',
+		);
+		expect(matchGroupTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses conflicting !! names', () => {
+		const from = makeSlide([titlePanel('a', -411, -1009, 327.1, { name: '!!hero' })]);
+		const to = makeSlide([titlePanel('b', 0, 0, 0, { name: '!!villain' })], 'slide-2');
+		expect(matchGroupTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('pairs the staged title panel through the full matcher', () => {
+		const from = makeSlide([picture('a-photo', 1), titlePanel('a-group', -411, -1009, 327.1)]);
+		const to = makeSlide([picture('b-photo', 1), titlePanel('b-group', 0, 0, 0)], 'slide-2');
+		const { pairs } = matchMorphElementsFull(from, to);
+		const byFrom = new Map(pairs.map((p) => [p.fromElement.id, p.toElement.id]));
+		expect(byFrom.get('a-group')).toBe('b-group');
+	});
+});
+
+describe('matchIdenticalTwins', () => {
+	it('pairs identical painted shapes however far apart they sit', () => {
+		const from = makeSlide([overlay('a', 1279, 'Rectangle 6')]);
+		const to = makeSlide([overlay('b', 1, 'Rectangle 1')], 'slide-2');
+		const pairs = matchIdenticalTwins(from.elements, to.elements, new Set(), new Set());
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].fromElement.id).toBe('a');
+		expect(pairs[0].toElement.id).toBe('b');
+	});
+
+	it('refuses unstyled shapes, which carry no identity statement', () => {
+		const from = makeSlide([makeElement({ id: 'a', type: 'shape', x: 0, y: 0 })]);
+		const to = makeSlide([makeElement({ id: 'b', type: 'shape', x: 900, y: 900 })], 'slide-2');
+		expect(matchIdenticalTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses the same size when the paint differs', () => {
+		const white = overlay('b', 1, 'Rectangle 1');
+		(white as { shapeStyle: Record<string, unknown> }).shapeStyle.fillColor = '#FFFFFF';
+		const from = makeSlide([overlay('a', 1279, 'Rectangle 6')]);
+		const to = makeSlide([white], 'slide-2');
+		expect(matchIdenticalTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses the same paint when the size differs', () => {
+		const from = makeSlide([overlay('a', 1279, 'Rectangle 6')]);
+		const to = makeSlide([overlay('b', 1, 'Rectangle 1')], 'slide-2');
+		(to.elements[0] as { width: number }).width = 640;
+		expect(matchIdenticalTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses wordful twins that say different things', () => {
+		const from = makeSlide([overlay('a', 1279)]);
+		const to = makeSlide([overlay('b', 1)], 'slide-2');
+		(from.elements[0] as { text: string }).text = 'Hello';
+		(to.elements[0] as { text: string }).text = 'World';
+		expect(matchIdenticalTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+});
+
+describe('morph matching end to end', () => {
+	// The full matcher wiring: the title recolours via its creationId, the
+	// photo glides in from the left via name + media, and the overlay glides
+	// in from the right as an identical twin.
+	function stagedSlides(): { from: PptxSlide; to: PptxSlide } {
+		const from = makeSlide([
+			makeElement({ id: 'a-text', type: 'text', text: 'The Future', x: 219, y: 262 }),
+			picture('a-pic', -1279),
+			overlay('a-rect', 1279, 'Rectangle 6'),
+		]);
+		const to = makeSlide(
+			[
+				picture('b-pic-in', 1),
+				makeElement({
+					id: 'b-pic-top',
+					type: 'picture',
+					name: 'Picture 5',
+					x: 0,
+					y: -737,
+					imagePath: 'ppt/media/image2.png',
+				}),
+				overlay('b-rect', 1, 'Rectangle 1'),
+				makeElement({ id: 'b-text', type: 'text', text: 'The Future', x: 219, y: 262 }),
+				makeElement({ id: 'b-dot', type: 'shape', x: 624, y: 344, width: 32, height: 32 }),
+			],
+			'slide-2',
+		);
+		return { from, to };
+	}
+
+	it('pairs the photo, the overlay, and the title', () => {
+		const { from, to } = stagedSlides();
+		const { pairs } = matchMorphElementsFull(from, to);
+		const byFrom = new Map(pairs.map((p) => [p.fromElement.id, p.toElement.id]));
+		expect(byFrom.get('a-pic')).toBe('b-pic-in');
+		expect(byFrom.get('a-rect')).toBe('b-rect');
+		// The title carries no identity here beyond its words and position, so
+		// it pairs by proximity; the off-stage leftovers stay unmatched.
+		expect(pairs.length).toBeGreaterThanOrEqual(2);
+	});
+});

--- a/packages/shared/src/render/morph-heuristics.ts
+++ b/packages/shared/src/render/morph-heuristics.ts
@@ -1,0 +1,329 @@
+/**
+ * Appearance and media heuristics for the weaker morph matching passes.
+ *
+ * PowerPoint's by-object matcher does not stop at explicit identity
+ * (`!!` names, `a16:creationId`): real decks show it also pairs a picture
+ * with its counterpart across independently-authored slides (same
+ * `cNvPr/@name`, same image bytes, every id different) and glides in a
+ * full-slide overlay whose twin is identical apart from where it sits. These
+ * passes reproduce that without overreaching: media identity is exact, and
+ * the twin pass demands the same type, the exact same box size and the same
+ * resolved paint, so the issue #131 wheel (same ids and names, different
+ * colours and sizes) keeps falling through to proximity.
+ *
+ * Everything here is pure; the pass bookkeeping (used-element sets) is owned
+ * by `morph-matching`, which calls into this module one-way.
+ *
+ * @module render/morph-heuristics
+ */
+
+import type { GroupPptxElement, PptxElement } from 'pptx-viewer-core';
+
+import { correspondingChildren } from './morph-flatten';
+import { getElementMorphName } from './morph-name';
+import type { MorphPair } from './morph-types';
+
+/** Depth cap for the recursive text read; real decks never nest this far. */
+const TEXT_MAX_DEPTH = 8;
+
+/**
+ * Everything an element WRITES, including the text of its descendants.
+ *
+ * A group paints nothing itself - all of its words live in its children - so
+ * reading only `element.text` reports every group as wordless and lets two
+ * groups with nothing in common look interchangeable (issue #144: a wheel
+ * slide's centre panel paired with a detail slide's callout box and glided
+ * across the slide, "drifting text").
+ */
+function elementText(element: PptxElement, depth = 0): string {
+	const own = (element as { text?: string }).text ?? '';
+	const children = (element as { children?: PptxElement[] }).children;
+	if (!children || depth >= TEXT_MAX_DEPTH) {
+		return own;
+	}
+	let text = own;
+	for (const child of children) {
+		text += ` ${elementText(child, depth + 1)}`;
+	}
+	return text;
+}
+
+/**
+ * Whether two elements both carry text, and carry DIFFERENT text.
+ *
+ * Used to veto a purely positional or appearance-based match:
+ * same-place-different-words is the signature of a rebuilt panel, not of one
+ * object that moved. Whitespace is normalised so a reflowed line break does
+ * not read as a different string.
+ */
+export function differentText(a: PptxElement, b: PptxElement): boolean {
+	const textOf = (element: PptxElement): string =>
+		elementText(element).replace(/\s+/gu, ' ').trim();
+	const fromText = textOf(a);
+	const toText = textOf(b);
+	return fromText !== '' && toText !== '' && fromText !== toText;
+}
+
+/**
+ * Whether two elements both carry an explicit `!!` morph name and those names
+ * DIFFER.
+ *
+ * The `!!` prefix is the author telling PowerPoint which shapes are the same
+ * object across slides, so two different `!!` names are a statement that these
+ * two are NOT (pass 1 already paired every side that agreed). Letting such a
+ * pair fall through to a weaker signal lets an off-canvas box fly in from
+ * off-stage - the "mystery box" of issue #144. Mirrors the `a16:creationId`
+ * rule in pass 2b: evidence of identity that disagrees is evidence of
+ * difference.
+ */
+export function conflictingMorphNames(a: PptxElement, b: PptxElement): boolean {
+	const fromName = getElementMorphName(a);
+	if (!fromName) {
+		return false;
+	}
+	const toName = getElementMorphName(b);
+	return Boolean(toName) && toName !== fromName;
+}
+
+/** The media part an image/picture element paints (path, else data URL). */
+function mediaIdentity(el: PptxElement): string | undefined {
+	const props = el as { imagePath?: string; imageData?: string };
+	return props.imagePath ?? props.imageData ?? undefined;
+}
+
+/** Euclidean distance between two elements' top-left corners (slide space). */
+function centreDistance(a: PptxElement, b: PptxElement): number {
+	const dx = a.x - b.x;
+	const dy = a.y - b.y;
+	return Math.sqrt(dx * dx + dy * dy);
+}
+
+/** Whether two elements are the same kind of picture painting the same media. */
+function sameMediaPicture(a: PptxElement, b: PptxElement): boolean {
+	if (a.type !== 'picture' && a.type !== 'image') {
+		return false;
+	}
+	if (b.type !== a.type) {
+		return false;
+	}
+	if (conflictingMorphNames(a, b)) {
+		return false;
+	}
+	const aMedia = mediaIdentity(a);
+	const bMedia = mediaIdentity(b);
+	return Boolean(aMedia) && aMedia === bMedia;
+}
+
+/** The `shapeStyle` paint fields that decide what an element looks like. */
+const APPEARANCE_KEYS = [
+	'fillMode',
+	'fillColor',
+	'fillOpacity',
+	'strokeColor',
+	'strokeWidth',
+	'strokeOpacity',
+	'strokeDash',
+] as const;
+
+/**
+ * Whether the element DECLARES paint (an explicit fill or stroke). The twin
+ * pass requires this: two default, unstyled shapes are interchangeable
+ * background debris on any slide, and pairing them is how off-stage boxes
+ * come flying in (the "mystery box" class of bug). A shape whose author
+ * picked a fill and a line and then moved it is a deliberate object.
+ */
+function hasDeclaredPaint(el: PptxElement): boolean {
+	const style = (el as { shapeStyle?: Record<string, unknown> }).shapeStyle;
+	if (!style) {
+		return false;
+	}
+	return APPEARANCE_KEYS.some((key) => style[key] !== undefined);
+}
+
+/**
+ * A canonical string for everything an element LOOKS like (discriminant,
+ * geometry preset, resolved fill/stroke paint, media). Two elements with
+ * equal signatures are visually interchangeable apart from where they sit.
+ */
+export function appearanceSignature(el: PptxElement): string {
+	const style = (el as { shapeStyle?: Record<string, unknown> }).shapeStyle;
+	const parts: string[] = [el.type, (el as { shapeType?: string }).shapeType ?? ''];
+	if (style) {
+		for (const key of APPEARANCE_KEYS) {
+			parts.push(style[key] === undefined ? '' : String(style[key]));
+		}
+	}
+	parts.push(mediaIdentity(el) ?? '');
+	return parts.join('|');
+}
+
+/**
+ * Pass: pair pictures that paint the SAME media part, even when every id - and
+ * often the `cNvPr/@name` - differs.
+ *
+ * Independently-authored slides number their shapes from 1, so "the same
+ * picture" is never the ids (or the creationIds) agreeing: it is the image
+ * bytes agreeing. A full-bleed photo that slides into view is typically
+ * auto-named differently on each slide ("Picture 3" on one, "Picture 7" on
+ * the other); pairing by media is what makes it glide instead of fading in.
+ *
+ * When several outgoing pictures share one media part, the author's Selection
+ * Pane name outranks distance, and the nearest candidate wins the rest -
+ * which keeps two same-named thumbnails parked at opposite edges from
+ * CROSS-pairing (each thumbnail morphs into its nearest on-slide copy, not
+ * its neighbour's).
+ */
+export function matchSameMedia(
+	fromElements: readonly PptxElement[],
+	toElements: readonly PptxElement[],
+	usedFrom: Set<string>,
+	usedTo: Set<string>,
+): MorphPair[] {
+	const pairs: MorphPair[] = [];
+	for (const fromEl of fromElements) {
+		if (usedFrom.has(fromEl.id)) {
+			continue;
+		}
+		const fromName = fromEl.name?.trim();
+		let best: { to: PptxElement; named: boolean; dist: number } | undefined;
+		for (const toEl of toElements) {
+			if (usedTo.has(toEl.id) || !sameMediaPicture(fromEl, toEl)) {
+				continue;
+			}
+			const named = Boolean(fromName) && toEl.name?.trim() === fromName;
+			const dist = centreDistance(fromEl, toEl);
+			const better =
+				best === undefined || (named && !best.named) || (named === best.named && dist < best.dist);
+			if (better) {
+				best = { to: toEl, named, dist };
+			}
+		}
+		if (best) {
+			pairs.push({ fromElement: fromEl, toElement: best.to });
+			usedFrom.add(fromEl.id);
+			usedTo.add(best.to.id);
+		}
+	}
+	return pairs;
+}
+
+/**
+ * Whether two elements are groups of the SAME box size whose children line up
+ * one for one (each child pairs by `!!` name, pane name, or a >= 50% box
+ * overlap - the same evidence the flattener reads before decomposing a pair)
+ * and which read the same. The words veto stays: two near-by panels that say
+ * different things are a rebuilt panel, not one container that moved (issue
+ * #144's drifting text).
+ */
+function sameSizedTwinCasts(a: PptxElement, b: PptxElement): boolean {
+	if (a.type !== 'group' || b.type !== 'group') {
+		return false;
+	}
+	if (a.width !== b.width || a.height !== b.height) {
+		return false;
+	}
+	if (conflictingMorphNames(a, b)) {
+		return false;
+	}
+	if (differentText(a, b)) {
+		return false;
+	}
+	const aChildren = (a as GroupPptxElement).children;
+	const bChildren = (b as GroupPptxElement).children;
+	if (!Array.isArray(aChildren) || !Array.isArray(bChildren)) {
+		return false;
+	}
+	return correspondingChildren(aChildren, bChildren) !== undefined;
+}
+
+/**
+ * Pass: pair whole GROUPS whose casts correspond, even when every id differs.
+ *
+ * A title staged as a rotated full-slide group parked far above the visible
+ * area on one slide and landed un-rotated on the next shares nothing a
+ * stronger pass can read - different `p:cNvPr/@id`, different
+ * `a16:creationId`, often a different name, position and angle - but it is
+ * the same object to a reader: the same box size, the same words, and
+ * children (a backdrop rectangle and a title text box) pairing one for one.
+ * PowerPoint glides the container into place while un-rotating it; pairing
+ * the groups (rather than decomposing them, which would bake the children
+ * out of their rotated frame) reproduces that as one journey interpolating
+ * the box and the angle.
+ */
+export function matchGroupTwins(
+	fromElements: readonly PptxElement[],
+	toElements: readonly PptxElement[],
+	usedFrom: Set<string>,
+	usedTo: Set<string>,
+): MorphPair[] {
+	const pairs: MorphPair[] = [];
+	for (const fromEl of fromElements) {
+		if (usedFrom.has(fromEl.id)) {
+			continue;
+		}
+		for (const toEl of toElements) {
+			if (usedTo.has(toEl.id)) {
+				continue;
+			}
+			if (!sameSizedTwinCasts(fromEl, toEl)) {
+				continue;
+			}
+			pairs.push({ fromElement: fromEl, toElement: toEl });
+			usedFrom.add(fromEl.id);
+			usedTo.add(toEl.id);
+			break;
+		}
+	}
+	return pairs;
+}
+
+/**
+ * Pass: pair "identical twins" - same type, the EXACT same box size and an
+ * identical DECLARED paint (explicit fill/stroke) - no matter how far apart
+ * they sit. The distance-agnostic counterpart of the proximity pass: for two
+ * shapes that are indistinguishable apart from where they are, interpolating
+ * the box is what PowerPoint does, and what a morph is for. Unstyled shapes
+ * carry no such statement and stay unmatched (see {@link hasDeclaredPaint}).
+ */
+export function matchIdenticalTwins(
+	fromElements: readonly PptxElement[],
+	toElements: readonly PptxElement[],
+	usedFrom: Set<string>,
+	usedTo: Set<string>,
+): MorphPair[] {
+	const pairs: MorphPair[] = [];
+	for (const fromEl of fromElements) {
+		if (usedFrom.has(fromEl.id)) {
+			continue;
+		}
+		if (!hasDeclaredPaint(fromEl)) {
+			continue;
+		}
+		const fromSignature = appearanceSignature(fromEl);
+		for (const toEl of toElements) {
+			if (usedTo.has(toEl.id)) {
+				continue;
+			}
+			if (appearanceSignature(toEl) !== fromSignature) {
+				continue;
+			}
+			if (fromEl.width !== toEl.width || fromEl.height !== toEl.height) {
+				continue;
+			}
+			// Same-place-different-words is a rebuilt panel, not a moved object.
+			if (differentText(fromEl, toEl)) {
+				continue;
+			}
+			// An explicit `!!` name that disagrees is the author saying these
+			// are two different objects.
+			if (conflictingMorphNames(fromEl, toEl)) {
+				continue;
+			}
+			pairs.push({ fromElement: fromEl, toElement: toEl });
+			usedFrom.add(fromEl.id);
+			usedTo.add(toEl.id);
+			break;
+		}
+	}
+	return pairs;
+}

--- a/packages/shared/src/render/morph-matching.ts
+++ b/packages/shared/src/render/morph-matching.ts
@@ -3,6 +3,8 @@
  *
  * Matches elements between two consecutive slides using a multi-pass
  * strategy: explicit `!!` naming convention, `a16:creationId` GUID identity,
+ * the child correspondence that let two groups be decomposed, same-media
+ * pictures, identical twins (same type / exact size / identical paint),
  * native shape-id matching (creationId-less decks only), and
  * type + proximity + size matching.
  *
@@ -11,6 +13,13 @@
 import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
 
 import { flattenMorphElements, morphGroupChildPairs } from './morph-flatten';
+import {
+	conflictingMorphNames,
+	differentText,
+	matchGroupTwins,
+	matchIdenticalTwins,
+	matchSameMedia,
+} from './morph-heuristics';
 import { getElementMorphName } from './morph-name';
 import type { MorphMatchResult, MorphPair } from './morph-types';
 import { PROXIMITY_SIZE_RATIO_LIMIT, PROXIMITY_THRESHOLD } from './morph-types';
@@ -23,68 +32,6 @@ import { PROXIMITY_SIZE_RATIO_LIMIT, PROXIMITY_THRESHOLD } from './morph-types';
 // importing this one back (a cycle that breaks once the graph is bundled).
 export { getElementMorphName } from './morph-name';
 
-/** Depth cap for the recursive text read; real decks never nest this far. */
-const TEXT_MAX_DEPTH = 8;
-
-/**
- * Everything an element WRITES, including the text of its descendants.
- *
- * A group paints nothing itself - all of its words live in its children - so
- * reading only `element.text` reports every group as wordless and lets two
- * groups with nothing in common look interchangeable (issue #144: a wheel
- * slide's centre panel paired with a detail slide's callout box and glided
- * across the slide, "drifting text"). The same recursion is why
- * `appearanceSignature` descends into children.
- */
-function elementText(element: PptxElement, depth = 0): string {
-	const own = (element as { text?: string }).text ?? '';
-	const children = (element as { children?: PptxElement[] }).children;
-	if (!children || depth >= TEXT_MAX_DEPTH) {
-		return own;
-	}
-	let text = own;
-	for (const child of children) {
-		text += ` ${elementText(child, depth + 1)}`;
-	}
-	return text;
-}
-
-/**
- * Whether two elements both carry text, and carry DIFFERENT text.
- *
- * Used to veto a purely positional match: same-place-different-words is the
- * signature of a rebuilt panel, not of one object that moved. Whitespace is
- * normalised so a reflowed line break does not read as a different string.
- */
-function differentText(a: PptxElement, b: PptxElement): boolean {
-	const textOf = (element: PptxElement): string =>
-		elementText(element).replace(/\s+/gu, ' ').trim();
-	const fromText = textOf(a);
-	const toText = textOf(b);
-	return fromText !== '' && toText !== '' && fromText !== toText;
-}
-
-/**
- * Whether both elements carry an explicit `!!` morph name and those names
- * DIFFER.
- *
- * The `!!` prefix is the author telling PowerPoint which shapes are the same
- * object across slides, so two different `!!` names are a statement that these
- * two are NOT (pass 1 already paired every side that agreed). Letting such a
- * pair fall through to a weaker signal is how an off-canvas 100x74 rect named
- * `!!D` came to be paired with a detail slide's `!!Breakdgsdfgdfsg` header
- * chip 247px away, flying an empty grey box in from off-stage - the
- * "mystery box" of issue #144. Mirrors the `a16:creationId` rule in pass 2b:
- * evidence of identity that disagrees is evidence of difference.
- */
-function conflictingMorphNames(a: PptxElement, b: PptxElement): boolean {
-	const fromName = getElementMorphName(a);
-	if (!fromName) {
-		return false;
-	}
-	const toName = getElementMorphName(b);
-	return Boolean(toName) && toName !== fromName;
-}
 // ---------------------------------------------------------------------------
 // Creation identity (`a16:creationId`)
 // ---------------------------------------------------------------------------
@@ -146,6 +93,9 @@ export function getElementCreationId(element: PptxElement): string | undefined {
  *   1. Explicit !! naming convention (element name from cNvPr/@name, or text content)
  *   2a. `a16:creationId` GUID (PowerPoint's own cross-slide shape identity)
  *   2c. The child correspondence that let two groups be decomposed
+ *   2d. Same media part (pictures: the same image)
+ *   2e. Identical twins: same type, exact size, identical paint appearance
+ *   2f. Group twins: same-size groups whose child casts correspond one for one
  *   2b. Native shape id from `p:cNvPr/@id` (only when creationIds are absent)
  *   3. Type + proximity + size matching (same type within 300px, similar box)
  *
@@ -264,6 +214,46 @@ export function matchMorphElementsFull(fromSlide: PptxSlide, toSlide: PptxSlide)
 			usedTo.add(toEl.id);
 		}
 	}
+
+	// Pass 2d: same media part (pictures).
+	//
+	// PowerPoint's by-object matcher pairs a picture with its counterpart even
+	// when every id differs: slides authored independently number their shapes
+	// from 1, so the same off-stage full-bleed photo can carry the same pane
+	// name on both slides with a different `p:cNvPr/@id` AND a different
+	// `a16:creationId` - and the name often differs too ("Picture 3" on one
+	// slide, "Picture 7" on the other). What makes them the same object is the
+	// identical image bytes. Without this pass the pair dissolves and the
+	// picture pops in place instead of gliding in from off-stage.
+	pairs.push(...matchSameMedia(fromElements, toElements, usedFrom, usedTo));
+
+	// Pass 2e: identical twins - same type, the EXACT same box size and an
+	// identical appearance signature, however far apart they sit.
+	//
+	// A title dimmed by a full-slide black overlay parked off one edge on the
+	// outgoing slide and on-screen on the incoming one is the same object
+	// twice over: same shape type, same box, same fill and line, different
+	// name/ids/creationIds, and far beyond the proximity pass's 300px reach.
+	// PowerPoint glides it in from the edge; two shapes indistinguishable
+	// apart from where they sit are the same object as far as a morph is
+	// concerned. The exact-size + identical-paint gate keeps the issue #131
+	// wheel safe: its wedges differ in colour and size, so they still fall
+	// through to proximity.
+	pairs.push(...matchIdenticalTwins(fromElements, toElements, usedFrom, usedTo));
+
+	// Pass 2f: group twins - whole GROUPS of the same box size whose child
+	// casts correspond one for one, however far apart they sit.
+	//
+	// A title panel staged as a rotated full-slide group parked far above the
+	// visible area on one slide and landed un-rotated on the next has nothing
+	// a stronger pass can read: different name/ids/creationIds, different
+	// position and angle - but the same box and a one-for-one child cast
+	// (backdrop rectangle and title text box). PowerPoint glides the container
+	// into place while un-rotating it; pairing the groups (instead of
+	// decomposing them, which would bake the children out of their rotated
+	// frame) reproduces that as one journey interpolating the box and the
+	// angle.
+	pairs.push(...matchGroupTwins(fromElements, toElements, usedFrom, usedTo));
 
 	// Pass 2b: match by the shape's native OOXML id (`p:cNvPr/@id`) - a
 	// fallback for decks whose producer emits no creationIds.


### PR DESCRIPTION
## What does this change?

PowerPoint's by-object morph matcher does not stop at explicit identity: real decks morph elements whose every id differs, because independently-authored slides number their shapes from 1. The matcher only had names, `a16:creationId`, native ids and a 300px proximity pass, so same-named media and same-looking shapes parked far apart dissolved or popped instead of gliding.

This PR adds three weaker matching passes in a new pure shared module (`morph-heuristics.ts`), all honouring the conflicting-`!!`-names veto:

- **2d `matchSameMedia`**: pictures painting the same media part pair up regardless of ids and names. The author's Selection Pane name outranks distance, and the nearest candidate wins the rest - which keeps two same-named thumbnails parked at opposite edges from cross-pairing.
- **2e `matchIdenticalTwins`**: same type, exact box size and identical *declared* paint (explicit fill/stroke), however far apart. The declared-paint gate keeps default unstyled shapes unmatched (the "mystery box" class of bug, issue #144).
- **2f `matchGroupTwins`**: whole groups of the same box size whose child casts correspond one for one, pairing the container so a rotation stays one journey; the different-words veto stays (issue #144's drifting text).

The shared vetoes (`differentText`, `conflictingMorphNames`) move into the new module, and `morph-flatten` exports `correspondingChildren` so the group-twin pass reads the same child evidence the decomposer reads. Overreach is bounded by design: the issue #131 wheel (same ids and names, different colours and sizes) still falls through to proximity.

## Type of change

- [x] New feature (non-breaking)

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

The matcher is framework-agnostic: the change is one shared module, and every binding inherits the improved pairing with no binding code touched.

| Binding                      | Affected? | Fixed / implemented here? | Notes                                                        |
| ---------------------------- | --------- | ------------------------- | ------------------------------------------------------------ |
| React (`packages/react`)     | yes       | yes (shared)              | inherits the new passes; morph e2e specs re-run              |
| Vue (`packages/vue`)         | yes       | yes (shared)              | inherits the new passes; morph e2e specs re-run              |
| Angular (`packages/angular`) | yes       | yes (shared)              | inherits the new passes; morph e2e specs re-run              |
| Svelte (`packages/svelte`)   | yes       | yes (shared)              | inherits the new passes; morph e2e specs re-run              |
| Vanilla (`packages/vanilla`) | yes       | yes (shared)              | inherits the new passes; morph e2e specs re-run              |

Checked by re-running the morph e2e specs locally across all five projects (see Testing).

### New UI feature

- [x] The framework-agnostic logic lives in `pptx-viewer-shared`, not duplicated per binding
- [x] Implemented in **all five** bindings (inherited through the shared matcher)
- [x] No user-visible copy is added, so no i18n keys are needed

---

## Testing

- [x] Unit tests added: `morph-heuristics.test.ts` covers each pass and every veto (different words, conflicting `!!` names, size/paint mismatches, cast mismatches) plus an end-to-end run through the full matcher. All existing morph suites pass unchanged (320 morph tests, 6739 in the full shared suite).
- [x] Regression test added that fails without this change (each pass has a positive pairing case the old matcher cannot produce).
- [x] No new e2e spec: the matcher is exercised through the existing morph specs (`issue-131-fidelity`, `issue-144-morph`, `issue-160-morph-crossfade`, `morph-shape-swap`), which I ran locally across all five projects: 89 passed. The one failure outside those (`issue-131-fidelity` text wrapping) reproduces on clean `main` on all five bindings and is unrelated; a single `issue-144` angular timing flake passed on re-run (10/10).

## Checks run locally

- [x] `bun run lint`
- [x] `bun run fmt:check`
- [x] `bun run typecheck`
- [x] `bun run test` (full shared suite; the bindings carry no morph-specific units - the matcher lives in shared)

## Conventional Commits

- [x] Commit messages follow Conventional Commits (`feat(shared)`).
