### PR TITLE
fix(react): keep selection handles aligned during transforms

### DIFF
--- a/packages/react/src/viewer/components/elements/ResizeHandles.overlay-sync.test.tsx
+++ b/packages/react/src/viewer/components/elements/ResizeHandles.overlay-sync.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ResizeHandles } from './ResizeHandles';
+
+let container: HTMLDivElement;
+let elementHost: HTMLDivElement;
+let handleHost: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+	container = document.createElement('div');
+	elementHost = document.createElement('div');
+	elementHost.setAttribute('data-element-id', 'shape-1');
+	elementHost.getBoundingClientRect = () =>
+		({
+			x: 0,
+			y: 0,
+			left: 0,
+			top: 0,
+			right: 100,
+			bottom: 100,
+			width: 100,
+			height: 100,
+			toJSON: () => ({}),
+		}) as DOMRect;
+	handleHost = document.createElement('div');
+	handleHost.setAttribute('data-pptx-handle-for', 'shape-1');
+	document.body.append(elementHost, handleHost, container);
+	root = createRoot(container);
+});
+
+afterEach(() => {
+	act(() => root.unmount());
+	document.body.replaceChildren();
+});
+
+describe('resize handles live rotation', () => {
+	it('rotates the element and detached selection handles together', () => {
+		const onRotate = vi.fn();
+		act(() => {
+			root.render(
+				<ResizeHandles
+					elementId='shape-1'
+					adjustmentHandles={[]}
+					onResizePointerDown={vi.fn()}
+					onAdjustmentPointerDown={vi.fn()}
+					onRotate={onRotate}
+				/>,
+			);
+		});
+
+		const rotateButton = container.querySelector<HTMLButtonElement>('[data-pptx-compact]');
+		expect(rotateButton).not.toBeNull();
+		rotateButton!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+		window.dispatchEvent(
+			new PointerEvent('pointermove', { clientX: 150, clientY: 50, bubbles: true }),
+		);
+
+		expect(elementHost.style.transform).toBe('rotate(90deg)');
+		expect(handleHost.style.transform).toBe('rotate(90deg)');
+
+		window.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+		expect(onRotate).toHaveBeenCalledWith('shape-1', 90);
+	});
+});

--- a/packages/react/src/viewer/components/elements/ResizeHandles.tsx
+++ b/packages/react/src/viewer/components/elements/ResizeHandles.tsx
@@ -4,6 +4,7 @@ import { LuRotateCw } from 'react-icons/lu';
 
 import type { ResizeHandle, ShapeAdjustmentHandleDescriptor } from '../../types';
 import { cn } from '../../utils';
+import { syncSelectionHandleOverlay } from '../../utils/selection-handle-overlay';
 
 export interface ResizeHandlesProps {
 	elementId: string;
@@ -175,7 +176,9 @@ export function ResizeHandles({
 			}
 			deg = Math.round(((deg % 360) + 360) % 360);
 			last = deg;
-			wrapper.style.transform = `rotate(${deg}deg)${base}`;
+			const transform = `rotate(${deg}deg)${base}`;
+			wrapper.style.transform = transform;
+			syncSelectionHandleOverlay(elementId, { transform });
 		};
 		const onPointerMove = (ev: PointerEvent): void => apply(ev.clientX, ev.clientY, ev.shiftKey);
 		const end = (): void => {

--- a/packages/react/src/viewer/hooks/pointer-live-patch.test.ts
+++ b/packages/react/src/viewer/hooks/pointer-live-patch.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment happy-dom
 /**
  * Regression test for the collaboration live-preview channel: React's drag and
  * resize write straight to the DOM and only commit to `slides` on pointer-up,
@@ -12,7 +13,7 @@ import {
 	reconcileSlidesInYDoc,
 } from 'pptx-viewer-shared';
 import type { YDocLike, YjsFactories } from 'pptx-viewer-shared';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import * as Y from 'yjs';
 
 import type { UsePointerHandlersInput, PointerFrameTracker } from './pointer-handler-types';
@@ -93,6 +94,17 @@ const newTracker = (): PointerFrameTracker => ({
 	lastSnapLinesKey: '',
 });
 
+function appendHandleHost(elementId: string): HTMLDivElement {
+	const host = document.createElement('div');
+	host.setAttribute('data-pptx-handle-for', elementId);
+	document.body.appendChild(host);
+	return host;
+}
+
+afterEach(() => {
+	document.body.replaceChildren();
+});
+
 function seed(activeSlide: PptxSlide): {
 	doc: Y.Doc;
 	patcher: ReturnType<typeof createCollaborationLivePatcher>;
@@ -103,6 +115,64 @@ function seed(activeSlide: PptxSlide): {
 	patcher.configure(asDoc(doc), factories);
 	return { doc, patcher };
 }
+
+describe('selection handle overlay preview', () => {
+	it('keeps the selection handles aligned during a drag preview', () => {
+		const active = slide([element('e1')]);
+		const input = makeInput(active, createCollaborationLivePatcher());
+		const domEl = document.createElement('div');
+		const handleHost = appendHandleHost('e1');
+		input.dragStateRef.current = {
+			elementId: 'e1',
+			startClientX: 0,
+			startClientY: 0,
+			startPositionsById: { e1: { x: 100, y: 100 } },
+			domEls: new Map([['e1', domEl]]),
+			moved: false,
+			lastDx: 0,
+			lastDy: 0,
+		};
+
+		processPointerMove(move(40, 25), input, newTracker());
+
+		expect(domEl.style.left).toBe('140px');
+		expect(domEl.style.top).toBe('125px');
+		expect(handleHost.style.left).toBe('140px');
+		expect(handleHost.style.top).toBe('125px');
+	});
+
+	it('keeps the selection handles aligned during a resize preview', () => {
+		const active = slide([element('e1')]);
+		const input = makeInput(active, createCollaborationLivePatcher());
+		const domEl = document.createElement('div');
+		const handleHost = appendHandleHost('e1');
+		input.resizeStateRef.current = {
+			elementId: 'e1',
+			startClientX: 0,
+			startClientY: 0,
+			startX: 100,
+			startY: 100,
+			startWidth: 200,
+			startHeight: 150,
+			handle: 'se',
+			moved: false,
+			domEl,
+			lastX: 100,
+			lastY: 100,
+			lastWidth: 200,
+			lastHeight: 150,
+		};
+
+		processPointerMove(move(50, 30), input, newTracker());
+
+		expect(domEl.style.width).toBe('250px');
+		expect(domEl.style.height).toBe('180px');
+		expect(handleHost.style.left).toBe('100px');
+		expect(handleHost.style.top).toBe('100px');
+		expect(handleHost.style.width).toBe('250px');
+		expect(handleHost.style.height).toBe('180px');
+	});
+});
 
 describe('pointer live patch', () => {
 	it('publishes a drag to the Y.Doc before pointer-up', () => {

--- a/packages/react/src/viewer/hooks/pointer-move-handlers.ts
+++ b/packages/react/src/viewer/hooks/pointer-move-handlers.ts
@@ -14,6 +14,7 @@ import type { ResizeHandleId } from 'pptx-viewer-shared';
 
 import { MIN_ELEMENT_SIZE } from '../constants';
 import { computeSnapToShapeResult } from '../utils/geometry-selection';
+import { syncSelectionHandleOverlay } from '../utils/selection-handle-overlay';
 import type { UsePointerHandlersInput, PointerFrameTracker } from './pointer-handler-types';
 
 // ---------------------------------------------------------------------------
@@ -262,8 +263,11 @@ function processDragMove(
 	for (const [id, domEl] of drag.domEls) {
 		const start = drag.startPositionsById[id];
 		if (start) {
-			domEl.style.left = `${start.x + appliedDx}px`;
-			domEl.style.top = `${start.y + appliedDy}px`;
+			const x = start.x + appliedDx;
+			const y = start.y + appliedDy;
+			domEl.style.left = `${x}px`;
+			domEl.style.top = `${y}px`;
+			syncSelectionHandleOverlay(id, { x, y });
 		}
 	}
 	// Mirror the in-flight positions to collaborators. The DOM writes above
@@ -315,18 +319,21 @@ function processResizeMove(
 	rs.lastY = geo.y;
 	rs.lastWidth = geo.width;
 	rs.lastHeight = geo.height;
+	const width = Math.max(geo.width, MIN_ELEMENT_SIZE);
+	const height = Math.max(geo.height, MIN_ELEMENT_SIZE);
 	if (rs.domEl) {
 		rs.domEl.style.left = `${geo.x}px`;
 		rs.domEl.style.top = `${geo.y}px`;
-		rs.domEl.style.width = `${Math.max(geo.width, MIN_ELEMENT_SIZE)}px`;
-		rs.domEl.style.height = `${Math.max(geo.height, MIN_ELEMENT_SIZE)}px`;
+		rs.domEl.style.width = `${width}px`;
+		rs.domEl.style.height = `${height}px`;
 	}
+	syncSelectionHandleOverlay(rs.elementId, { x: geo.x, y: geo.y, width, height });
 	if (live) {
 		publishLiveGeometry(live.patcher, live.slideId, rs.elementId, {
 			x: geo.x,
 			y: geo.y,
-			width: Math.max(geo.width, MIN_ELEMENT_SIZE),
-			height: Math.max(geo.height, MIN_ELEMENT_SIZE),
+			width,
+			height,
 		});
 	}
 }

--- a/packages/react/src/viewer/utils/selection-handle-overlay.ts
+++ b/packages/react/src/viewer/utils/selection-handle-overlay.ts
@@ -1,0 +1,47 @@
+/** Geometry mirrored to the detached selection-handle overlay during a gesture. */
+export interface SelectionHandleOverlayGeometry {
+	x?: number;
+	y?: number;
+	width?: number;
+	height?: number;
+	transform?: string;
+}
+
+/**
+ * Keep React's stage-level selection handles aligned with the element DOM node
+ * while drag, resize, and rotate gestures bypass React state for live preview.
+ *
+ * The overlay is a sibling rather than a child of the element, so it does not
+ * inherit those imperative style writes. React remains authoritative after the
+ * pointer-up commit and replaces these temporary values on the next render.
+ */
+export function syncSelectionHandleOverlay(
+	elementId: string,
+	geometry: SelectionHandleOverlayGeometry,
+): void {
+	if (typeof document === 'undefined') {
+		return;
+	}
+
+	for (const candidate of document.querySelectorAll<HTMLElement>('[data-pptx-handle-for]')) {
+		if (candidate.getAttribute('data-pptx-handle-for') !== elementId) {
+			continue;
+		}
+		if (geometry.x !== undefined) {
+			candidate.style.left = `${geometry.x}px`;
+		}
+		if (geometry.y !== undefined) {
+			candidate.style.top = `${geometry.y}px`;
+		}
+		if (geometry.width !== undefined) {
+			candidate.style.width = `${geometry.width}px`;
+		}
+		if (geometry.height !== undefined) {
+			candidate.style.height = `${geometry.height}px`;
+		}
+		if (geometry.transform !== undefined) {
+			candidate.style.transform = geometry.transform;
+		}
+		return;
+	}
+}


### PR DESCRIPTION
## What does this change?

React renders resize, rotate, and adjustment handles in a stage-level overlay so shape clip paths do not block their hit targets. Drag, resize, and rotate previews update the element DOM directly until pointer-up, but the sibling overlay kept its previous geometry. The shape therefore moved while its blue handles stayed behind, then the handles snapped into place on release.

This change mirrors the temporary `left`, `top`, `width`, `height`, and `transform` values to the matching `data-pptx-handle-for` host. The normal React state commit remains authoritative after pointer-up. Connector handles are unchanged because they remain nested in the element.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

## Cross-binding parity

This is React-specific because the regression comes from the React binding moving selection handles into a detached stage-level overlay. Other bindings own their handle positioning independently.

## Testing

- Added drag and resize preview regressions that assert the element and detached overlay receive identical geometry.
- Added a live rotation regression that asserts the element and detached overlay rotate together before pointer-up.
- Focused React regressions: 4 files and 36 tests passed.
- Full `packages/react` suite: 370 files and 6,629 tests passed.
- React package typecheck passed.
- Targeted oxfmt and oxlint checks passed.

## Checks run locally

- `oxfmt --check` on changed files
- `oxlint --deny-warnings` on changed files
- Focused React Vitest regressions
- Full `packages/react` Vitest suite
- `packages/react` typecheck
