### PR TITLE
feat: complete the morph transition fix set

### DIFF
--- a/packages/angular/src/viewer/presentation-show-navigator.test.ts
+++ b/packages/angular/src/viewer/presentation-show-navigator.test.ts
@@ -130,6 +130,37 @@ describe('presentationShowNavigator hidden slides', () => {
 	});
 });
 
+describe('presentationShowNavigator transition direction', () => {
+	function deckWithTransitions(): PptxSlide[] {
+		return [
+			{ id: 's1', rId: 'rId1', slideNumber: 1, elements: [] } as PptxSlide,
+			{
+				id: 's2',
+				rId: 'rId2',
+				slideNumber: 2,
+				elements: [],
+				transition: { type: 'morph', durationMs: 500 },
+			} as PptxSlide,
+		];
+	}
+
+	it('plays the incoming slide transition on a forward step', () => {
+		const { navigator } = makeNavigator(deckWithTransitions());
+		navigator.navigate('next');
+		expect(navigator.activeTransition()?.transition.type).toBe('morph');
+		expect(navigator.activeTransition()?.outgoing.id).toBe('s1');
+	});
+
+	it('replays the leaving slide transition on a backward step', () => {
+		const { navigator } = makeNavigator(deckWithTransitions());
+		navigator.goToSlide(1);
+		navigator.navigate('prev');
+		// Stepping back onto slide 1 replays slide 2's morph in reverse.
+		expect(navigator.activeTransition()?.transition.type).toBe('morph');
+		expect(navigator.activeTransition()?.outgoing.id).toBe('s2');
+	});
+});
+
 describe('presentationShowNavigator end of show', () => {
 	it('raises the black end screen by default', () => {
 		const harness = makeNavigator(slides(false));

--- a/packages/angular/src/viewer/presentation-show-navigator.ts
+++ b/packages/angular/src/viewer/presentation-show-navigator.ts
@@ -242,14 +242,19 @@ export class PresentationShowNavigator {
 		}
 
 		// Play the incoming slide's transition (if any) over the new slide,
-		// animating the outgoing slide out. Forward navigation only, matching
-		// PowerPoint, which does not replay transitions when stepping back.
+		// animating the outgoing slide out. A backward step replays the LEAVING
+		// slide's transition in reverse instead (PowerPoint: a morph glides its
+		// shapes back to where they came from).
 		const incoming = slides[next];
 		const outgoing = slides[current];
 		const transition =
-			(direction === 'next' || direction === 'first') && incoming?.transition && outgoing
-				? { outgoing, transition: incoming.transition }
-				: null;
+			direction === 'prev'
+				? outgoing?.transition && incoming
+					? { outgoing, transition: outgoing.transition }
+					: null
+				: (direction === 'next' || direction === 'first') && incoming?.transition && outgoing
+					? { outgoing, transition: incoming.transition }
+					: null;
 		this.commit(next, transition);
 	}
 

--- a/packages/angular/src/viewer/presentation-transition-overlay.component.ts
+++ b/packages/angular/src/viewer/presentation-transition-overlay.component.ts
@@ -15,7 +15,6 @@ import type { CanvasSize, MorphTransitionPlan } from '../internal/shared';
 import {
 	buildMorphScopedCss,
 	buildMorphTransitionPlan,
-	DEFAULT_MORPH_DURATION_MS,
 	MORPH_CROSSFADE_GROUP_STYLE,
 	MORPH_CROSSFADE_HALF_BLEND_MODE,
 	morphOptionToMode,
@@ -24,7 +23,7 @@ import type { StyleMap } from './element-style';
 import { SlideCanvasComponent } from './slide-canvas.component';
 import {
 	getSlideTransitionAnimations,
-	resolveTransitionDuration,
+	resolveOverlayDurationMs,
 	transitionSlideBoxSize,
 } from './transition-helpers';
 import type { SlideTransitionAnimations } from './transition-helpers';
@@ -362,19 +361,9 @@ export class PresentationTransitionOverlayComponent {
 	// ------------------------------------------------------------------
 
 	/** Effective transition duration (ms), floored/defaulted. */
-	protected readonly resolvedDurationMs = computed<number>(() => {
-		const override = this.durationMs();
-		if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
-			return override;
-		}
-		const tr = this.transition();
-		// PowerPoint's Morph defaults to 2.00s (`p14:dur` overrides arrive in
-		// `durationMs`); the generic 1s default made it visibly abrupt.
-		if (tr.type === 'morph' && !(typeof tr.durationMs === 'number' && tr.durationMs > 0)) {
-			return DEFAULT_MORPH_DURATION_MS;
-		}
-		return resolveTransitionDuration(tr.durationMs);
-	});
+	protected readonly resolvedDurationMs = computed<number>(() =>
+		resolveOverlayDurationMs(this.durationMs(), this.transition()),
+	);
 
 	/** Resolved CSS animation descriptors for the outgoing/incoming layers. */
 	protected readonly animations = computed<SlideTransitionAnimations>(() => {

--- a/packages/angular/src/viewer/transition-helpers.test.ts
+++ b/packages/angular/src/viewer/transition-helpers.test.ts
@@ -11,6 +11,7 @@ import {
 	resolveDirection,
 	resolveDirection8,
 	resolveOrientation,
+	resolveOverlayDurationMs,
 	resolveTransitionDuration,
 	transitionSlideBoxSize,
 } from './transition-helpers';
@@ -416,5 +417,35 @@ describe('transitionSlideBoxSize', () => {
 			width: 1,
 			height: 1,
 		});
+	});
+});
+
+describe('resolveOverlayDurationMs', () => {
+	const transition = (overrides: Partial<PptxSlideTransition>): PptxSlideTransition =>
+		({ type: 'morph', ...overrides }) as PptxSlideTransition;
+
+	it('lets the explicit override win over everything', () => {
+		expect(resolveOverlayDurationMs(800, transition({ durationMs: 2500, speed: 'slow' }))).toBe(
+			800,
+		);
+	});
+
+	it('honours an authored p14:dur for morphs', () => {
+		expect(resolveOverlayDurationMs(undefined, transition({ durationMs: 2500 }))).toBe(2500);
+	});
+
+	it('honours the legacy spd token for morphs', () => {
+		expect(resolveOverlayDurationMs(undefined, transition({ speed: 'slow' }))).toBe(1000);
+		expect(resolveOverlayDurationMs(undefined, transition({ speed: 'fast' }))).toBe(500);
+	});
+
+	it('falls back to the un-authored morph default', () => {
+		expect(resolveOverlayDurationMs(undefined, transition({}))).toBe(500);
+	});
+
+	it('keeps the angular classic-transition policy for non-morphs', () => {
+		expect(resolveOverlayDurationMs(undefined, { type: 'fade' } as PptxSlideTransition)).toBe(
+			DEFAULT_TRANSITION_DURATION_MS,
+		);
 	});
 });

--- a/packages/angular/src/viewer/transition-helpers.ts
+++ b/packages/angular/src/viewer/transition-helpers.ts
@@ -18,6 +18,10 @@
  * `PresentationTransitionOverlayComponent` imports the same symbol names from
  * here unchanged.
  */
+import type { PptxSlideTransition } from 'pptx-viewer-core';
+
+import { resolveTransitionDurationMs } from '../internal/shared';
+
 export type {
 	SlideTransitionAnimations,
 	ResolvedDirection,
@@ -57,6 +61,30 @@ export function resolveTransitionDuration(durationMs: number | undefined): numbe
 			? durationMs
 			: DEFAULT_TRANSITION_DURATION_MS;
 	return Math.max(MIN_TRANSITION_DURATION_MS, raw);
+}
+
+/**
+ * The presentation overlay's effective duration (ms): an explicit override
+ * wins; a MORPH delegates to the shared resolver, which honours an authored
+ * `p14:dur`, then the legacy `spd` token, then PowerPoint's 0.5s fallback for
+ * a morph that declares neither. The previous local copy ignored `spd`
+ * entirely, so spd-authored morphs played at the (wrong) hard-coded default
+ * while every other binding honoured the authored speed.
+ *
+ * Classic (non-morph) transitions keep Angular's own floor/default policy
+ * above - that divergence is deliberate (see the file header).
+ */
+export function resolveOverlayDurationMs(
+	override: number | undefined,
+	transition: PptxSlideTransition,
+): number {
+	if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
+		return override;
+	}
+	if (transition.type === 'morph') {
+		return resolveTransitionDurationMs(transition);
+	}
+	return resolveTransitionDuration(transition.durationMs);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/viewer/hooks/presentation-mode/slide-transition.test.ts
+++ b/packages/react/src/viewer/hooks/presentation-mode/slide-transition.test.ts
@@ -147,7 +147,7 @@ describe('executeSlideTransition', () => {
 		expect(deps.presentationTimersRef.current).toHaveLength(1);
 	});
 
-	it('does not mount an overlay for a backward / non-forward move', () => {
+	it('does not mount an overlay when playTransition is false', () => {
 		const deps = createMockDeps({ playTransition: false });
 		executeSlideTransition(1, deps);
 		expect(deps.setTransitionOverlay).toHaveBeenCalledWith(null);
@@ -156,6 +156,40 @@ describe('executeSlideTransition', () => {
 		expect(deps.startSlideAnimations).toHaveBeenCalledWith(1);
 		expect(deps.scheduleAutoAdvanceForSlide).toHaveBeenCalledWith(1);
 		expect(deps.presentationTimersRef.current).toHaveLength(0);
+	});
+
+	it('mounts the overlay for a backward step using the LEAVING slide transition', () => {
+		// Stepping back from slide 2 (index 1, morph) onto slide 1 (index 0,
+		// no transition): the leaving slide's morph replays in reverse.
+		const leaving = createMockSlide({
+			id: 'slide-2',
+			transition: { type: 'morph', durationMs: 500 } as PptxSlide['transition'],
+		});
+		const deps = createMockDeps({
+			slides: [createMockSlide({ id: 'slide-1' }), leaving],
+			currentSlideIndex: 1,
+			reverse: true,
+			playTransition: true,
+		});
+		executeSlideTransition(0, deps);
+		expect(deps.setTransitionOverlay).toHaveBeenCalledWith({
+			outgoingSlideIndex: 1,
+			incomingSlideIndex: 0,
+			transition: { type: 'morph', durationMs: 500 },
+			durationMs: 500,
+		});
+	});
+
+	it('is instant on a backward step when the leaving slide has no transition', () => {
+		const deps = createMockDeps({
+			slides: [createMockSlide({ id: 'slide-1' }), createMockSlide({ id: 'slide-2' })],
+			currentSlideIndex: 1,
+			reverse: true,
+			playTransition: true,
+		});
+		executeSlideTransition(0, deps);
+		expect(deps.setTransitionOverlay).toHaveBeenCalledWith(null);
+		expect(deps.startSlideAnimations).toHaveBeenCalledWith(0);
 	});
 
 	it('does not mount an overlay for an instant (none) transition', () => {

--- a/packages/react/src/viewer/hooks/presentation-mode/slide-transition.ts
+++ b/packages/react/src/viewer/hooks/presentation-mode/slide-transition.ts
@@ -35,6 +35,14 @@ export interface SlideTransitionDeps {
 	 */
 	playTransition: boolean;
 	/**
+	 * Play the LEAVING slide's transition instead, running it in reverse. Set
+	 * when stepping backward onto the previous slide: PowerPoint replays the
+	 * transition of the slide being left (a morph glides its shapes back to
+	 * where they came from). The overlay still animates the outgoing slide out
+	 * over the incoming one, only the transition definition's source changes.
+	 */
+	reverse?: boolean;
+	/**
 	 * Seed the incoming slide as fully built rather than replaying it. Set when
 	 * stepping BACKWARD onto a slide, which PowerPoint shows with its builds
 	 * already complete.
@@ -49,14 +57,19 @@ export interface SlideTransitionDeps {
  * incoming slide carries a real (non-instant) `p:transition` and this is a
  * forward navigation, the outgoing slide is snapshotted into an animated
  * overlay layer that plays over the new slide for the transition's duration
- * (mirroring the Vue/Angular bindings). Entrance animations and auto-advance
- * are deferred until the transition has played so the incoming slide's builds
- * don't start underneath the overlay. For instant transitions the slide is
- * revealed at once with no overlay.
+ * (mirroring the Vue/Angular bindings). A backward step plays the LEAVING
+ * slide's transition in reverse instead ({@link SlideTransitionDeps.reverse}).
+ * Entrance animations and auto-advance are deferred until the transition has
+ * played so the incoming slide's builds don't start underneath the overlay.
+ * For instant transitions the slide is revealed at once with no overlay.
  */
 export function executeSlideTransition(nextSlideIndex: number, deps: SlideTransitionDeps): void {
 	const incomingSlide = deps.slides[nextSlideIndex];
-	const transition = incomingSlide?.transition;
+	// Forward navigation (and jumps) play the ENTERING slide's transition; a
+	// backward step replays the LEAVING slide's transition in reverse.
+	const transition = deps.reverse
+		? deps.slides[deps.currentSlideIndex]?.transition
+		: incomingSlide?.transition;
 	const durationMs = deps.playTransition ? resolveTransitionDurationMs(transition) : 0;
 
 	deps.clearPresentationTimers();

--- a/packages/react/src/viewer/hooks/presentation-mode/useSlideNavigation.ts
+++ b/packages/react/src/viewer/hooks/presentation-mode/useSlideNavigation.ts
@@ -208,8 +208,11 @@ export function useSlideNavigation(input: UseSlideNavigationInput): UseSlideNavi
 				scheduleAutoAdvanceForSlide: rehearsing ? undefined : scheduleAutoAdvanceForSlide,
 				presentationTimersRef,
 				setTransitionOverlay,
-				// PowerPoint plays a slide's transition only when advancing into it.
-				playTransition: direction === 1,
+				// PowerPoint plays a slide's transition only when advancing into it,
+				// and replays the LEAVING slide's transition in reverse when stepping
+				// back (a morph glides its shapes back to where they came from).
+				playTransition: true,
+				reverse: direction === -1,
 				// Stepping back onto a slide shows it with its builds already played.
 				seedCompleted: direction === -1,
 			});

--- a/packages/shared/src/render/element-style.ts
+++ b/packages/shared/src/render/element-style.ts
@@ -209,7 +209,43 @@ function imageFitTransformParts(el: PptxElement): { placement: string; crop: str
 	if (!isImageLikeElement(el) && el.type !== 'media') {
 		return { placement: '', crop: '' };
 	}
+	return fitTransformsFromInsets({
+		cropLeft: clampCropValue(el.cropLeft),
+		cropTop: clampCropValue(el.cropTop),
+		cropRight: clampCropValue(el.cropRight),
+		cropBottom: clampCropValue(el.cropBottom),
+		fillRectLeft: el.fillRectLeft ?? 0,
+		fillRectTop: el.fillRectTop ?? 0,
+		fillRectRight: el.fillRectRight ?? 0,
+		fillRectBottom: el.fillRectBottom ?? 0,
+	});
+}
 
+/** The eight `a:srcRect` / `a:fillRect` inset fractions that place a picture. */
+export interface ImageFitInsets {
+	cropLeft: number;
+	cropTop: number;
+	cropRight: number;
+	cropBottom: number;
+	fillRectLeft: number;
+	fillRectTop: number;
+	fillRectRight: number;
+	fillRectBottom: number;
+}
+
+/**
+ * The `<img>` `transform` for ARBITRARY inset fractions, always padded to the
+ * full `translate/scale translate/scale` list.
+ *
+ * The Morph engine interpolates a pair's insets SAMPLE BY SAMPLE (the crop and
+ * the frame must compensate each other or the image visibly zooms, see
+ * `morph-image-crop`), so it needs the mapping for values between two
+ * elements', not just for whole elements.
+ */
+export function fitTransformsFromInsets(insets: ImageFitInsets): {
+	placement: string;
+	crop: string;
+} {
 	// `a:stretch/a:fillRect` stretches the (cropped) image into a sub-rect of
 	// the FRAME; negative offsets legitimately push it past the frame edges,
 	// and the overflow-hidden frame clips the spill (issue #132 deck, phone
@@ -217,10 +253,10 @@ function imageFitTransformParts(el: PptxElement): { placement: string; crop: str
 	// stamp a pixel-sized shape clip-path on the img itself, and a transform
 	// moves the already-clipped result while a geometry change would move the
 	// img out of its own clip and blank it.
-	const frLeft = el.fillRectLeft ?? 0;
-	const frTop = el.fillRectTop ?? 0;
-	const frRight = el.fillRectRight ?? 0;
-	const frBottom = el.fillRectBottom ?? 0;
+	const frLeft = insets.fillRectLeft;
+	const frTop = insets.fillRectTop;
+	const frRight = insets.fillRectRight;
+	const frBottom = insets.fillRectBottom;
 	const hasFillRect =
 		Math.abs(frLeft) + Math.abs(frTop) + Math.abs(frRight) + Math.abs(frBottom) > 0.0001;
 	const placement = hasFillRect
@@ -229,31 +265,29 @@ function imageFitTransformParts(el: PptxElement): { placement: string; crop: str
 			)}, ${round6(Math.max(0.01, 1 - frTop - frBottom))})`
 		: '';
 
-	const cropLeft = clampCropValue(el.cropLeft);
-	const cropTop = clampCropValue(el.cropTop);
-	const cropRight = clampCropValue(el.cropRight);
-	const cropBottom = clampCropValue(el.cropBottom);
-	if (cropLeft + cropRight <= 0.0001 && cropTop + cropBottom <= 0.0001) {
-		return { placement, crop: '' };
+	let cropLeft = insets.cropLeft;
+	let cropTop = insets.cropTop;
+	let cropRight = insets.cropRight;
+	let cropBottom = insets.cropBottom;
+	if (cropLeft + cropRight > 0.0001 || cropTop + cropBottom > 0.0001) {
+		// A crop that swallows (almost) the whole source would divide by ~0
+		// below, so the pair is rescaled to leave a 1% sliver rather than
+		// producing Infinity.
+		const horizontalScale = cropLeft + cropRight >= 0.99 ? 0.99 / (cropLeft + cropRight) : 1;
+		const verticalScale = cropTop + cropBottom >= 0.99 ? 0.99 / (cropTop + cropBottom) : 1;
+		cropLeft = clampCropValue(cropLeft * horizontalScale);
+		cropRight = clampCropValue(cropRight * horizontalScale);
+		cropTop = clampCropValue(cropTop * verticalScale);
+		cropBottom = clampCropValue(cropBottom * verticalScale);
+		const remainingWidth = Math.max(0.01, 1 - cropLeft - cropRight);
+		const remainingHeight = Math.max(0.01, 1 - cropTop - cropBottom);
+		const tx = Math.round((-cropLeft / remainingWidth) * 10000) / 100;
+		const ty = Math.round((-cropTop / remainingHeight) * 10000) / 100;
+		const sx = Math.round((1 / remainingWidth) * 1e6) / 1e6;
+		const sy = Math.round((1 / remainingHeight) * 1e6) / 1e6;
+		return { placement, crop: `translate(${tx}%, ${ty}%) scale(${sx}, ${sy})` };
 	}
-
-	// A crop that swallows (almost) the whole source would divide by ~0
-	// below, so the pair is rescaled to leave a 1% sliver rather than
-	// producing Infinity.
-	const horizontalScale = cropLeft + cropRight >= 0.99 ? 0.99 / (cropLeft + cropRight) : 1;
-	const verticalScale = cropTop + cropBottom >= 0.99 ? 0.99 / (cropTop + cropBottom) : 1;
-	const left = clampCropValue(cropLeft * horizontalScale);
-	const right = clampCropValue(cropRight * horizontalScale);
-	const top = clampCropValue(cropTop * verticalScale);
-	const bottom = clampCropValue(cropBottom * verticalScale);
-	const remainingWidth = Math.max(0.01, 1 - left - right);
-	const remainingHeight = Math.max(0.01, 1 - top - bottom);
-
-	const tx = Math.round((-left / remainingWidth) * 10000) / 100;
-	const ty = Math.round((-top / remainingHeight) * 10000) / 100;
-	const sx = Math.round((1 / remainingWidth) * 1e6) / 1e6;
-	const sy = Math.round((1 / remainingHeight) * 1e6) / 1e6;
-	return { placement, crop: `translate(${tx}%, ${ty}%) scale(${sx}, ${sy})` };
+	return { placement, crop: '' };
 }
 
 /**

--- a/packages/shared/src/render/morph-animation.ts
+++ b/packages/shared/src/render/morph-animation.ts
@@ -361,6 +361,54 @@ function crossfadeIncomingMayFadeIn(element: PptxElement): boolean {
 // ---------------------------------------------------------------------------
 
 /**
+ * Stage-journeyed matched pairs whose stacking ORDER swaps between the slides,
+ * as incoming element id -> the z-index journey `{ from, to }` (the pair's
+ * outgoing document index -> its incoming document index).
+ *
+ * Only pairs the overlay does NOT ghost participate: a stage-journeyed pair is
+ * painted directly on the live stage in the INCOMING slide's order, so a pair
+ * that swaps stacking order would pop to its new layer at frame 1 and never
+ * show the outgoing slide's front relationship. The z-index track makes the
+ * browser step the swap at the animation midpoint, in sync with the motion -
+ * the closest a discrete layer model gets to PowerPoint's continuous z-order
+ * interpolation. Pairs with ghosts are handled by the overlay-order machinery
+ * instead (see `morph-overlay-order`).
+ */
+export function computeZOrderSwaps(
+	pairs: MorphPair[],
+	flattenedFrom: readonly PptxElement[],
+	flattenedTo: readonly PptxElement[],
+	ghostIds?: ReadonlySet<string>,
+): Map<string, { from: number; to: number }> {
+	const outIndex = new Map(flattenedFrom.map((el, i) => [el.id, i] as const));
+	const inIndex = new Map(flattenedTo.map((el, i) => [el.id, i] as const));
+	const swaps = new Map<string, { from: number; to: number }>();
+	const stageJourneyed = pairs.filter((pair) => !(ghostIds?.has(pair.fromElement.id) ?? false));
+	for (let i = 0; i < stageJourneyed.length; i++) {
+		for (let j = i + 1; j < stageJourneyed.length; j++) {
+			const a = stageJourneyed[i];
+			const b = stageJourneyed[j];
+			const aOut = outIndex.get(a.fromElement.id);
+			const bOut = outIndex.get(b.fromElement.id);
+			const aIn = inIndex.get(a.toElement.id);
+			const bIn = inIndex.get(b.toElement.id);
+			if (aOut === undefined || bOut === undefined || aIn === undefined || bIn === undefined) {
+				continue;
+			}
+			// Relative order flips: the outgoing slide stacks a above b while the
+			// incoming slide stacks b above a. Both journeys then carry the
+			// swap (a: 0->1 behind, b: 1->0 front), stepping together at the
+			// animation midpoint.
+			if (aOut < bOut !== aIn < bIn) {
+				swaps.set(a.toElement.id, { from: aOut, to: aIn });
+				swaps.set(b.toElement.id, { from: bOut, to: bIn });
+			}
+		}
+	}
+	return swaps;
+}
+
+/**
  * Generate morph animation keyframes for matched element pairs.
  *
  * Produces CSS `@keyframes` blocks that animate position, size, rotation,
@@ -373,6 +421,8 @@ function crossfadeIncomingMayFadeIn(element: PptxElement): boolean {
  *   {@link resolveMorphGhostIds}). A pair whose ghost is NOT painted has no
  *   stand-in above it, so this half must stay visible. Defaults to "all", the
  *   behaviour before the ghost set existed.
+ * @param zSwaps - Incoming id -> z-index journey for stacking-order swaps (see
+ *   {@link computeZOrderSwaps}). The track rides the same shorthand.
  * @returns An array of animation style descriptors for each pair.
  */
 export function generateMorphAnimations(
@@ -380,6 +430,7 @@ export function generateMorphAnimations(
 	durationMs: number,
 	_mode: MorphMode = 'object',
 	ghostIds?: ReadonlySet<string>,
+	zSwaps?: ReadonlyMap<string, { from: number; to: number }>,
 ): MorphAnimationStyle[] {
 	const animations: MorphAnimationStyle[] = [];
 
@@ -423,16 +474,28 @@ export function generateMorphAnimations(
 		// rotates its ring graphic per slide so the arrow points at the selected
 		// wedge; interpolating only the DELTA played the ring at `rotate(dr)->0`
 		// instead of `rotate(from)->rotate(to)`, sweeping giant arcs across the
-		// slide. Flips use the incoming element's, stated after the rotation to
-		// match the static order (right-to-left: flip first, then rotate).
-		// Animate FROM an equivalent start angle that reaches the element's own
-		// authored rotation over the shorter arc; the `to` frame must keep the
-		// authored value so the element lands exactly on its static transform.
+		// slide.
+		//
+		// The ROTATION must sit LEFT of the scale: CSS applies the list
+		// right-to-left, so `scale(sx, sy) rotate(θ)` scales the rotated shape
+		// along the PARENT's axes - a shear for any rotated pair whose sx≠sy
+		// (a rotated sliver widening 11x reads as stretch + skew), while
+		// `rotate(θ) scale(sx, sy)` scales the box along its OWN axes, which is
+		// the resize PowerPoint animates. It also lets a picture's crop track
+		// (which scales the img in that same local frame) compose with the
+		// frame scale multiplicatively.
+		//
+		// Flips are stated PER FRAME, each endpoint carrying ITS OWN element's
+		// flags: when they differ (a small mirror-flipped photo growing into an
+		// upright one), CSS interpolates the scale arguments numerically through
+		// zero, exactly the edge-on card flip PowerPoint plays. The factors are
+		// always emitted (even when +1) so both frames share one function list
+		// and interpolate numerically instead of falling back to matrix
+		// decomposition.
 		const toRot = toElement.rotation ?? 0;
 		const fromRot = inSlot ? toRot : shortestRotationTarget(toRot, fromElement.rotation ?? 0);
-		const flips = `${toElement.flipHorizontal ? ' scaleX(-1)' : ''}${
-			toElement.flipVertical ? ' scaleY(-1)' : ''
-		}`;
+		const fromFlips = flipFactors(fromElement);
+		const toFlips = flipFactors(toElement);
 
 		// A GHOSTED inert pair is painted twice: its ghost is a pixel-identical
 		// copy sitting in the overlay directly above it. For an opaque element
@@ -454,11 +517,21 @@ export function generateMorphAnimations(
 		// out of this block and rides a second animation, so the journey and the
 		// dissolve can follow their own measured curves (see the ghost half).
 		const fromProps: string[] = [
-			`\t\ttransform: translate(${dx}px, ${dy}px) scale(${sx}, ${sy}) rotate(${fromRot}deg)${flips};`,
+			`\t\ttransform: translate(${dx}px, ${dy}px) rotate(${fromRot}deg) scale(${sx}, ${sy})${fromFlips};`,
 		];
 		const toProps: string[] = [
-			`\t\ttransform: translate(0, 0) scale(1, 1) rotate(${toRot}deg)${flips};`,
+			`\t\ttransform: translate(0, 0) rotate(${toRot}deg) scale(1, 1)${toFlips};`,
 		];
+		// A stacking-order swap rides the same journey: z-index interpolates as
+		// an integer, so the browser steps front <-> behind at the animation
+		// midpoint, while both pictures are mid-flight (PowerPoint interpolates
+		// z-order continuously; a stepped swap synced to the motion is the
+		// closest a discrete layer model gets).
+		const zSwap = zSwaps?.get(toElement.id);
+		if (zSwap) {
+			fromProps.push(`\t\tz-index: ${zSwap.from};`);
+			toProps.push(`\t\tz-index: ${zSwap.to};`);
+		}
 		if (!crossfadesIn) {
 			fromProps.push(`\t\topacity: ${inert ? 0 : fromOpacity};`);
 			toProps.push(`\t\topacity: ${inert ? 0 : toOpacity};`);
@@ -586,12 +659,12 @@ export function generateMorphGhostAnimations(
 		const sx = inSlot ? 1 : Math.max(toElement.width, 1) / Math.max(fromElement.width, 1);
 		const sy = inSlot ? 1 : Math.max(toElement.height, 1) / Math.max(fromElement.height, 1);
 		// The ghost starts on its own authored rotation, so the SHORTEST-arc
-		// adjustment goes on the target angle here (mirror of the incoming half).
+		// adjustment goes on the target angle here (mirror of the incoming
+		// half). Flips are per-frame, as in {@link generateMorphAnimations}.
 		const fromRot = fromElement.rotation ?? 0;
 		const toRot = inSlot ? fromRot : shortestRotationTarget(fromRot, toElement.rotation ?? 0);
-		const flips = `${fromElement.flipHorizontal ? ' scaleX(-1)' : ''}${
-			fromElement.flipVertical ? ' scaleY(-1)' : ''
-		}`;
+		const fromFlips = flipFactors(fromElement);
+		const toFlips = flipFactors(toElement);
 		// A dissolve and a journey are two different curves, so when the ghost does
 		// both they ride two animations: the transform keeps {@link MORPH_EASING},
 		// which its live counterpart also travels on (a single easing for both
@@ -602,13 +675,13 @@ export function generateMorphGhostAnimations(
 @keyframes ${safeName} {
 \tfrom {
 \t\ttransform-origin: center;
-\t\ttransform: translate(0, 0) scale(1, 1) rotate(${fromRot}deg)${flips};${
+\t\ttransform: translate(0, 0) rotate(${fromRot}deg) scale(1, 1)${fromFlips};${
 			fadesOut ? '' : `\n\t\topacity: ${opacity};`
 		}
 \t}
 \tto {
 \t\ttransform-origin: center;
-\t\ttransform: translate(${dx}px, ${dy}px) scale(${sx}, ${sy}) rotate(${toRot}deg)${flips};${
+\t\ttransform: translate(${dx}px, ${dy}px) rotate(${toRot}deg) scale(${sx}, ${sy})${toFlips};${
 			fadesOut ? '' : `\n\t\topacity: ${opacity};`
 		}
 \t}
@@ -684,6 +757,21 @@ function staticTransformSuffix(el: PptxElement): string {
 	return ` rotate(${rot}deg)${el.flipHorizontal ? ' scaleX(-1)' : ''}${
 		el.flipVertical ? ' scaleY(-1)' : ''
 	}`;
+}
+
+/**
+ * The flip factors a journey frame must carry for this element, ALWAYS emitted
+ * (even as +1) so paired keyframes share one transform function list and CSS
+ * interpolates them numerically.
+ *
+ * Interpolating a differing flag then runs the scale argument through zero,
+ * which is precisely the edge-on card flip PowerPoint plays when one slide's
+ * picture is mirrored and its counterpart is not. Stating only one endpoint's
+ * flags (the old behaviour) snapped the mirror at the flight's start instead
+ * of animating it.
+ */
+function flipFactors(el: PptxElement): string {
+	return ` scaleX(${el.flipHorizontal ? -1 : 1}) scaleY(${el.flipVertical ? -1 : 1})`;
 }
 
 /**
@@ -850,13 +938,23 @@ export function generateFullMorphTransition(
 	// of a pair have to agree on it, since a hidden live element with no ghost
 	// above it is an invisible shape, and a ghost with a visible element under it
 	// is a double exposure.
-	const ghostIds = resolveMorphGhostIds(
-		flattenMorphElements(fromSlide.elements, toSlide.elements),
+	const flattenedFrom = flattenMorphElements(fromSlide.elements, toSlide.elements);
+	const ghostIds = resolveMorphGhostIds(flattenedFrom, matchResult.pairs);
+
+	// Stage-journeyed pairs whose stacking ORDER flips between the slides get a
+	// z-index journey (outgoing index -> incoming index), so the pass-behind
+	// happens mid-flight in sync with the motion instead of popping at frame 1:
+	// two same-named full-bleed pictures that swap stacking order must both be
+	// painted in front while they fly, never only at rest.
+	const zSwaps = computeZOrderSwaps(
 		matchResult.pairs,
+		flattenedFrom,
+		flattenMorphElements(toSlide.elements, fromSlide.elements),
+		ghostIds,
 	);
 
 	// Generate main element morph animations
-	const pairAnims = generateMorphAnimations(matchResult.pairs, durationMs, mode, ghostIds);
+	const pairAnims = generateMorphAnimations(matchResult.pairs, durationMs, mode, ghostIds, zSwaps);
 	allAnimations.push(...pairAnims);
 
 	// Shape-geometry morph: for matched pairs whose shape outline changes

--- a/packages/shared/src/render/morph-animation.ts
+++ b/packages/shared/src/render/morph-animation.ts
@@ -441,7 +441,32 @@ export function generateMorphAnimations(
 		// element already looks exactly as it should, for the whole morph. Leaving
 		// it alone (rather than animating it from itself to itself) also keeps it
 		// out of the binding's animation state, so nothing has to unwind at the end.
+		//
+		// EXCEPT when the pair's stacking order swaps: a z-index journey only
+		// works if BOTH sides of the flip are stepped together. The swapping
+		// counterpart may be this very inert pair - skipping it leaves it at
+		// its static (incoming) layer, and since an omitted z-index loses the
+		// DOM-order tie-break to an animated one, the flip renders as an
+		// immediate swap instead of a mid-flight one. Emit the journey alone.
 		if (!ghosted && isInertMorphPair(fromElement, toElement)) {
+			const inertZSwap = zSwaps?.get(toElement.id);
+			if (!inertZSwap) {
+				continue;
+			}
+			const inertName = `pptx-morph-z-${index}-${toElement.id.replace(/[^a-zA-Z0-9]/gu, '')}`;
+			animations.push({
+				elementId: toElement.id,
+				animation: `${inertName} ${durationMs}ms ${MORPH_EASING} forwards`,
+				keyframes: `
+@keyframes ${inertName} {
+\tfrom {
+\t\tz-index: ${inertZSwap.from};
+\t}
+\tto {
+\t\tz-index: ${inertZSwap.to};
+\t}
+}`,
+			});
 			continue;
 		}
 		const safeName = `pptx-morph-${index}-${toElement.id.replace(/[^a-zA-Z0-9]/gu, '')}`;

--- a/packages/shared/src/render/morph-heuristics.test.ts
+++ b/packages/shared/src/render/morph-heuristics.test.ts
@@ -15,13 +15,13 @@ import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import {
-	appearanceSignature,
-	differentText,
 	matchGroupTwins,
 	matchIdenticalTwins,
+	matchNamedTextTwins,
 	matchSameMedia,
 } from './morph-heuristics';
 import { matchMorphElementsFull } from './morph-matching';
+import { appearanceSignature, differentText } from './morph-predicates';
 
 function makeElement(
 	overrides: Partial<PptxElement> & { id: string; type: PptxElement['type'] },
@@ -162,10 +162,107 @@ describe('matchSameMedia', () => {
 		expect(byFrom.get('a-right')).toBe('b-right');
 	});
 
+	it('pairs a split-picture mosaic piece-for-piece', () => {
+		// One artwork is staged as a 971x971 base plus seven cropped tiles, ALL
+		// the same media part, all named "Picture 2" but the base. The next
+		// slide repeats the same eight boxes shifted straight up; several tiles
+		// SHARE the base's exact corner, so nearest-first greedy pairing runs
+		// into equidistant candidates, lets early iterations consume a
+		// neighbour's twin and forces later ones across the slide ("the pieces
+		// jump around"). The incoming list here is even authored bottom-up,
+		// unlike the outgoing one.
+		const from = [
+			picture('f-base', 155, { y: 581, width: 971, height: 971, name: 'Picture 5' }),
+			picture('f-t1', 513, { y: 1217, width: 384, height: 335 }),
+			picture('f-t2', 481, { y: 958, width: 414, height: 259 }),
+			picture('f-t3', 158, { y: 1121, width: 356, height: 431 }),
+			picture('f-t4', 492, { y: 581, width: 381, height: 377 }),
+			picture('f-t5', 873, { y: 581, width: 254, height: 584 }),
+			picture('f-t6', 896, { y: 1165, width: 231, height: 386 }),
+			// Same top-left corner as the base, different box: the tie trap.
+			picture('f-t7', 155, { y: 581, width: 356, height: 540 }),
+		];
+		const SHIFT_Y = -700;
+		const twin = (id: string, el: PptxElement): PptxElement =>
+			picture(id, el.x, {
+				y: el.y + SHIFT_Y,
+				width: el.width,
+				height: el.height,
+				name: el.name,
+			});
+		const to = [
+			...from
+				.slice(1)
+				.reverse()
+				.map((el, i) => twin(`b-t${7 - i}`, el)),
+			twin('b-base', from[0]),
+		];
+		const pairs = matchSameMedia(from, to, new Set(), new Set());
+		expect(pairs).toHaveLength(8);
+		for (const pair of pairs) {
+			const f = pair.fromElement;
+			const t = pair.toElement;
+			expect(t.x).toBe(f.x);
+			expect(t.y).toBe(f.y + SHIFT_Y);
+			expect(t.width).toBe(f.width);
+			expect(t.height).toBe(f.height);
+		}
+	});
+
 	it('refuses conflicting !! names', () => {
 		const from = makeSlide([picture('a', -1279, { name: '!!hero' })]);
 		const to = makeSlide([picture('b', 1, { name: '!!villain' })], 'slide-2');
 		expect(matchSameMedia(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+});
+
+describe('matchNamedTextTwins', () => {
+	/** A same-named headline parked far off-stage on the outgoing slide. */
+	function headline(id: string, y: number, overrides: Partial<PptxElement> = {}): PptxElement {
+		return makeElement({
+			id,
+			type: 'text',
+			name: 'Title 1',
+			x: 78,
+			y,
+			width: 1123,
+			height: 486,
+			text: 'ROADMAP 2026',
+			...overrides,
+		});
+	}
+
+	it('pairs a same-named headline parked far off-stage with its landing spot', () => {
+		const from = makeSlide([headline('a', -1439)]);
+		const to = makeSlide([headline('b', 117)], 'slide-2');
+		const pairs = matchNamedTextTwins(from.elements, to.elements, new Set(), new Set());
+		expect(pairs).toHaveLength(1);
+		expect(pairs[0].fromElement.id).toBe('a');
+		expect(pairs[0].toElement.id).toBe('b');
+	});
+
+	it('refuses twins whose words differ (a rebuilt headline)', () => {
+		const from = makeSlide([headline('a', -1439)]);
+		const to = makeSlide([headline('b', 117, { text: 'ROADMAP 2027' })], 'slide-2');
+		expect(matchNamedTextTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses different names, which carry no identity', () => {
+		const from = makeSlide([headline('a', -1439)]);
+		const to = makeSlide([headline('b', 117, { name: 'Title 2' })], 'slide-2');
+		expect(matchNamedTextTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses a different box, which is a rebuilt frame', () => {
+		const from = makeSlide([headline('a', -1439)]);
+		const to = makeSlide([headline('b', 117, { width: 900 })], 'slide-2');
+		expect(matchNamedTextTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
+	});
+
+	it('refuses conflicting !! names', () => {
+		const from = makeSlide([headline('a', -1439, { name: '!!Title 1' })]);
+		const to = makeSlide([headline('b', 117, { name: '!!Other 1' })], 'slide-2');
+		expect(matchNamedTextTwins(from.elements, to.elements, new Set(), new Set())).toHaveLength(0);
 	});
 });
 

--- a/packages/shared/src/render/morph-heuristics.ts
+++ b/packages/shared/src/render/morph-heuristics.ts
@@ -1,5 +1,5 @@
 /**
- * Appearance and media heuristics for the weaker morph matching passes.
+ * The weaker morph matching passes.
  *
  * PowerPoint's by-object matcher does not stop at explicit identity
  * (`!!` names, `a16:creationId`): real decks show it also pairs a picture
@@ -12,7 +12,9 @@
  * colours and sizes) keeps falling through to proximity.
  *
  * Everything here is pure; the pass bookkeeping (used-element sets) is owned
- * by `morph-matching`, which calls into this module one-way.
+ * by `morph-matching`, which calls into this module one-way. The shared
+ * evidence predicates live in `morph-predicates`, and the same-media pass's
+ * minimum-cost solver in `morph-media-assignment`.
  *
  * @module render/morph-heuristics
  */
@@ -20,142 +22,17 @@
 import type { GroupPptxElement, PptxElement } from 'pptx-viewer-core';
 
 import { correspondingChildren } from './morph-flatten';
-import { getElementMorphName } from './morph-name';
+import { minCostMediaAssignment } from './morph-media-assignment';
+import type { MediaCandidate } from './morph-media-assignment';
+import {
+	appearanceSignature,
+	centreDistance,
+	conflictingMorphNames,
+	differentText,
+	hasDeclaredPaint,
+	sameMediaPicture,
+} from './morph-predicates';
 import type { MorphPair } from './morph-types';
-
-/** Depth cap for the recursive text read; real decks never nest this far. */
-const TEXT_MAX_DEPTH = 8;
-
-/**
- * Everything an element WRITES, including the text of its descendants.
- *
- * A group paints nothing itself - all of its words live in its children - so
- * reading only `element.text` reports every group as wordless and lets two
- * groups with nothing in common look interchangeable (issue #144: a wheel
- * slide's centre panel paired with a detail slide's callout box and glided
- * across the slide, "drifting text").
- */
-function elementText(element: PptxElement, depth = 0): string {
-	const own = (element as { text?: string }).text ?? '';
-	const children = (element as { children?: PptxElement[] }).children;
-	if (!children || depth >= TEXT_MAX_DEPTH) {
-		return own;
-	}
-	let text = own;
-	for (const child of children) {
-		text += ` ${elementText(child, depth + 1)}`;
-	}
-	return text;
-}
-
-/**
- * Whether two elements both carry text, and carry DIFFERENT text.
- *
- * Used to veto a purely positional or appearance-based match:
- * same-place-different-words is the signature of a rebuilt panel, not of one
- * object that moved. Whitespace is normalised so a reflowed line break does
- * not read as a different string.
- */
-export function differentText(a: PptxElement, b: PptxElement): boolean {
-	const textOf = (element: PptxElement): string =>
-		elementText(element).replace(/\s+/gu, ' ').trim();
-	const fromText = textOf(a);
-	const toText = textOf(b);
-	return fromText !== '' && toText !== '' && fromText !== toText;
-}
-
-/**
- * Whether two elements both carry an explicit `!!` morph name and those names
- * DIFFER.
- *
- * The `!!` prefix is the author telling PowerPoint which shapes are the same
- * object across slides, so two different `!!` names are a statement that these
- * two are NOT (pass 1 already paired every side that agreed). Letting such a
- * pair fall through to a weaker signal lets an off-canvas box fly in from
- * off-stage - the "mystery box" of issue #144. Mirrors the `a16:creationId`
- * rule in pass 2b: evidence of identity that disagrees is evidence of
- * difference.
- */
-export function conflictingMorphNames(a: PptxElement, b: PptxElement): boolean {
-	const fromName = getElementMorphName(a);
-	if (!fromName) {
-		return false;
-	}
-	const toName = getElementMorphName(b);
-	return Boolean(toName) && toName !== fromName;
-}
-
-/** The media part an image/picture element paints (path, else data URL). */
-function mediaIdentity(el: PptxElement): string | undefined {
-	const props = el as { imagePath?: string; imageData?: string };
-	return props.imagePath ?? props.imageData ?? undefined;
-}
-
-/** Euclidean distance between two elements' top-left corners (slide space). */
-function centreDistance(a: PptxElement, b: PptxElement): number {
-	const dx = a.x - b.x;
-	const dy = a.y - b.y;
-	return Math.sqrt(dx * dx + dy * dy);
-}
-
-/** Whether two elements are the same kind of picture painting the same media. */
-function sameMediaPicture(a: PptxElement, b: PptxElement): boolean {
-	if (a.type !== 'picture' && a.type !== 'image') {
-		return false;
-	}
-	if (b.type !== a.type) {
-		return false;
-	}
-	if (conflictingMorphNames(a, b)) {
-		return false;
-	}
-	const aMedia = mediaIdentity(a);
-	const bMedia = mediaIdentity(b);
-	return Boolean(aMedia) && aMedia === bMedia;
-}
-
-/** The `shapeStyle` paint fields that decide what an element looks like. */
-const APPEARANCE_KEYS = [
-	'fillMode',
-	'fillColor',
-	'fillOpacity',
-	'strokeColor',
-	'strokeWidth',
-	'strokeOpacity',
-	'strokeDash',
-] as const;
-
-/**
- * Whether the element DECLARES paint (an explicit fill or stroke). The twin
- * pass requires this: two default, unstyled shapes are interchangeable
- * background debris on any slide, and pairing them is how off-stage boxes
- * come flying in (the "mystery box" class of bug). A shape whose author
- * picked a fill and a line and then moved it is a deliberate object.
- */
-function hasDeclaredPaint(el: PptxElement): boolean {
-	const style = (el as { shapeStyle?: Record<string, unknown> }).shapeStyle;
-	if (!style) {
-		return false;
-	}
-	return APPEARANCE_KEYS.some((key) => style[key] !== undefined);
-}
-
-/**
- * A canonical string for everything an element LOOKS like (discriminant,
- * geometry preset, resolved fill/stroke paint, media). Two elements with
- * equal signatures are visually interchangeable apart from where they sit.
- */
-export function appearanceSignature(el: PptxElement): string {
-	const style = (el as { shapeStyle?: Record<string, unknown> }).shapeStyle;
-	const parts: string[] = [el.type, (el as { shapeType?: string }).shapeType ?? ''];
-	if (style) {
-		for (const key of APPEARANCE_KEYS) {
-			parts.push(style[key] === undefined ? '' : String(style[key]));
-		}
-	}
-	parts.push(mediaIdentity(el) ?? '');
-	return parts.join('|');
-}
 
 /**
  * Pass: pair pictures that paint the SAME media part, even when every id - and
@@ -167,11 +44,17 @@ export function appearanceSignature(el: PptxElement): string {
  * auto-named differently on each slide ("Picture 3" on one, "Picture 7" on
  * the other); pairing by media is what makes it glide instead of fading in.
  *
- * When several outgoing pictures share one media part, the author's Selection
- * Pane name outranks distance, and the nearest candidate wins the rest -
- * which keeps two same-named thumbnails parked at opposite edges from
- * CROSS-pairing (each thumbnail morphs into its nearest on-slide copy, not
- * its neighbour's).
+ * When MANY pictures share one media part the choice is global, not greedy.
+ * A staged artwork can be a base plus several cropped tiles, all the same
+ * media, several PARKED ON EXACTLY THE SAME CORNER - and a uniform slide-up
+ * shift leaves alternative bijections whose TOTAL travel equals the true one,
+ * so neither nearest-first greedy nor cardinality-first augmenting paths can
+ * tell them apart. The pass therefore runs a minimum-cost assignment
+ * (Hungarian, see `morph-media-assignment`) over every legal pairing edge,
+ * where an edge's cost ranks the same preferences pair by pair: same
+ * Selection Pane name beats unnamed regardless of distance, nearer beats
+ * farther, an equally reachable box of the same size beats a mismatched one,
+ * and input order breaks whatever ties remain.
  */
 export function matchSameMedia(
 	fromElements: readonly PptxElement[],
@@ -179,29 +62,50 @@ export function matchSameMedia(
 	usedFrom: Set<string>,
 	usedTo: Set<string>,
 ): MorphPair[] {
-	const pairs: MorphPair[] = [];
-	for (const fromEl of fromElements) {
+	const candidatesOf = new Map<string, MediaCandidate[]>();
+	for (let i = 0; i < fromElements.length; i++) {
+		const fromEl = fromElements[i];
 		if (usedFrom.has(fromEl.id)) {
 			continue;
 		}
 		const fromName = fromEl.name?.trim();
-		let best: { to: PptxElement; named: boolean; dist: number } | undefined;
-		for (const toEl of toElements) {
+		const candidates: MediaCandidate[] = [];
+		for (let j = 0; j < toElements.length; j++) {
+			const toEl = toElements[j];
 			if (usedTo.has(toEl.id) || !sameMediaPicture(fromEl, toEl)) {
 				continue;
 			}
-			const named = Boolean(fromName) && toEl.name?.trim() === fromName;
-			const dist = centreDistance(fromEl, toEl);
-			const better =
-				best === undefined || (named && !best.named) || (named === best.named && dist < best.dist);
-			if (better) {
-				best = { to: toEl, named, dist };
-			}
+			candidates.push({
+				to: toEl,
+				named: Boolean(fromName) && toEl.name?.trim() === fromName,
+				dist: centreDistance(fromEl, toEl),
+				sizeDelta: Math.abs(toEl.width - fromEl.width) + Math.abs(toEl.height - fromEl.height),
+				toIndex: j,
+			});
 		}
-		if (best) {
-			pairs.push({ fromElement: fromEl, toElement: best.to });
+		if (candidates.length > 0) {
+			candidatesOf.set(fromEl.id, candidates);
+		}
+	}
+	if (candidatesOf.size === 0) {
+		return [];
+	}
+
+	const assignment = minCostMediaAssignment(candidatesOf);
+
+	const toById = new Map(toElements.map((el) => [el.id, el] as const));
+	const pairs: MorphPair[] = [];
+	for (const fromEl of fromElements) {
+		const candidates = candidatesOf.get(fromEl.id);
+		const col = assignment.get(fromEl.id);
+		if (!candidates || col === undefined || usedFrom.has(fromEl.id)) {
+			continue;
+		}
+		const toEl = toById.get(candidates[col].to.id);
+		if (toEl) {
+			pairs.push({ fromElement: fromEl, toElement: toEl });
 			usedFrom.add(fromEl.id);
-			usedTo.add(best.to.id);
+			usedTo.add(toEl.id);
 		}
 	}
 	return pairs;
@@ -234,6 +138,63 @@ function sameSizedTwinCasts(a: PptxElement, b: PptxElement): boolean {
 		return false;
 	}
 	return correspondingChildren(aChildren, bChildren) !== undefined;
+}
+
+/**
+ * Pass: pair TEXT elements that carry the same Selection Pane NAME, the same
+ * box size and the same words, however far apart they sit.
+ *
+ * A headline parked far off-stage on one slide and re-landed on-screen on the
+ * next is the same object to PowerPoint and the reader: same pane name,
+ * byte-identical box, identical words, different `a16:creationId`. No other
+ * pass can take it: media is pictures-only, the identical-twin pass demands
+ * DECLARED paint which a text box never has, and proximity caps at 300px - so
+ * the headline dissolved out and faded in instead of sliding with the rest of
+ * its panel. Name + box + words together are as strong an identity statement
+ * as paint is for shapes; a rebuilt headline says different words and stays
+ * excluded by the words veto.
+ */
+export function matchNamedTextTwins(
+	fromElements: readonly PptxElement[],
+	toElements: readonly PptxElement[],
+	usedFrom: Set<string>,
+	usedTo: Set<string>,
+): MorphPair[] {
+	const pairs: MorphPair[] = [];
+	for (const fromEl of fromElements) {
+		if (usedFrom.has(fromEl.id) || fromEl.type !== 'text') {
+			continue;
+		}
+		const fromName = fromEl.name?.trim();
+		if (!fromName) {
+			continue;
+		}
+		for (const toEl of toElements) {
+			if (usedTo.has(toEl.id) || toEl.type !== 'text') {
+				continue;
+			}
+			if (toEl.name?.trim() !== fromName) {
+				continue;
+			}
+			if (
+				Math.abs(fromEl.width - toEl.width) > 0.5 ||
+				Math.abs(fromEl.height - toEl.height) > 0.5
+			) {
+				continue;
+			}
+			if (differentText(fromEl, toEl)) {
+				continue;
+			}
+			if (conflictingMorphNames(fromEl, toEl)) {
+				continue;
+			}
+			pairs.push({ fromElement: fromEl, toElement: toEl });
+			usedFrom.add(fromEl.id);
+			usedTo.add(toEl.id);
+			break;
+		}
+	}
+	return pairs;
 }
 
 /**
@@ -283,7 +244,7 @@ export function matchGroupTwins(
  * they sit. The distance-agnostic counterpart of the proximity pass: for two
  * shapes that are indistinguishable apart from where they are, interpolating
  * the box is what PowerPoint does, and what a morph is for. Unstyled shapes
- * carry no such statement and stay unmatched (see {@link hasDeclaredPaint}).
+ * carry no such statement and stay unmatched (see `hasDeclaredPaint`).
  */
 export function matchIdenticalTwins(
 	fromElements: readonly PptxElement[],

--- a/packages/shared/src/render/morph-image-crop.test.ts
+++ b/packages/shared/src/render/morph-image-crop.test.ts
@@ -7,6 +7,7 @@ import {
 	generateImageCropGhostAnimations,
 	generateImageCropMorphAnimations,
 	morphImageCropChanged,
+	sampleImageCropMorphSteps,
 } from './morph-image-crop';
 import { buildMorphAnimationRules, buildMorphTransitionPlan } from './morph-plan';
 
@@ -161,6 +162,107 @@ describe('generateImageCropGhostAnimations', () => {
 		expect(ghost.target).toBe('image');
 	});
 });
+
+describe('a pair whose frame grows WITH its crop', () => {
+	// A rotated sliver of a picture (right 91% cropped away, frame 43x482px)
+	// grows into the full picture (no crop, 482px wide), same height, same
+	// rotation. The frame widens ~11x while the crop opens ~11x, so the
+	// picture's pixel scale is the same on both slides and PowerPoint REVEALS
+	// rightwards - no stretch, no zoom, no slide. The outgoing frame's width
+	// ratio (0.089935) must match the surviving crop fraction (1 - 0.91007) or
+	// the picture's pixel scale genuinely differs between the slides.
+	const from = {
+		id: 'sliver',
+		type: 'picture',
+		name: 'Picture 8',
+		x: 143,
+		y: 36,
+		width: 43.31,
+		height: 482.1,
+		rotation: 26.7,
+		imagePath: 'ppt/media/reveal.png',
+		cropRight: 0.91007,
+	} as unknown as PptxElement;
+	const to = {
+		id: 'full',
+		type: 'picture',
+		name: 'Picture 6',
+		x: 120,
+		y: 135,
+		width: 481.53,
+		height: 482.1,
+		rotation: 26.7,
+		imagePath: 'ppt/media/reveal.png',
+	} as unknown as PptxElement;
+
+	it('switches the track to stepped, linear-timed keyframes', () => {
+		const [animation] = generateImageCropMorphAnimations(
+			[{ fromElement: from, toElement: to }],
+			300,
+		);
+		expect(animation.animation).toContain('300ms linear forwards');
+		expect(animation.animation).not.toContain('cubic-bezier');
+		// Densely sampled: more stops than a from/to pair could carry.
+		expect(animation.keyframes.match(/transform:/gu)?.length).toBeGreaterThan(10);
+	});
+
+	it('keeps the painted width constant through the flight', () => {
+		// At every sample the img scale must cancel the frame's own growth at
+		// the SAME eased progress, or the image visibly zooms mid-morph.
+		const samples = sampleImageCropMorphSteps(from, to);
+		const initialWidth = from.width * extractCropScaleX(samples[0].transform);
+		for (const sample of samples) {
+			const frameWidth = from.width + (to.width - from.width) * sample.progress;
+			const paintedWidth = frameWidth * extractCropScaleX(sample.transform);
+			expect(Math.abs(paintedWidth - initialWidth)).toBeLessThan(initialWidth * 0.02);
+		}
+	});
+
+	it('advances the sample progress along the real CSS easing curve', () => {
+		// Regression: a swapped-exponent bezier evaluation made the early
+		// samples race ahead (progress 0.097 at time 0.021), so the img track
+		// desynced from the container journey in the live transition even
+		// though a per-sample invariant still held. cubic-bezier(0.4, 0, 0.2, 1)
+		// stays well below the diagonal early on and is monotone.
+		const samples = sampleImageCropMorphSteps(from, to);
+		expect(samples[1].percent).toBe('2.0833%');
+		expect(samples[1].progress).toBeLessThan(0.05);
+		let previous = -1;
+		for (const sample of samples) {
+			expect(sample.progress).toBeGreaterThanOrEqual(previous);
+			previous = sample.progress;
+		}
+		expect(samples[samples.length - 1].progress).toBe(1);
+	});
+
+	it('lands on the incoming static transform and starts on the outgoing one', () => {
+		const samples = sampleImageCropMorphSteps(from, to);
+		expect(samples[0].percent).toBe('0%');
+		expect(samples[0].transform).toBe(buildImageFitTransform(from, true));
+		expect(samples[samples.length - 1].percent).toBe('100%');
+		expect(samples[samples.length - 1].transform).toBe(buildImageFitTransform(to, true));
+	});
+
+	it('keeps the single eased pair when only the crop changes', () => {
+		// The issue #148 case (identical frames) must stay a from/to pair on
+		// the morph easing; the stepped track is only for compounding frames.
+		const same = background('b', SLIDE_12_CROP);
+		const [animation] = generateImageCropMorphAnimations(
+			[{ fromElement: background('a', SLIDE_3_CROP), toElement: same }],
+			300,
+		);
+		expect(animation.animation).toContain('cubic-bezier');
+		expect(animation.animation).not.toContain('linear forwards');
+		expect(animation.keyframes.match(/transform:/gu)?.length).toBe(2);
+	});
+});
+
+/** Pull the CROP pair's scale factor out of a padded img fit transform. */
+function extractCropScaleX(transform: string): number {
+	const matches = [...transform.matchAll(/scale\(([\d.]+)/gu)];
+	expect(matches.length).toBeGreaterThanOrEqual(2);
+	return Number(matches[matches.length - 1][1]);
+}
 
 describe('a rescaled picture end to end', () => {
 	const from = slide('slide3', [background('slide3-bg', SLIDE_3_CROP)]);

--- a/packages/shared/src/render/morph-image-crop.ts
+++ b/packages/shared/src/render/morph-image-crop.ts
@@ -18,33 +18,50 @@
  * function-by-function and the final frame is exactly the incoming element's
  * static style - nothing snaps when the plan is torn down.
  *
+ * When the FRAME changes as well as the crop, two linear interpolations do not
+ * compose to PowerPoint's reveal: the crop track there steps through the pair's
+ * inset fractions (see `sampleImageCropMorphSteps`).
+ *
  * @module render/morph-image-crop
  */
 import type { PptxElement } from 'pptx-viewer-core';
 import { isImageLikeElement } from 'pptx-viewer-core';
 
-import { buildImageFitTransform } from './element-style';
+import { buildImageFitTransform, fitTransformsFromInsets } from './element-style';
+import type { ImageFitInsets } from './element-style';
 import type { MorphAnimationStyle, MorphPair } from './morph-types';
 import { MORPH_EASING } from './morph-types';
 
 /** Crop/placement insets are fractions of the source; 0.0001 is ~0.01%. */
 const CROP_EPSILON = 0.0001;
 
+/** Frame sizes within this relative difference count as unchanged. */
+const FRAME_EPSILON = 0.002;
+
 /** The eight inset fractions that together decide what a picture paints. */
-function cropInsets(element: PptxElement): number[] {
+function cropInsets(element: PptxElement): ImageFitInsets {
 	if (!isImageLikeElement(element)) {
-		return [0, 0, 0, 0, 0, 0, 0, 0];
+		return {
+			cropLeft: 0,
+			cropTop: 0,
+			cropRight: 0,
+			cropBottom: 0,
+			fillRectLeft: 0,
+			fillRectTop: 0,
+			fillRectRight: 0,
+			fillRectBottom: 0,
+		};
 	}
-	return [
-		element.cropLeft ?? 0,
-		element.cropTop ?? 0,
-		element.cropRight ?? 0,
-		element.cropBottom ?? 0,
-		element.fillRectLeft ?? 0,
-		element.fillRectTop ?? 0,
-		element.fillRectRight ?? 0,
-		element.fillRectBottom ?? 0,
-	];
+	return {
+		cropLeft: element.cropLeft ?? 0,
+		cropTop: element.cropTop ?? 0,
+		cropRight: element.cropRight ?? 0,
+		cropBottom: element.cropBottom ?? 0,
+		fillRectLeft: element.fillRectLeft ?? 0,
+		fillRectTop: element.fillRectTop ?? 0,
+		fillRectRight: element.fillRectRight ?? 0,
+		fillRectBottom: element.fillRectBottom ?? 0,
+	};
 }
 
 /**
@@ -60,7 +77,125 @@ export function morphImageCropChanged(fromElement: PptxElement, toElement: PptxE
 	}
 	const from = cropInsets(fromElement);
 	const to = cropInsets(toElement);
-	return from.some((value, index) => Math.abs(value - to[index]) > CROP_EPSILON);
+	const keys = Object.keys(from) as (keyof ImageFitInsets)[];
+	return keys.some((key) => Math.abs(from[key] - to[key]) > CROP_EPSILON);
+}
+
+/**
+ * Whether the pair's FRAMES differ as well as the crops.
+ *
+ * When only the crop changes, the frame is a fixed window and animating the
+ * img transform alone is exact. When the frame also grows or shrinks, the
+ * element journey scales that window at the same time and the two tracks
+ * compose multiplicatively - and two linear interpolations do NOT cancel: the
+ * image visibly zooms through the flight. PowerPoint interpolates the crop
+ * FRACTION linearly instead, which against the linear frame scale keeps the
+ * picture's pixel scale constant: a reveal, not a zoom.
+ */
+function frameChanged(fromElement: PptxElement, toElement: PptxElement): boolean {
+	return (
+		Math.abs(fromElement.width / Math.max(toElement.width, 1) - 1) > FRAME_EPSILON ||
+		Math.abs(fromElement.height / Math.max(toElement.height, 1) - 1) > FRAME_EPSILON
+	);
+}
+
+/**
+ * Progress along a CSS cubic-bezier easing at normalized time `t` (0..1).
+ *
+ * Standard solver: Newton where the x-curve's derivative is usable, bisection
+ * where it is not (the x curve is monotone for valid CSS control points). The
+ * stepped crop track samples this so its baked keyframe percentages advance
+ * exactly like the element journey's eased progress.
+ */
+function easedProgress(t: number, x1: number, y1: number, x2: number, y2: number): number {
+	// B(u) = 3a·u(1-u)² + 3b·u²(1-u) + u³ for the axis whose control points
+	// are 0, a, b, 1.
+	const axisAt = (a: number, b: number, u: number): number =>
+		3 * a * u * (1 - u) * (1 - u) + 3 * b * u * u * (1 - u) + u * u * u;
+	const axisDerivative = (a: number, b: number, u: number): number =>
+		3 * (1 - u) * (1 - u) * a + 6 * (1 - u) * u * (b - a) + 3 * u * u * (1 - b);
+	const xAt = (u: number): number => axisAt(x1, x2, u);
+	const yAt = (u: number): number => axisAt(y1, y2, u);
+
+	let u = t;
+	for (let i = 0; i < 8; i++) {
+		const err = xAt(u) - t;
+		if (Math.abs(err) < 1e-6) {
+			return yAt(u);
+		}
+		const slope = axisDerivative(x1, x2, u);
+		if (Math.abs(slope) < 1e-6) {
+			break;
+		}
+		u -= err / slope;
+		if (u <= 0 || u >= 1) {
+			break;
+		}
+	}
+	let lo = 0;
+	let hi = 1;
+	u = t;
+	for (let i = 0; i < 24; i++) {
+		if (xAt(u) < t) {
+			lo = u;
+		} else {
+			hi = u;
+		}
+		u = (lo + hi) / 2;
+	}
+	return yAt(u);
+}
+
+/** Time samples the stepped track takes across the flight. */
+const CROP_TRACK_STEPS = 48;
+
+export interface ImageCropMorphSample {
+	/** Keyframe selector, in percent of the duration (0-100). */
+	readonly percent: string;
+	/** Eased progress this sample's insets were computed at (0-1). */
+	readonly progress: number;
+	/** The `<img>` transform at this sample. */
+	readonly transform: string;
+}
+
+/**
+ * The stepped crop track for a pair whose frame changes alongside its crop.
+ *
+ * Samples the pair's inset fractions at eased-time points and maps each through
+ * the same inset maths the static renderer uses, so the crop fraction travels
+ * linearly (as PowerPoint's does) while the keyframe PERCENTAGES carry
+ * {@link MORPH_EASING}'s shape. Rendered with `linear` timing, because the
+ * easing already lives in the percentages.
+ */
+export function sampleImageCropMorphSteps(
+	fromElement: PptxElement,
+	toElement: PptxElement,
+): ImageCropMorphSample[] {
+	const from = cropInsets(fromElement);
+	const to = cropInsets(toElement);
+	const keys = Object.keys(from) as (keyof ImageFitInsets)[];
+	const samples: ImageCropMorphSample[] = [];
+	for (let step = 0; step <= CROP_TRACK_STEPS; step++) {
+		const time = step / CROP_TRACK_STEPS;
+		const progress =
+			step === 0 ? 0 : step === CROP_TRACK_STEPS ? 1 : easedProgress(time, 0.4, 0, 0.2, 1);
+		const insets = {} as ImageFitInsets;
+		for (const key of keys) {
+			insets[key] = from[key] + (to[key] - from[key]) * progress;
+		}
+		const percent = Math.round(time * 100 * 10000) / 10000;
+		// Pad exactly like `buildImageFitTransform(, true)` so the first and
+		// last samples are byte-identical to the two elements' static tracks -
+		// and the final sample to the incoming style the plan hands back to.
+		const { placement, crop } = fitTransformsFromInsets(insets);
+		const identity = 'translate(0%, 0%) scale(1, 1)';
+		const transform =
+			step === CROP_TRACK_STEPS
+				? buildImageFitTransform(toElement, true)
+				: `${placement || identity} ${crop || identity}`;
+		samples.push({ percent: `${percent}%`, progress, transform });
+	}
+	return samples;
 }
 
 /**
@@ -86,6 +221,46 @@ function cropKeyframes(name: string, fromTransform: string, toTransform: string)
 }`;
 }
 
+/** Stepped variant of {@link cropKeyframes} (easing baked into percentages). */
+function steppedCropKeyframes(name: string, samples: ImageCropMorphSample[]): string {
+	const stops = samples
+		.map(
+			(sample) =>
+				`\t${sample.percent} {\n\t\ttransform-origin: top left;\n\t\ttransform: ${sample.transform};\n\t}`,
+		)
+		.join('\n');
+	return `\n@keyframes ${name} {\n${stops}\n}`;
+}
+
+/** Shared per-pair track construction for the incoming and ghost halves. */
+function cropTrack(
+	index: number,
+	suffix: string,
+	elementId: string,
+	fromElement: PptxElement,
+	toElement: PptxElement,
+	durationMs: number,
+): MorphAnimationStyle {
+	const safeName = `pptx-morph-crop-${suffix}-${index}-${elementId.replace(/[^a-zA-Z0-9]/gu, '')}`;
+	const stepped = frameChanged(fromElement, toElement);
+	return {
+		elementId,
+		target: 'image',
+		// Stepped frames carry the easing in their percentages, so the track
+		// itself must advance linearly to stay in sync with the element journey.
+		animation: stepped
+			? `${safeName} ${durationMs}ms linear forwards`
+			: `${safeName} ${durationMs}ms ${MORPH_EASING} forwards`,
+		keyframes: stepped
+			? steppedCropKeyframes(safeName, sampleImageCropMorphSteps(fromElement, toElement))
+			: cropKeyframes(
+					safeName,
+					buildImageFitTransform(fromElement, true),
+					buildImageFitTransform(toElement, true),
+				),
+	};
+}
+
 /**
  * The INCOMING half of every pair whose picture crop changed.
  *
@@ -107,17 +282,7 @@ export function generateImageCropMorphAnimations(
 		if (!morphImageCropChanged(fromElement, toElement)) {
 			continue;
 		}
-		const safeName = `pptx-morph-crop-${index}-${toElement.id.replace(/[^a-zA-Z0-9]/gu, '')}`;
-		animations.push({
-			elementId: toElement.id,
-			target: 'image',
-			animation: `${safeName} ${durationMs}ms ${MORPH_EASING} forwards`,
-			keyframes: cropKeyframes(
-				safeName,
-				buildImageFitTransform(fromElement, true),
-				buildImageFitTransform(toElement, true),
-			),
-		});
+		animations.push(cropTrack(index, '', toElement.id, fromElement, toElement, durationMs));
 	}
 	return animations;
 }
@@ -149,17 +314,7 @@ export function generateImageCropGhostAnimations(
 		if (!morphImageCropChanged(fromElement, toElement)) {
 			continue;
 		}
-		const safeName = `pptx-morph-crop-ghost-${index}-${fromElement.id.replace(/[^a-zA-Z0-9]/gu, '')}`;
-		animations.push({
-			elementId: fromElement.id,
-			target: 'image',
-			animation: `${safeName} ${durationMs}ms ${MORPH_EASING} forwards`,
-			keyframes: cropKeyframes(
-				safeName,
-				buildImageFitTransform(fromElement, true),
-				buildImageFitTransform(toElement, true),
-			),
-		});
+		animations.push(cropTrack(index, 'ghost-', fromElement.id, fromElement, toElement, durationMs));
 	}
 	return animations;
 }

--- a/packages/shared/src/render/morph-matching.ts
+++ b/packages/shared/src/render/morph-matching.ts
@@ -14,13 +14,13 @@ import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
 
 import { flattenMorphElements, morphGroupChildPairs } from './morph-flatten';
 import {
-	conflictingMorphNames,
-	differentText,
 	matchGroupTwins,
 	matchIdenticalTwins,
+	matchNamedTextTwins,
 	matchSameMedia,
 } from './morph-heuristics';
 import { getElementMorphName } from './morph-name';
+import { conflictingMorphNames, differentText } from './morph-predicates';
 import type { MorphMatchResult, MorphPair } from './morph-types';
 import { PROXIMITY_SIZE_RATIO_LIMIT, PROXIMITY_THRESHOLD } from './morph-types';
 
@@ -95,6 +95,7 @@ export function getElementCreationId(element: PptxElement): string | undefined {
  *   2c. The child correspondence that let two groups be decomposed
  *   2d. Same media part (pictures: the same image)
  *   2e. Identical twins: same type, exact size, identical paint appearance
+ *   2e2. Named text twins: same pane name, same box, same words
  *   2f. Group twins: same-size groups whose child casts correspond one for one
  *   2b. Native shape id from `p:cNvPr/@id` (only when creationIds are absent)
  *   3. Type + proximity + size matching (same type within 300px, similar box)
@@ -240,6 +241,13 @@ export function matchMorphElementsFull(fromSlide: PptxSlide, toSlide: PptxSlide)
 	// wheel safe: its wedges differ in colour and size, so they still fall
 	// through to proximity.
 	pairs.push(...matchIdenticalTwins(fromElements, toElements, usedFrom, usedTo));
+
+	// Pass 2e2: named text twins - same pane NAME, same box, same words,
+	// however far apart. A text box never declares paint (the gate pass 2e
+	// requires), so a headline parked off-stage and re-landed on-screen -
+	// different creationId, same everything a reader can see - fell through
+	// every pass and dissolved instead of sliding with its panel.
+	pairs.push(...matchNamedTextTwins(fromElements, toElements, usedFrom, usedTo));
 
 	// Pass 2f: group twins - whole GROUPS of the same box size whose child
 	// casts correspond one for one, however far apart they sit.

--- a/packages/shared/src/render/morph-media-assignment.ts
+++ b/packages/shared/src/render/morph-media-assignment.ts
@@ -1,0 +1,175 @@
+/**
+ * Minimum-cost assignment for the same-media morph matching pass.
+ *
+ * When several pictures on one slide share a media part, the pass has to pick
+ * one incoming counterpart per outgoing picture - and with a uniform shift
+ * there can be equally-valid bijections whose TOTAL travel is identical, so
+ * nearest-first greedy and cardinality-first augmenting paths cannot tell
+ * them apart. This module solves the choice as a minimum-cost one-to-one
+ * assignment (Kuhn-Munkres with potentials, O(k^3)) over every legal
+ * same-media edge.
+ *
+ * Everything here is pure; `morph-heuristics` builds the candidate list and
+ * consumes the result one-way.
+ *
+ * @module render/morph-media-assignment
+ */
+
+import type { PptxElement } from 'pptx-viewer-core';
+
+/**
+ * One legal pairing edge of the media pass: an outgoing picture, an incoming
+ * picture painting the same media part, how strongly they advertise the match
+ * (same Selection Pane name beats unnamed) and how far apart they sit.
+ */
+export interface MediaCandidate {
+	readonly to: PptxElement;
+	readonly named: boolean;
+	readonly dist: number;
+	/** How far apart the two BOXES are (`|dw| + |dh|`), breaking exact ties. */
+	readonly sizeDelta: number;
+	/** Incoming-array index: deterministic tie-break among equal candidates. */
+	readonly toIndex: number;
+}
+
+/**
+ * Preference order for one outgoing picture's candidate list.
+ *
+ * Lexicographic preference encoded as weights whose scales cannot cross: an
+ * unnamed edge pays a bonus-sized penalty, then raw travel distance, then how
+ * unlike the two BOXES are, then the incoming input index (a power-of-two
+ * divisor stays binary-exact) for full determinism.
+ */
+export function mediaEdgeCost(candidate: MediaCandidate): number {
+	return (
+		(candidate.named ? 0 : NAMED_EDGE_PENALTY) +
+		candidate.dist +
+		candidate.sizeDelta +
+		candidate.toIndex / 1024
+	);
+}
+
+/** Penalty for pairing against a counterpart without the outgoing pane name. */
+export const NAMED_EDGE_PENALTY = 1e9;
+
+/** Absent-edge cost, far above any attainable sum of real edge costs. */
+export const ABSENT_EDGE_COST = 1e12;
+
+/**
+ * Solve the pass as a minimum-cost one-to-one assignment over every legal
+ * same-media pairing edge.
+ *
+ * @returns For each outgoing id, the column assigned to it, expressed as an
+ *          index into ITS OWN candidate array (`undefined` when the solver
+ *          had to park it on padding, i.e. it stays unmatched).
+ */
+export function minCostMediaAssignment(
+	candidatesOf: Map<string, MediaCandidate[]>,
+): Map<string, number> {
+	const fromIds = [...candidatesOf.keys()];
+	const toIds: string[] = [];
+	for (const candidates of candidatesOf.values()) {
+		for (const candidate of candidates) {
+			if (!toIds.includes(candidate.to.id)) {
+				toIds.push(candidate.to.id);
+			}
+		}
+	}
+
+	const size = Math.max(fromIds.length, toIds.length);
+	const grid: number[][] = [];
+	for (let r = 0; r < fromIds.length; r++) {
+		const candidates = candidatesOf.get(fromIds[r]);
+		const row: number[] = new Array(size).fill(ABSENT_EDGE_COST);
+		if (candidates) {
+			for (const candidate of candidates) {
+				row[toIds.indexOf(candidate.to.id)] = mediaEdgeCost(candidate);
+			}
+		}
+		grid.push(row);
+	}
+	while (grid.length < size) {
+		grid.push(new Array(size).fill(ABSENT_EDGE_COST));
+	}
+
+	const rowToCol = hungarianAssignment(grid);
+
+	const assignment = new Map<string, number>();
+	for (let r = 0; r < fromIds.length; r++) {
+		const col = rowToCol[r];
+		if (col === undefined || col >= toIds.length) {
+			continue;
+		}
+		const candidates = candidatesOf.get(fromIds[r]);
+		const localIndex = candidates?.findIndex((c) => c.to.id === toIds[col]);
+		if (localIndex !== undefined && localIndex >= 0) {
+			assignment.set(fromIds[r], localIndex);
+		}
+	}
+	return assignment;
+}
+
+/**
+ * O(k^3) Kuhn-Munkres assignment (potential method) for a SQUARE cost matrix.
+ *
+ * @returns `columns[r]`, the 0-based column assigned to row r.
+ */
+export function hungarianAssignment(cost: readonly (readonly number[])[]): number[] {
+	const k = cost.length;
+	if (k === 0) {
+		return [];
+	}
+	const u = new Array<number>(k + 1).fill(0);
+	const v = new Array<number>(k + 1).fill(0);
+	// p[j]: the row (1-based) currently matched to column j; way[j]: the
+	// previous column on the alternating path that reached j.
+	const matchOfCol = new Array<number>(k + 1).fill(0);
+	const parent = new Array<number>(k + 1).fill(0);
+	for (let i = 1; i <= k; i++) {
+		matchOfCol[0] = i;
+		let j0 = 0;
+		const minv = new Array<number>(k + 1).fill(Number.POSITIVE_INFINITY);
+		const used = new Array<boolean>(k + 1).fill(false);
+		do {
+			used[j0] = true;
+			const i0 = matchOfCol[j0];
+			let delta = Number.POSITIVE_INFINITY;
+			let j1 = 0;
+			for (let j = 1; j <= k; j++) {
+				if (used[j]) {
+					continue;
+				}
+				const current = cost[i0 - 1][j - 1] - u[i0] - v[j];
+				if (current < minv[j]) {
+					minv[j] = current;
+					parent[j] = j0;
+				}
+				if (minv[j] < delta) {
+					delta = minv[j];
+					j1 = j;
+				}
+			}
+			for (let j = 0; j <= k; j++) {
+				if (used[j]) {
+					u[matchOfCol[j]] += delta;
+					v[j] -= delta;
+				} else {
+					minv[j] -= delta;
+				}
+			}
+			j0 = j1;
+		} while (matchOfCol[j0] !== 0);
+		do {
+			const j1 = parent[j0];
+			matchOfCol[j0] = matchOfCol[j1];
+			j0 = j1;
+		} while (j0 !== 0);
+	}
+	const columns = new Array<number>(k).fill(-1);
+	for (let j = 1; j <= k; j++) {
+		if (matchOfCol[j] > 0) {
+			columns[matchOfCol[j] - 1] = j - 1;
+		}
+	}
+	return columns;
+}

--- a/packages/shared/src/render/morph-overlay-order.test.ts
+++ b/packages/shared/src/render/morph-overlay-order.test.ts
@@ -198,4 +198,60 @@ describe('resolveMorphOverlayArrivals', () => {
 
 		expect([...lifted]).toStrictEqual([]);
 	});
+
+	it('lifts a dissolving-in pair the incoming slide stacks above a travelling ghost', () => {
+		// A title sits at the BOTTOM of the outgoing stack and near the top of
+		// the incoming one, while a full-slide photo (same name, same image,
+		// every id different) slides in from off-stage left and a full-slide
+		// overlay glides in from the right. The merged order anchors the pair
+		// to its outgoing layer, where the ghosts are above it - but mid-flight
+		// those ghosts composite at their counterparts' INCOMING layer, below
+		// the title, so the title must lift to stay visible for the whole
+		// morph.
+		const photo = {
+			from: box('a-photo', -1279, 0, 1279, 720),
+			to: box('b-photo', 1, 0, 1279, 720),
+		};
+		const title = {
+			from: box('a-title', 219, 262, 841, 195),
+			to: box('b-title', 219, 262, 841, 195),
+		};
+		const outgoing = [title.from, photo.from];
+		const incoming = [photo.to, title.to];
+
+		const lifted = resolveMorphOverlayArrivals(
+			outgoing,
+			incoming,
+			[pair(photo.from, photo.to), pair(title.from, title.to)],
+			new Set(['a-photo']),
+			new Set(['b-title']),
+		);
+
+		expect([...lifted]).toStrictEqual(['b-title']);
+	});
+
+	it('leaves an arrival the incoming slide stacks below a travelling ghost', () => {
+		// Mirror image: the incoming slide puts the title UNDER the photo, so
+		// the ghost legitimately passes over it and no lift is warranted.
+		const photo = {
+			from: box('a-photo', -1279, 0, 1279, 720),
+			to: box('b-photo', 1, 0, 1279, 720),
+		};
+		const title = {
+			from: box('a-title', 219, 262, 841, 195),
+			to: box('b-title', 219, 262, 841, 195),
+		};
+		const outgoing = [title.from, photo.from];
+		const incoming = [title.to, photo.to];
+
+		const lifted = resolveMorphOverlayArrivals(
+			outgoing,
+			incoming,
+			[pair(photo.from, photo.to), pair(title.from, title.to)],
+			new Set(['a-photo']),
+			new Set(['b-title']),
+		);
+
+		expect([...lifted]).toStrictEqual([]);
+	});
 });

--- a/packages/shared/src/render/morph-overlay-order.ts
+++ b/packages/shared/src/render/morph-overlay-order.ts
@@ -17,7 +17,10 @@
  * at the end instead of cross-dissolving with the old.
  *
  * This module decides which incoming shapes have to be lifted into the overlay
- * as well, by ranking both slides' shapes in one merged z-order.
+ * as well, by ranking both slides' shapes in one merged z-order and - because
+ * a travelling ghost composites at the layer the INCOMING slide gives its
+ * counterpart, not at the layer the outgoing slide gave the pair - by the
+ * incoming slide's own stacking too.
  *
  * @module render/morph-overlay-order
  */
@@ -158,12 +161,29 @@ export function resolveMorphOverlayArrivals(
 	const rank = buildMorphMergedOrder(outgoing, incoming, pairs);
 	const matched = new Set(pairs.map((pair) => pair.toElement.id));
 	const counterpart = new Map(pairs.map((pair) => [pair.fromElement.id, pair.toElement]));
+	const incomingIndex = new Map(incoming.map((element, index) => [element.id, index]));
 	const ghosts = outgoing
 		.filter((element) => holdingGhostIds.has(element.id))
-		.map((element) => ({
-			rank: rank.get(element.id) ?? 0,
-			box: travelledBox(element, counterpart.get(element.id)),
-		}));
+		.map((element) => {
+			const twin = counterpart.get(element.id);
+			return {
+				rank: rank.get(element.id) ?? 0,
+				// Mid-flight a ghost IS its counterpart, so it composites at the
+				// layer the INCOMING slide gives that counterpart - which is not
+				// always where the outgoing slide stacked the pair. A title that
+				// sits at the bottom of the outgoing stack and near the top of
+				// the incoming one must stay above the sliding photo and overlay
+				// for the whole morph: the merged order (which anchors a pair to
+				// its outgoing layer) must not be the only voice here, or the
+				// arrival dissolves in underneath the travelling ghost and pops
+				// when the overlay comes down.
+				incomingRank:
+					twin === undefined
+						? Number.POSITIVE_INFINITY
+						: (incomingIndex.get(twin.id) ?? Number.POSITIVE_INFINITY),
+				box: travelledBox(element, twin),
+			};
+		});
 
 	const lifted = new Set<string>();
 	for (const element of incoming) {
@@ -171,8 +191,14 @@ export function resolveMorphOverlayArrivals(
 			continue;
 		}
 		const mine = rank.get(element.id) ?? 0;
+		const mineIncoming = incomingIndex.get(element.id) ?? Number.NEGATIVE_INFINITY;
 		const box = travelledBox(element);
-		if (ghosts.some((ghost) => ghost.rank < mine && boxesOverlap(ghost.box, box))) {
+		if (
+			ghosts.some(
+				(ghost) =>
+					boxesOverlap(ghost.box, box) && (ghost.rank < mine || ghost.incomingRank < mineIncoming),
+			)
+		) {
 			lifted.add(element.id);
 		}
 	}

--- a/packages/shared/src/render/morph-predicates.ts
+++ b/packages/shared/src/render/morph-predicates.ts
@@ -1,0 +1,152 @@
+/**
+ * Shared evidence predicates for the morph matching passes.
+ *
+ * These answer the questions every pass asks before pairing two elements: do
+ * they SAY different things (`differentText`), do their `!!` morph names
+ * disagree (`conflictingMorphNames`), what media do they paint, how far apart
+ * do they sit, and do they look alike (`appearanceSignature`). The passes in
+ * `morph-heuristics` combine them; `morph-matching` reuses the two vetoes for
+ * its own gates.
+ *
+ * Everything here is pure.
+ *
+ * @module render/morph-predicates
+ */
+
+import type { PptxElement } from 'pptx-viewer-core';
+
+import { getElementMorphName } from './morph-name';
+
+/** Depth cap for the recursive text read; real decks never nest this far. */
+const TEXT_MAX_DEPTH = 8;
+
+/**
+ * Everything an element WRITES, including the text of its descendants.
+ *
+ * A group paints nothing itself - all of its words live in its children - so
+ * reading only `element.text` reports every group as wordless and lets two
+ * groups with nothing in common look interchangeable (issue #144: a wheel
+ * slide's centre panel paired with a detail slide's callout box and glided
+ * across the slide, "drifting text").
+ */
+function elementText(element: PptxElement, depth = 0): string {
+	const own = (element as { text?: string }).text ?? '';
+	const children = (element as { children?: PptxElement[] }).children;
+	if (!children || depth >= TEXT_MAX_DEPTH) {
+		return own;
+	}
+	let text = own;
+	for (const child of children) {
+		text += ` ${elementText(child, depth + 1)}`;
+	}
+	return text;
+}
+
+/**
+ * Whether two elements both carry text, and carry DIFFERENT text.
+ *
+ * Used to veto a purely positional or appearance-based match:
+ * same-place-different-words is the signature of a rebuilt panel, not of one
+ * object that moved. Whitespace is normalised so a reflowed line break does
+ * not read as a different string.
+ */
+export function differentText(a: PptxElement, b: PptxElement): boolean {
+	const textOf = (element: PptxElement): string =>
+		elementText(element).replace(/\s+/gu, ' ').trim();
+	const fromText = textOf(a);
+	const toText = textOf(b);
+	return fromText !== '' && toText !== '' && fromText !== toText;
+}
+
+/**
+ * Whether two elements both carry an explicit `!!` morph name and those names
+ * DIFFER.
+ *
+ * The `!!` prefix is the author telling PowerPoint which shapes are the same
+ * object across slides, so two different `!!` names are a statement that these
+ * two are NOT (pass 1 already paired every side that agreed). Letting such a
+ * pair fall through to a weaker signal lets an off-canvas box fly in from
+ * off-stage - the "mystery box" of issue #144. Mirrors the `a16:creationId`
+ * rule in pass 2b: evidence of identity that disagrees is evidence of
+ * difference.
+ */
+export function conflictingMorphNames(a: PptxElement, b: PptxElement): boolean {
+	const fromName = getElementMorphName(a);
+	if (!fromName) {
+		return false;
+	}
+	const toName = getElementMorphName(b);
+	return Boolean(toName) && toName !== fromName;
+}
+
+/** The media part an image/picture element paints (path, else data URL). */
+export function mediaIdentity(el: PptxElement): string | undefined {
+	const props = el as { imagePath?: string; imageData?: string };
+	return props.imagePath ?? props.imageData ?? undefined;
+}
+
+/** Euclidean distance between two elements' top-left corners (slide space). */
+export function centreDistance(a: PptxElement, b: PptxElement): number {
+	const dx = a.x - b.x;
+	const dy = a.y - b.y;
+	return Math.sqrt(dx * dx + dy * dy);
+}
+
+/** Whether two elements are the same kind of picture painting the same media. */
+export function sameMediaPicture(a: PptxElement, b: PptxElement): boolean {
+	if (a.type !== 'picture' && a.type !== 'image') {
+		return false;
+	}
+	if (b.type !== a.type) {
+		return false;
+	}
+	if (conflictingMorphNames(a, b)) {
+		return false;
+	}
+	const aMedia = mediaIdentity(a);
+	const bMedia = mediaIdentity(b);
+	return Boolean(aMedia) && aMedia === bMedia;
+}
+
+/** The `shapeStyle` paint fields that decide what an element looks like. */
+export const APPEARANCE_KEYS = [
+	'fillMode',
+	'fillColor',
+	'fillOpacity',
+	'strokeColor',
+	'strokeWidth',
+	'strokeOpacity',
+	'strokeDash',
+] as const;
+
+/**
+ * Whether the element DECLARES paint (an explicit fill or stroke). The twin
+ * pass requires this: two default, unstyled shapes are interchangeable
+ * background debris on any slide, and pairing them is how off-stage boxes
+ * come flying in (the "mystery box" class of bug). A shape whose author
+ * picked a fill and a line and then moved it is a deliberate object.
+ */
+export function hasDeclaredPaint(el: PptxElement): boolean {
+	const style = (el as { shapeStyle?: Record<string, unknown> }).shapeStyle;
+	if (!style) {
+		return false;
+	}
+	return APPEARANCE_KEYS.some((key) => style[key] !== undefined);
+}
+
+/**
+ * A canonical string for everything an element LOOKS like (discriminant,
+ * geometry preset, resolved fill/stroke paint, media). Two elements with
+ * equal signatures are visually interchangeable apart from where they sit.
+ */
+export function appearanceSignature(el: PptxElement): string {
+	const style = (el as { shapeStyle?: Record<string, unknown> }).shapeStyle;
+	const parts: string[] = [el.type, (el as { shapeType?: string }).shapeType ?? ''];
+	if (style) {
+		for (const key of APPEARANCE_KEYS) {
+			parts.push(style[key] === undefined ? '' : String(style[key]));
+		}
+	}
+	parts.push(mediaIdentity(el) ?? '');
+	return parts.join('|');
+}

--- a/packages/shared/src/render/morph-transition.test.ts
+++ b/packages/shared/src/render/morph-transition.test.ts
@@ -13,6 +13,7 @@ import {
 	buildColorInterpolationProps,
 	buildStrokeInterpolationProps,
 	morphPairNeedsCrossfade,
+	computeZOrderSwaps,
 } from './morph-animation';
 import { parseHexColor, lerpColor, rgbaToHex } from './morph-color';
 import { matchMorphElements, matchMorphElementsFull, getElementMorphName } from './morph-matching';
@@ -953,6 +954,71 @@ describe('generateMorphAnimations', () => {
 		];
 		const anims = generateMorphAnimations(pairs, 1000);
 		expect(anims[0].keyframes.match(/scaleX\(-1\)/gu)?.length).toBe(2);
+	});
+
+	it('steps an inert counterpart of a stacking swap together with the mover', () => {
+		// The outgoing slide stacks the photo UNDER a full-frame graphic and the
+		// incoming slide stacks it ABOVE; the graphic itself is visually
+		// unchanged (an inert pair). The z-index journey only works if BOTH
+		// sides of the flip are stepped together: skipping the inert half
+		// leaves it at its static (incoming) layer, where the DOM-order
+		// tie-break already favours the mover, and the swap renders
+		// immediately instead of at the animation midpoint.
+		const inertFrom = makeElement({
+			id: 'inert-a',
+			type: 'picture',
+			imagePath: 'ppt/media/g.png',
+			x: 345,
+			y: 65,
+			width: 590,
+			height: 590,
+		});
+		const inertTo = makeElement({
+			id: 'inert-b',
+			type: 'picture',
+			imagePath: 'ppt/media/g.png',
+			x: 345,
+			y: 65,
+			width: 590,
+			height: 590,
+		});
+		const moverFrom = makeElement({
+			id: 'a',
+			type: 'picture',
+			imagePath: 'ppt/media/p.jpeg',
+			x: 601,
+			y: 282,
+			width: 79,
+			height: 76,
+		});
+		const moverTo = makeElement({
+			id: 'b',
+			type: 'picture',
+			imagePath: 'ppt/media/p.jpeg',
+			x: 307,
+			y: 37,
+			width: 667,
+			height: 645,
+		});
+		const pairs: MorphPair[] = [
+			{ fromElement: inertFrom, toElement: inertTo },
+			{ fromElement: moverFrom, toElement: moverTo },
+		];
+		// Outgoing doc order: mover first (under the graphic); incoming: mover
+		// last (above it).
+		const zSwaps = computeZOrderSwaps(pairs, [moverFrom, inertFrom], [inertTo, moverTo]);
+		expect(zSwaps.get('b')).toStrictEqual({ from: 0, to: 1 });
+		expect(zSwaps.get('inert-b')).toStrictEqual({ from: 1, to: 0 });
+
+		const anims = generateMorphAnimations(pairs, 1000, 'object', new Set(), zSwaps);
+		const inertAnim = anims.find((a) => a.elementId === 'inert-b');
+		expect(inertAnim).toBeDefined();
+		expect(inertAnim!.keyframes).toContain('z-index: 1');
+		expect(inertAnim!.keyframes).toContain('z-index: 0');
+		expect(inertAnim!.keyframes).not.toContain('transform');
+		const moverAnim = anims.find((a) => a.elementId === 'b');
+		expect(moverAnim!.keyframes).toContain('z-index: 0');
+		expect(moverAnim!.keyframes).toContain('z-index: 1');
 	});
 
 	it('keeps a short forward turn untouched', () => {

--- a/packages/shared/src/render/morph-transition.test.ts
+++ b/packages/shared/src/render/morph-transition.test.ts
@@ -902,6 +902,59 @@ describe('generateMorphAnimations', () => {
 		expect(anims[0].keyframes).not.toContain('rotate(315deg)');
 	});
 
+	it('animates a flip change through edge-on instead of snapping it', () => {
+		// A small photo is mirror-flipped and upside down; its grown counterpart
+		// on the next slide is upright. Stating one endpoint's flips on BOTH
+		// frames either flew an upright copy (losing the authored mirror) or
+		// snapped it at landing. Per-frame factors with a constant function
+		// list let CSS interpolate scaleX -1 -> 1 through 0, which is the
+		// edge-on card flip PowerPoint plays, while rotation runs its own arc
+		// alongside.
+		const pairs: MorphPair[] = [
+			{
+				fromElement: makeElement({
+					id: 'a',
+					type: 'picture',
+					imagePath: 'ppt/media/photo.jpeg',
+					rotation: 183.5,
+					flipHorizontal: true,
+				}),
+				toElement: makeElement({
+					id: 'b',
+					type: 'picture',
+					imagePath: 'ppt/media/photo.jpeg',
+				}),
+			},
+		];
+		const anims = generateMorphAnimations(pairs, 1000);
+		const frames = anims[0].keyframes;
+		expect(frames).toContain('scaleX(-1)');
+		expect(frames).toContain('scaleX(1)');
+		// The unflipped axis stays explicit on both frames too, so the transform
+		// lists pair up and interpolate numerically rather than by matrix.
+		expect(frames.match(/scaleY\(1\)/gu)?.length).toBe(2);
+		expect(frames).toContain('rotate(-176.5deg)');
+		expect(frames).toContain('rotate(0deg)');
+
+		// The ghost mirrors the same journey in reverse.
+		const ghosts = generateMorphGhostAnimations(pairs, 1000, 0);
+		expect(ghosts[0].keyframes).toContain('scaleX(-1)');
+		expect(ghosts[0].keyframes).toContain('scaleX(1)');
+	});
+
+	it('keeps a shared flip stated on every frame', () => {
+		// Both endpoints mirrored horizontally: the factor must survive on both
+		// frames or the flight loses the authored mirror and snaps at the end.
+		const pairs: MorphPair[] = [
+			{
+				fromElement: makeElement({ id: 'a', type: 'shape', flipHorizontal: true }),
+				toElement: makeElement({ id: 'b', type: 'shape', flipHorizontal: true }),
+			},
+		];
+		const anims = generateMorphAnimations(pairs, 1000);
+		expect(anims[0].keyframes.match(/scaleX\(-1\)/gu)?.length).toBe(2);
+	});
+
 	it('keeps a short forward turn untouched', () => {
 		const pairs: MorphPair[] = [
 			{

--- a/packages/shared/src/render/slide-transition-css.test.ts
+++ b/packages/shared/src/render/slide-transition-css.test.ts
@@ -412,6 +412,9 @@ describe('resolveTransitionDurationMs', () => {
 
 	it('keeps the morph default when neither a duration nor a speed is authored', () => {
 		expect(resolveTransitionDurationMs({ type: 'morph' })).toBe(DEFAULT_MORPH_DURATION_MS);
+		// Desktop PowerPoint plays a Morph that declares nothing at 0.5s (its
+		// Duration box reads 0.50 for such slides).
+		expect(DEFAULT_MORPH_DURATION_MS).toBe(500);
 	});
 });
 

--- a/packages/shared/src/render/slide-transition-types.ts
+++ b/packages/shared/src/render/slide-transition-types.ts
@@ -131,11 +131,15 @@ export const DEFAULT_TRANSITION_DURATION_MS = 1000;
 /**
  * Default Morph duration (ms) for a transition that declares NEITHER an
  * explicit `p14:dur` (which lands in `durationMs` and always wins) NOR a legacy
- * `spd` speed (see {@link TRANSITION_SPEED_DURATION_MS}). Applying Morph in the
- * PowerPoint UI writes an explicit duration, so this only covers decks that
- * declare nothing at all.
+ * `spd` speed (see {@link TRANSITION_SPEED_DURATION_MS}).
+ *
+ * A Morph that declares nothing carries no duration hint at all, and desktop
+ * PowerPoint then plays it at its own 0.5s fallback (the Duration box shows
+ * 0.50 for such slides and the transition measures at half a second); the
+ * previous 1.0s/2.0s defaults made those decks play at double PowerPoint
+ * speed.
  */
-export const DEFAULT_MORPH_DURATION_MS = 2000;
+export const DEFAULT_MORPH_DURATION_MS = 500;
 
 /**
  * Duration (ms) for each legacy `p:transition/@spd` speed.

--- a/packages/svelte/src/viewer/presentation/presentation-controller.svelte.test.ts
+++ b/packages/svelte/src/viewer/presentation/presentation-controller.svelte.test.ts
@@ -162,6 +162,21 @@ describe('presentationController (native-timing)', () => {
 		expect(controller.transition).toBeNull();
 	});
 
+	it('onSlideChange replays the leaving slide transition on a backward step', () => {
+		const deck = new Deck();
+		deck.slides = [slide('s1'), slide('s2', { transition: { type: 'morph', durationMs: 500 } })];
+		const controller = new PresentationController({
+			getSlides: () => deck.slides,
+			getCurrentIndex: () => deck.index,
+			navigate: () => {},
+		});
+
+		controller.onSlideChange(1, 0);
+		expect(controller.transition?.transition.type).toBe('morph');
+		expect(controller.transition?.outgoing?.id).toBe('s2');
+		expect(controller.transition?.incoming?.id).toBe('s1');
+	});
+
 	it('endTransition and stop drop the overlay', () => {
 		const deck = new Deck();
 		deck.slides = [slide('s1'), slide('s2', { transition: { type: 'fade', durationMs: 600 } })];

--- a/packages/svelte/src/viewer/presentation/presentation-controller.svelte.ts
+++ b/packages/svelte/src/viewer/presentation/presentation-controller.svelte.ts
@@ -344,7 +344,10 @@ export class PresentationController {
 		this.playback.reset({ completed: nextIndex < previousIndex });
 		const slides = this.#deps.getSlides();
 		const incoming = slides[nextIndex];
-		const transition = incoming?.transition;
+		// Forward steps play the ENTERING slide's transition; a backward step
+		// replays the LEAVING slide's transition in reverse (a morph glides its
+		// shapes back to where they came from).
+		const transition = (nextIndex < previousIndex ? slides[previousIndex] : incoming)?.transition;
 		if (transition && transition.type && transition.type !== 'none') {
 			this.#transition = { outgoing: slides[previousIndex], incoming, transition };
 		} else {

--- a/packages/vanilla/src/viewer/animation/presentation-playback.test.ts
+++ b/packages/vanilla/src/viewer/animation/presentation-playback.test.ts
@@ -272,4 +272,46 @@ describe('createPresentationPlayback (native-timing controller)', () => {
 		});
 		expect(stageWrap.querySelector('.pptxv-transition-overlay')).toBeNull();
 	});
+
+	it('replays the leaving slide transition on a backward step', () => {
+		const playback = createPresentationPlayback();
+		const stage0 = buildStage(doc, ['a']);
+		stageWrap.appendChild(stage0);
+		playback.syncStage({
+			doc,
+			stageWrap,
+			stage: stage0,
+			slide: slideWith([]),
+			slideIndex: 0,
+			presenting: true,
+		});
+
+		// Forward to slide 1, which carries a fade transition.
+		stageWrap.replaceChildren();
+		const stage1 = buildStage(doc, ['b']);
+		stageWrap.appendChild(stage1);
+		playback.syncStage({
+			doc,
+			stageWrap,
+			stage: stage1,
+			slide: slideWith([], undefined, { type: 'fade', durationMs: 300 }),
+			slideIndex: 1,
+			presenting: true,
+		});
+
+		// Step back onto slide 0 (no transition of its own): the LEAVING slide's
+		// fade replays in reverse, so an overlay is still mounted.
+		stageWrap.replaceChildren();
+		const stage0b = buildStage(doc, ['a']);
+		stageWrap.appendChild(stage0b);
+		playback.syncStage({
+			doc,
+			stageWrap,
+			stage: stage0b,
+			slide: slideWith([]),
+			slideIndex: 0,
+			presenting: true,
+		});
+		expect(stageWrap.querySelector('.pptxv-transition-overlay')).not.toBeNull();
+	});
 });

--- a/packages/vanilla/src/viewer/animation/presentation-playback.ts
+++ b/packages/vanilla/src/viewer/animation/presentation-playback.ts
@@ -300,7 +300,10 @@ export function createPresentationPlayback(): PresentationPlayback {
 
 			// Play the incoming slide's transition when the slide changed mid-show
 			// (never on the initial enter; only with an outgoing snapshot to animate).
-			const transition = params.slide.transition;
+			// A backward step replays the LEAVING slide's transition in reverse
+			// (PowerPoint: a morph glides its shapes back to where they came from).
+			const goingBack = params.slideIndex < lastIndex;
+			const transition = goingBack ? outgoingSlide?.transition : params.slide.transition;
 			if (
 				!entering &&
 				slideChanged &&

--- a/packages/vue/src/viewer/composables/usePresentationNavigation.test.ts
+++ b/packages/vue/src/viewer/composables/usePresentationNavigation.test.ts
@@ -127,3 +127,26 @@ describe('usePresentationNavigation - loop continuously', () => {
 		expect(nav.showEndScreen.value).toBeFalsy();
 	});
 });
+
+describe('usePresentationNavigation transition direction', () => {
+	it('plays the entering slide transition on a forward step', async () => {
+		const { nav } = setup({
+			slides: [slide('s1'), slide('s2', { transition: { type: 'morph', durationMs: 500 } })],
+		});
+		nav.goTo(1);
+		await vi.waitFor(() => expect(nav.transitionState.value?.transition.type).toBe('morph'));
+		expect(nav.transitionState.value?.outgoing?.id).toBe('s1');
+		expect(nav.transitionState.value?.incoming?.id).toBe('s2');
+	});
+
+	it('replays the leaving slide transition on a backward step', async () => {
+		const { nav } = setup({
+			slides: [slide('s1'), slide('s2', { transition: { type: 'morph', durationMs: 500 } })],
+		});
+		nav.goTo(1);
+		await vi.waitFor(() => expect(nav.transitionState.value?.transition.type).toBe('morph'));
+		nav.goTo(0);
+		await vi.waitFor(() => expect(nav.transitionState.value?.outgoing?.id).toBe('s2'));
+		expect(nav.transitionState.value?.incoming?.id).toBe('s1');
+	});
+});

--- a/packages/vue/src/viewer/composables/usePresentationNavigation.ts
+++ b/packages/vue/src/viewer/composables/usePresentationNavigation.ts
@@ -167,7 +167,11 @@ export function usePresentationNavigation(
 		// The playback controller rebuilds itself on the active-slide change (it
 		// watches `activeSlide`), so no explicit reset is needed here.
 		const incoming = options.slides()[index];
-		const transition = incoming?.transition;
+		// Forward steps play the ENTERING slide's transition; a backward step
+		// replays the LEAVING slide's transition in reverse (a morph glides its
+		// shapes back to where they came from).
+		const transition = (index < previousIndex ? options.slides()[previousIndex] : incoming)
+			?.transition;
 		transitionState.value =
 			transition && transition.type && transition.type !== 'none'
 				? { outgoing: options.slides()[previousIndex], incoming, transition }


### PR DESCRIPTION
## What does this change?

Completes the morph transition fix set: the matcher gains the weaker pairing passes PowerPoint uses, the journeys gain PowerPoint's stacking/flip/crop behaviour, backward steps replay the leaving slide's transition, and transition durations are verified against desktop PowerPoint (COM `SlideShowTransition.Duration`).

- **Matcher passes** (new `morph-heuristics` passes, wired into `morph-matching`):
  - **2d same-media**: pictures painting the same media part pair up regardless of ids and names. With several same-media tiles the choice is a **minimum-cost assignment** (Kuhn-Munkres, O(k^3), in the new `morph-media-assignment` module): greedy nearest-first is order-dependent without backtracking, and equally-valid bijections with equal total travel defeat cardinality-first solvers too.
  - **2e identical twins**: same type, exact box size, identical *declared* paint, however far apart. The declared-paint gate keeps unstyled shapes unmatched (the "mystery box" class of bug, issue #144).
  - **2e2 named text twins**: same pane name, same box, same words, however far apart. A text box never declares paint, so a headline parked off-stage and re-landed on-screen fell through every pass and dissolved instead of sliding with its panel.
  - **2f group twins**: same-size groups whose child casts correspond one for one, pairing the container so a rotation stays one journey.
  - All passes honour the conflicting-`!!`-names and different-words vetoes (issue #144's drifting text); the issue #131 wheel still falls through to proximity.
- **Journey fixes** (`morph-animation`):
  - Stacking-order swaps step **mid-flight** via z-index journeys (`computeZOrderSwaps`) instead of popping at frame 1 - including the inert counterpart of a swap, whose journey used to be skipped entirely.
  - The overlay-order machinery lifts an arrival the *incoming* slide stacks above a travelling ghost (mid-flight a ghost composites at its counterpart's incoming layer).
  - Flips are stated per frame (always emitted, even as +1) so CSS interpolates scaleX -1 -> 1 through zero: the edge-on card flip PowerPoint plays.
  - Journey transform order becomes `translate rotate scale`, so a rotated pair resizes along its own axes instead of shearing; a picture whose frame grows with its crop now **reveals** instead of zooming (stepped crop track sampled along the real CSS easing; a swapped-exponent bezier evaluation fixed).
- **Backward replay** (all five bindings): stepping back replays the LEAVING slide's transition, as PowerPoint does - a morph glides its shapes back to where they came from. Previously react/angular skipped transitions on backward steps and vue/svelte/vanilla replayed the target slide's.
- **Durations, COM-verified**: an un-authored Morph plays at PowerPoint's 0.5s fallback (was 2s), the legacy `spd` tokens map to fast 0.5s / med 0.75s / slow 1.0s, and an explicit `p14:dur` wins over `spd`. Angular's overlay had a local duration resolver that ignored `spd` entirely - it now delegates to the shared resolver (classic transitions keep Angular's own floor/default policy, a documented divergence).

The shared evidence predicates (different-words and conflicting-`!!` vetoes, media identity, appearance signatures) live in the new `morph-predicates` module; `morph-flatten` exports `correspondingChildren` for the group-twin pass.

## Type of change

- [x] New feature (non-breaking)

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

The matcher and journey engine are framework-agnostic; every binding inherits them. The backward-replay behaviour is wired per binding, and Angular additionally needed its overlay duration resolver corrected.

| Binding                      | Affected? | Fixed / implemented here? | Notes                                                                 |
| ---------------------------- | --------- | ------------------------- | --------------------------------------------------------------------- |
| React (`packages/react`)     | yes       | yes                       | shared passes/journeys + backward-replay wiring (`slide-transition`)  |
| Vue (`packages/vue`)         | yes       | yes                       | shared passes/journeys + backward-replay wiring (`usePresentationNavigation`) |
| Angular (`packages/angular`) | yes       | yes                       | shared passes/journeys + navigator prev branch + overlay duration fix |
| Svelte (`packages/svelte`)   | yes       | yes                       | shared passes/journeys + backward-replay wiring (`presentation-controller`) |
| Vanilla (`packages/vanilla`) | yes       | yes                       | shared passes/journeys + backward-replay wiring (`presentation-playback`) |

All five were actually checked: manual browser verification against the demos, per-binding unit tests, and the morph e2e specs run locally across all five projects (see Testing).

### New UI feature

- [x] The framework-agnostic logic lives in `pptx-viewer-shared`, not duplicated per binding
- [x] Implemented in **all five** bindings
- [x] No user-visible copy is added, so no i18n keys are needed

---

## Testing

- [x] Unit tests added: per-pass pairing and every veto (`morph-heuristics.test.ts`), the assignment solver through the split-mosaic end-to-end case, z-order journeys including the inert-counterpart case (`morph-transition.test.ts`), the stepped crop track's painted-width/easing/landing invariants (`morph-image-crop.test.ts`), the overlay arrival lift criterion (`morph-overlay-order.test.ts`), and backward replay per binding.
- [x] Regression test added that fails without this change (each pass and each journey fix has a case the old code could not produce).
- [x] e2e: ran the morph specs (`issue-131-fidelity`, `issue-144-morph`, `issue-160-morph-crossfade`, `morph-shape-swap`) locally across all five projects - 94-95 passed per run. Two failures remain that reproduce identically on clean `main` and are unrelated: the issue-131 text-wrap case (all five bindings) and the angular AutoSave-toggle case. One angular timing flake was observed once and passed on re-run.
- [x] Full shared suite green (7197 tests); per-binding suites green for every touched binding.

## Checks run locally

- [x] `bun run lint`
- [x] `bun run fmt:check`
- [x] `bun run typecheck`
- [x] `bun run test`

## Conventional Commits

- [x] Commit messages follow Conventional Commits (`feat(shared)` x3, `feat(react,vue,angular,svelte,vanilla)`, `fix(shared)`, `fix(angular)`).
