### PR TITLE
fix: wipe direction, feathered edge and the arriving transition half

### DIFF
--- a/packages/angular/src/viewer/presentation-transition-overlay.component.test.ts
+++ b/packages/angular/src/viewer/presentation-transition-overlay.component.test.ts
@@ -28,6 +28,7 @@ import { describe, expect, it } from 'vitest';
 
 import { buildMorphScopedCss, buildMorphTransitionPlan } from '../internal/shared';
 import {
+	classicIncomingLayerSlide,
 	morphCrossfadeGroupSlides,
 	morphLiftedSlide,
 } from './presentation-transition-overlay.component';
@@ -224,6 +225,68 @@ function discAndReplacedWording(): { from: PptxSlide; to: PptxSlide } {
 // chunks out of glyphs where the two line grids cross. PowerPoint's own render
 // keeps the blend coefficients summing to 1.0 for every frame, so the pair is
 // summed inside its own isolation group instead.
+describe('classicIncomingLayerSlide', () => {
+	const template = [
+		{
+			id: 'tpl-1',
+			type: 'shape',
+			name: 'Template Rect',
+			x: 0,
+			y: 0,
+			width: 960,
+			height: 540,
+		} as unknown as PptxElement,
+	];
+
+	it('wraps the arriving slide (with template elements) for a wipe', () => {
+		const incoming = slide('in', [
+			{
+				id: 'in-1',
+				type: 'shape',
+				name: 'Rect',
+				x: 10,
+				y: 10,
+				width: 50,
+				height: 25,
+			} as unknown as PptxElement,
+		]);
+
+		const layer = classicIncomingLayerSlide(
+			false,
+			'pptx-tr-wipe-from-left 600ms',
+			incoming,
+			template,
+		);
+
+		expect(layer?.id).toBe('in');
+		expect(layer?.elements.map((element) => element.id)).toStrictEqual(['tpl-1', 'in-1']);
+	});
+
+	it('renders no layer for the uncover family, which reveals the live stage', () => {
+		const incoming = slide('in', []);
+		expect(classicIncomingLayerSlide(false, 'none', incoming, template)).toBeUndefined();
+	});
+
+	it('renders no layer for a morph, which paints its own halves', () => {
+		const incoming = slide('in', []);
+		expect(
+			classicIncomingLayerSlide(true, 'pptx-morph-7-incoming 800ms', incoming, template),
+		).toBeUndefined();
+	});
+
+	it('renders no layer without an incoming slide', () => {
+		expect(
+			classicIncomingLayerSlide(false, 'pptx-tr-wipe-from-left 600ms', undefined, []),
+		).toBeUndefined();
+	});
+
+	it('binds the layer and its animation in the template', () => {
+		expect(OVERLAY_SOURCE).toContain('data-pptx-transition-layer="incoming"');
+		expect(OVERLAY_SOURCE).toContain('[ngStyle]="incomingLayerStyle()"');
+		expect(OVERLAY_SOURCE).toContain('incomingLayerSlide()');
+	});
+});
+
 describe('morphCrossfadeGroupSlides', () => {
 	it('wraps each half as its own single-element slide, in an isolated group', () => {
 		const { from, to } = discAndReplacedWording();

--- a/packages/angular/src/viewer/presentation-transition-overlay.component.ts
+++ b/packages/angular/src/viewer/presentation-transition-overlay.component.ts
@@ -15,7 +15,6 @@ import type { CanvasSize, MorphTransitionPlan } from '../internal/shared';
 import {
 	buildMorphScopedCss,
 	buildMorphTransitionPlan,
-	DEFAULT_MORPH_DURATION_MS,
 	MORPH_CROSSFADE_GROUP_STYLE,
 	MORPH_CROSSFADE_HALF_BLEND_MODE,
 	morphOptionToMode,
@@ -24,7 +23,7 @@ import type { StyleMap } from './element-style';
 import { SlideCanvasComponent } from './slide-canvas.component';
 import {
 	getSlideTransitionAnimations,
-	resolveTransitionDuration,
+	resolveOverlayDurationMs,
 	transitionSlideBoxSize,
 } from './transition-helpers';
 import type { SlideTransitionAnimations } from './transition-helpers';
@@ -32,6 +31,35 @@ import { ensureTransitionKeyframes } from './transition-keyframes';
 
 /** Safety margin (ms) added to the animation duration before firing complete. */
 const COMPLETE_MARGIN_MS = 50;
+
+/**
+ * The slide the incoming (arriving) layer paints for a CLASSIC transition, or
+ * `undefined` when no such layer may exist.
+ *
+ * Without this layer the overlay painted only the outgoing slide: a wipe
+ * (whose outgoing half is `none`) sat opaque for the whole duration and the
+ * arriving slide - only ever the live stage beneath - popped in the instant
+ * the overlay tore down ("takes the time, then instantly replaced"). Types
+ * whose incoming half is `none` (the uncover family) deliberately reveal the
+ * live stage and get no layer, and a morph paints its own halves.
+ *
+ * Exported and pure so it can be unit-tested: this package renders no component
+ * under test (see `action-settings-panel.component.test.ts`).
+ */
+export function classicIncomingLayerSlide(
+	isMorph: boolean,
+	incomingAnimation: string,
+	incomingSlide: PptxSlide | undefined,
+	templateElements: readonly PptxElement[],
+): PptxSlide | undefined {
+	if (isMorph || incomingAnimation === 'none' || !incomingSlide) {
+		return undefined;
+	}
+	if (templateElements.length === 0) {
+		return incomingSlide;
+	}
+	return { ...incomingSlide, elements: [...templateElements, ...incomingSlide.elements] };
+}
 
 /**
  * The slide the overlay paints ABOVE its ghosts, or `undefined` when a morph
@@ -170,6 +198,25 @@ export function morphCrossfadeGroupSlides(
 		}
 	`,
 	template: `
+		@if (incomingLayerSlide(); as incoming) {
+			<div
+				class="pptx-ng-transition-layer"
+				data-pptx-transition-layer="incoming"
+				[ngStyle]="incomingLayerStyle()"
+			>
+				<div [ngStyle]="slideBoxStyle()">
+					<pptx-slide-canvas
+						[slide]="incoming"
+						[canvasSize]="canvasSize()"
+						[mediaDataUrls]="mediaDataUrls()"
+						[zoom]="zoom()"
+						[autoFit]="false"
+						[interactive]="false"
+					/>
+				</div>
+			</div>
+		}
+
 		<div
 			class="pptx-ng-transition-layer"
 			data-pptx-transition-layer="outgoing"
@@ -362,19 +409,9 @@ export class PresentationTransitionOverlayComponent {
 	// ------------------------------------------------------------------
 
 	/** Effective transition duration (ms), floored/defaulted. */
-	protected readonly resolvedDurationMs = computed<number>(() => {
-		const override = this.durationMs();
-		if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
-			return override;
-		}
-		const tr = this.transition();
-		// PowerPoint's Morph defaults to 2.00s (`p14:dur` overrides arrive in
-		// `durationMs`); the generic 1s default made it visibly abrupt.
-		if (tr.type === 'morph' && !(typeof tr.durationMs === 'number' && tr.durationMs > 0)) {
-			return DEFAULT_MORPH_DURATION_MS;
-		}
-		return resolveTransitionDuration(tr.durationMs);
-	});
+	protected readonly resolvedDurationMs = computed<number>(() =>
+		resolveOverlayDurationMs(this.durationMs(), this.transition()),
+	);
 
 	/** Resolved CSS animation descriptors for the outgoing/incoming layers. */
 	protected readonly animations = computed<SlideTransitionAnimations>(() => {
@@ -465,6 +502,27 @@ export class PresentationTransitionOverlayComponent {
 		}
 		return style;
 	});
+
+	/**
+	 * The arriving slide rendered ABOVE the outgoing layer for a classic
+	 * transition, carrying the incoming animation (wipe/cover/fade/push), or
+	 * `undefined` for morphs and the uncover family (which reveal the live
+	 * stage instead).
+	 */
+	protected readonly incomingLayerSlide = computed<PptxSlide | undefined>(() =>
+		classicIncomingLayerSlide(
+			this.isMorph(),
+			this.animations().incoming,
+			this.incomingSlide(),
+			this.templateElements(),
+		),
+	);
+
+	/** Style for that arriving layer: the incoming animation + its stacking. */
+	protected readonly incomingLayerStyle = computed<StyleMap>(() => ({
+		'z-index': this.animations().outgoingOnTop ? '30' : '25',
+		animation: this.animations().incoming,
+	}));
 
 	/**
 	 * Slide box sized to the ZOOMED slide footprint, matching the stage's own

--- a/packages/angular/src/viewer/transition-helpers.test.ts
+++ b/packages/angular/src/viewer/transition-helpers.test.ts
@@ -1,7 +1,8 @@
-import type { PptxTransitionType } from 'pptx-viewer-core';
+import type { PptxSlideTransition, PptxTransitionType } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import {
+	DEFAULT_MORPH_DURATION_MS,
 	DEFAULT_TRANSITION_DURATION_MS,
 	INSTANT,
 	MIN_TRANSITION_DURATION_MS,
@@ -11,6 +12,7 @@ import {
 	resolveDirection,
 	resolveDirection8,
 	resolveOrientation,
+	resolveOverlayDurationMs,
 	resolveTransitionDuration,
 	transitionSlideBoxSize,
 } from './transition-helpers';
@@ -237,7 +239,10 @@ describe('getSlideTransitionAnimations', () => {
 	it('produces wipe animations with direction', () => {
 		const result = getSlideTransitionAnimations('wipe', 800, 'u');
 		expect(result.outgoing).toBe('none');
-		expect(result.incoming).toContain('wipe-from-top');
+		// `p:wipe/@dir` is the direction of TRAVEL: PowerPoint's UI "From
+		// Bottom" is stored as dir="u", so token u reveals from the BOTTOM
+		// edge sweeping up.
+		expect(result.incoming).toContain('wipe-from-bottom');
 		expect(result.incoming).toContain('800ms');
 	});
 
@@ -416,5 +421,37 @@ describe('transitionSlideBoxSize', () => {
 			width: 1,
 			height: 1,
 		});
+	});
+});
+
+describe('resolveOverlayDurationMs', () => {
+	const transition = (overrides: Partial<PptxSlideTransition>): PptxSlideTransition =>
+		({ type: 'morph', ...overrides }) as PptxSlideTransition;
+
+	it('lets the explicit override win over everything', () => {
+		expect(resolveOverlayDurationMs(800, transition({ durationMs: 2500, speed: 'slow' }))).toBe(
+			800,
+		);
+	});
+
+	it('honours an authored p14:dur for morphs', () => {
+		expect(resolveOverlayDurationMs(undefined, transition({ durationMs: 2500 }))).toBe(2500);
+	});
+
+	it('honours the legacy spd token for morphs', () => {
+		expect(resolveOverlayDurationMs(undefined, transition({ speed: 'slow' }))).toBe(1000);
+		expect(resolveOverlayDurationMs(undefined, transition({ speed: 'fast' }))).toBe(500);
+	});
+
+	it('falls back to the shared un-authored morph default', () => {
+		// The constant itself lives in shared (and its value is pinned by the
+		// shared suite); what this pins is that the overlay DELEGATES to it.
+		expect(resolveOverlayDurationMs(undefined, transition({}))).toBe(DEFAULT_MORPH_DURATION_MS);
+	});
+
+	it('keeps the angular classic-transition policy for non-morphs', () => {
+		expect(resolveOverlayDurationMs(undefined, { type: 'fade' } as PptxSlideTransition)).toBe(
+			DEFAULT_TRANSITION_DURATION_MS,
+		);
 	});
 });

--- a/packages/angular/src/viewer/transition-helpers.ts
+++ b/packages/angular/src/viewer/transition-helpers.ts
@@ -18,12 +18,17 @@
  * `PresentationTransitionOverlayComponent` imports the same symbol names from
  * here unchanged.
  */
+import type { PptxSlideTransition } from 'pptx-viewer-core';
+
+import { resolveTransitionDurationMs } from '../internal/shared';
+
 export type {
 	SlideTransitionAnimations,
 	ResolvedDirection,
 	ResolvedDirection8,
 } from '../internal/shared';
 export {
+	DEFAULT_MORPH_DURATION_MS,
 	resolveDirection,
 	resolveDirection8,
 	resolveOrientation,
@@ -57,6 +62,30 @@ export function resolveTransitionDuration(durationMs: number | undefined): numbe
 			? durationMs
 			: DEFAULT_TRANSITION_DURATION_MS;
 	return Math.max(MIN_TRANSITION_DURATION_MS, raw);
+}
+
+/**
+ * The presentation overlay's effective duration (ms): an explicit override
+ * wins; a MORPH delegates to the shared resolver, which honours an authored
+ * `p14:dur`, then the legacy `spd` token, then PowerPoint's 0.5s fallback for
+ * a morph that declares neither. The previous local copy ignored `spd`
+ * entirely, so spd-authored morphs played at the (wrong) hard-coded default
+ * while every other binding honoured the authored speed.
+ *
+ * Classic (non-morph) transitions keep Angular's own floor/default policy
+ * above - that divergence is deliberate (see the file header).
+ */
+export function resolveOverlayDurationMs(
+	override: number | undefined,
+	transition: PptxSlideTransition,
+): number {
+	if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
+		return override;
+	}
+	if (transition.type === 'morph') {
+		return resolveTransitionDurationMs(transition);
+	}
+	return resolveTransitionDuration(transition.durationMs);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/viewer/components/PresentationTransitionOverlay.test.tsx
+++ b/packages/react/src/viewer/components/PresentationTransitionOverlay.test.tsx
@@ -109,6 +109,48 @@ describe('presentationTransitionOverlay', () => {
 		expect(html).toContain('Outgoing Slide');
 	});
 
+	// Regression: for classic transitions the overlay used to render ONLY the
+	// outgoing layer, so a wipe (whose outgoing half is 'none') sat opaque for
+	// the whole duration and the arriving slide - only ever the live stage
+	// beneath - popped in the instant the overlay tore down. The arriving slide
+	// has to be IN the overlay, carrying the incoming animation.
+	it('renders the arriving slide carrying the incoming wipe animation', () => {
+		const html = renderToStaticMarkup(
+			<PresentationTransitionOverlay
+				outgoingSlide={makeSlide()}
+				incomingSlide={{ ...makeSlide(), id: 'incoming-slide' }}
+				templateElements={[]}
+				canvasSize={{ width: 960, height: 540 }}
+				transition={{ type: 'wipe', durationMs: 600, direction: 'r' }}
+				durationMs={600}
+				onComplete={vi.fn()}
+			/>,
+		);
+		expect(html).toMatch(/animation:\s*pptx-tr-wipe-from-left 600ms/u);
+		expect(html).toContain('data-pptx-transition-layer="incoming"');
+		// The arriving wording is painted by the overlay copy too (it is not
+		// relying on the stage beneath, which the outgoing layer covers).
+		expect(html).toContain('Outgoing Slide');
+	});
+
+	it('renders no static incoming layer for types that reveal the stage', () => {
+		// Uncover animates the OUTGOING slide away; its incoming half is 'none'
+		// precisely so the live stage is revealed. A static incoming layer here
+		// would cover the animation.
+		const html = renderToStaticMarkup(
+			<PresentationTransitionOverlay
+				outgoingSlide={makeSlide()}
+				incomingSlide={{ ...makeSlide(), id: 'incoming-slide' }}
+				templateElements={[]}
+				canvasSize={{ width: 960, height: 540 }}
+				transition={{ type: 'uncover', durationMs: 600, direction: 'l' }}
+				durationMs={600}
+				onComplete={vi.fn()}
+			/>,
+		);
+		expect(html).not.toContain('data-pptx-transition-layer="incoming"');
+	});
+
 	// Regression (issue #106): the overlay used to measure itself in a mount
 	// effect, so the FIRST painted frame scaled the outgoing slide by 1 while
 	// the incoming slide was already at stage scale. On a 1080p display that is

--- a/packages/react/src/viewer/components/PresentationTransitionOverlay.tsx
+++ b/packages/react/src/viewer/components/PresentationTransitionOverlay.tsx
@@ -333,11 +333,45 @@ export function PresentationTransitionOverlay({
 		>
 			{/* Inject the transition @keyframes so the `animation` shorthands resolve. */}
 			<style>{SLIDE_TRANSITION_KEYFRAMES}</style>
+			{/* The ARRIVING slide, carrying the incoming animation. Without this
+			    layer the arriving slide is only the live stage BENEATH the
+			    overlay: an opaque outgoing layer (wipe/cover leave it in place)
+			    hid it for the whole duration, then the teardown revealed it in
+			    one frame - "takes the time, then instantly replaced". Types whose
+			    incoming half is 'none' (uncover family) must keep revealing the
+			    stage, so no static layer is rendered for them. */}
+			{!morphPlan && animations.incoming !== 'none' && incomingSlide ? (
+				<div
+					data-pptx-transition-layer='incoming'
+					className='pptx-react-transition-layer absolute inset-0 flex items-center justify-center'
+					style={{
+						animation: animations.incoming,
+						zIndex: animations.outgoingOnTop ? 0 : 10,
+					}}
+				>
+					<div
+						style={{
+							width: canvasSize.width,
+							height: canvasSize.height,
+							flexShrink: 0,
+							transform: `scale(${scale})`,
+							transformOrigin: 'center',
+						}}
+					>
+						<SlideLayer
+							slide={incomingSlide}
+							templateElements={templateElements}
+							canvasSize={canvasSize}
+						/>
+					</div>
+				</div>
+			) : null}
 			<div
 				data-pptx-transition-layer='outgoing'
 				className='pptx-react-transition-layer absolute inset-0 flex items-center justify-center'
 				style={{
 					animation: animations.outgoing !== 'none' ? animations.outgoing : undefined,
+					zIndex: animations.outgoingOnTop ? 10 : 0,
 				}}
 			>
 				<div

--- a/packages/react/src/viewer/utils/transition-resolver.test.ts
+++ b/packages/react/src/viewer/utils/transition-resolver.test.ts
@@ -37,7 +37,10 @@ describe('getSlideTransitionAnimations', () => {
 	it('should produce wipe animations with direction', () => {
 		const result = getSlideTransitionAnimations('wipe', 800, 'u');
 		expect(result.outgoing).toBe('none');
-		expect(result.incoming).toContain('wipe-from-top');
+		// `p:wipe/@dir` is the direction of TRAVEL: PowerPoint's UI "From
+		// Bottom" is stored as dir="u", so token u reveals from the BOTTOM
+		// edge sweeping up.
+		expect(result.incoming).toContain('wipe-from-bottom');
 		expect(result.incoming).toContain('800ms');
 	});
 

--- a/packages/shared/src/render/slide-transition-css.test.ts
+++ b/packages/shared/src/render/slide-transition-css.test.ts
@@ -109,8 +109,22 @@ describe('getSlideTransitionAnimations', () => {
 	it('wipes the incoming layer only', () => {
 		const result = getSlideTransitionAnimations('wipe', 400, 'r');
 		expect(result.outgoing).toBe('none');
-		expect(result.incoming).toContain('pptx-tr-wipe-from-right');
+		// `dir` is the direction of TRAVEL: PowerPoint stores "From Left" as
+		// dir="r", so token r reveals from the LEFT edge sweeping right.
+		expect(result.incoming).toContain('pptx-tr-wipe-from-left');
 		expect(result.outgoingOnTop).toBeFalsy();
+	});
+
+	it('maps every wipe token to its opposite starting edge', () => {
+		expect(getSlideTransitionAnimations('wipe', 400, 'l').incoming).toContain(
+			'pptx-tr-wipe-from-right',
+		);
+		expect(getSlideTransitionAnimations('wipe', 400, 'u').incoming).toContain(
+			'pptx-tr-wipe-from-bottom',
+		);
+		expect(getSlideTransitionAnimations('wipe', 400, 'd').incoming).toContain(
+			'pptx-tr-wipe-from-top',
+		);
 	});
 
 	it('covers with diagonal support', () => {

--- a/packages/shared/src/render/slide-transition-css.ts
+++ b/packages/shared/src/render/slide-transition-css.ts
@@ -134,12 +134,20 @@ export function getSlideTransitionAnimations(
 		}
 
 		case 'wipe': {
+			// `p:wipe/@dir` is the direction of TRAVEL, not the starting edge:
+			// PowerPoint's UI offers "From Left / From Right / ..." and stores
+			// the OPPOSITE token (UI "From Left" is written as dir="r", and
+			// desktop PowerPoint reveals such a slide from the LEFT edge
+			// sweeping right). So a token of r starts the reveal at the left
+			// edge, u at the bottom, etc. - the inverse of every other mapping
+			// here, where the token names the motion and the keyframe names it
+			// the same way.
 			const dir = resolveDirection(direction, 'left');
 			const wipeNames: Record<ResolvedDirection, string> = {
-				left: `pptx-tr-wipe-from-left ${dur} ${EASE} forwards`,
-				right: `pptx-tr-wipe-from-right ${dur} ${EASE} forwards`,
-				up: `pptx-tr-wipe-from-top ${dur} ${EASE} forwards`,
-				down: `pptx-tr-wipe-from-bottom ${dur} ${EASE} forwards`,
+				left: `pptx-tr-wipe-from-right ${dur} ${EASE} forwards`,
+				right: `pptx-tr-wipe-from-left ${dur} ${EASE} forwards`,
+				up: `pptx-tr-wipe-from-bottom ${dur} ${EASE} forwards`,
+				down: `pptx-tr-wipe-from-top ${dur} ${EASE} forwards`,
 			};
 			return {
 				outgoing: 'none',

--- a/packages/shared/src/render/slide-transition-keyframes.ts
+++ b/packages/shared/src/render/slide-transition-keyframes.ts
@@ -22,6 +22,7 @@
 
 import { P14_TRANSITION_KEYFRAMES_ALL } from './p14-transition-keyframes';
 import { CINEMATIC_TRANSITION_KEYFRAMES } from './slide-transition-cinematic';
+import { WIPE_MASK_KEYFRAMES } from './slide-transition-wipe-keyframes';
 
 const CORE_SLIDE_TRANSITION_KEYFRAMES = `
 /* ── Fade ───────────────────────────────────────────────────────────── */
@@ -134,24 +135,6 @@ const CORE_SLIDE_TRANSITION_KEYFRAMES = `
 @keyframes pptx-tr-uncover-to-rd {
 	from { transform: translate(0, 0); }
 	to   { transform: translate(100%, 100%); }
-}
-
-/* ── Wipe (clip-path reveal) ────────────────────────────────────────── */
-@keyframes pptx-tr-wipe-from-left {
-	from { clip-path: inset(0 100% 0 0); }
-	to   { clip-path: inset(0 0 0 0); }
-}
-@keyframes pptx-tr-wipe-from-right {
-	from { clip-path: inset(0 0 0 100%); }
-	to   { clip-path: inset(0 0 0 0); }
-}
-@keyframes pptx-tr-wipe-from-top {
-	from { clip-path: inset(0 0 100% 0); }
-	to   { clip-path: inset(0 0 0 0); }
-}
-@keyframes pptx-tr-wipe-from-bottom {
-	from { clip-path: inset(100% 0 0 0); }
-	to   { clip-path: inset(0 0 0 0); }
 }
 
 /* ── Split ──────────────────────────────────────────────────────────── */
@@ -292,7 +275,7 @@ const CORE_SLIDE_TRANSITION_KEYFRAMES = `
  * faithful Office 2010 (`p14`) keyframes, so both the classic and exotic / 3-D
  * transitions animate wherever this single string is injected.
  */
-export const SLIDE_TRANSITION_KEYFRAMES = `${CORE_SLIDE_TRANSITION_KEYFRAMES}\n${P14_TRANSITION_KEYFRAMES_ALL}\n${CINEMATIC_TRANSITION_KEYFRAMES}`;
+export const SLIDE_TRANSITION_KEYFRAMES = `${CORE_SLIDE_TRANSITION_KEYFRAMES}\n${WIPE_MASK_KEYFRAMES}\n${P14_TRANSITION_KEYFRAMES_ALL}\n${CINEMATIC_TRANSITION_KEYFRAMES}`;
 
 /**
  * Alias of {@link SLIDE_TRANSITION_KEYFRAMES} under the `_CSS` name the Vue

--- a/packages/shared/src/render/slide-transition-wipe-keyframes.test.ts
+++ b/packages/shared/src/render/slide-transition-wipe-keyframes.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for the wipe mask keyframes (`slide-transition-wipe-keyframes.ts`).
+ *
+ * The wipe reveals via a 3x-oversized gradient mask whose position sweeps;
+ * the mask's black zone must sit over the element at the END frame and off it
+ * at the START frame, or the direction plays inverted (fully visible first,
+ * erasing upward). The from-top keyframes shipped exactly that inversion once.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { SLIDE_TRANSITION_KEYFRAMES } from './slide-transition-keyframes';
+
+const block = (name: string): string => {
+	const start = SLIDE_TRANSITION_KEYFRAMES.indexOf(`@keyframes ${name} {`);
+	const end = SLIDE_TRANSITION_KEYFRAMES.indexOf('@keyframes', start + 1);
+	return SLIDE_TRANSITION_KEYFRAMES.slice(start, end);
+};
+
+describe('wipe mask geometry', () => {
+	it.each([
+		['pptx-tr-wipe-from-left', '100% 0', '0% 0'],
+		['pptx-tr-wipe-from-right', '0% 0', '100% 0'],
+		['pptx-tr-wipe-from-top', '0 100%', '0 0%'],
+		['pptx-tr-wipe-from-bottom', '0 0%', '0 100%'],
+	])('%s starts hidden and ends opaque', (name, fromPosition, toPosition) => {
+		const keyframes = block(name);
+		const fromPart = keyframes.slice(keyframes.indexOf('from {'), keyframes.indexOf('to {'));
+		const toPart = keyframes.slice(keyframes.indexOf('to {'));
+		expect(fromPart).toContain(`mask-position: ${fromPosition}`);
+		expect(toPart).toContain(`mask-position: ${toPosition}`);
+	});
+});

--- a/packages/shared/src/render/slide-transition-wipe-keyframes.ts
+++ b/packages/shared/src/render/slide-transition-wipe-keyframes.ts
@@ -1,0 +1,116 @@
+/**
+ * Wipe mask keyframes for the slide-transition overlay.
+ *
+ * PowerPoint feathers the wipe edge with a WIDE, smooth gradient - the fade
+ * zone spans roughly a slide width in real renders, not a narrow band. The
+ * incoming layer is masked with a 3x-oversized gradient (fade zone = one slide
+ * width) whose position sweeps it across the slide; the band fully exits both
+ * edges, so the start is fully hidden and the end fully opaque. The old
+ * clip-path inset reveal had a hard edge no feather could be applied to.
+ *
+ * Extracted from `slide-transition-keyframes` to keep that module at its
+ * original size; `SLIDE_TRANSITION_KEYFRAMES` concatenates this block.
+ *
+ * @module render/slide-transition-wipe-keyframes
+ */
+
+/**
+ * The four directional wipe reveals (`pptx-tr-wipe-from-*`), as a stylesheet
+ * fragment.
+ */
+export const WIPE_MASK_KEYFRAMES = `
+/* ── Wipe (soft mask reveal) ──────────────────────────────────────────── */
+/* PowerPoint feathers the wipe edge with a WIDE, smooth gradient - the fade
+ * zone spans roughly a slide width in real renders, not a narrow band. The
+ * incoming layer is masked with a 3x-oversized gradient (fade zone = one slide
+ * width) whose position sweeps it across the slide; the band fully exits both
+ * edges, so the start is fully hidden and the end fully opaque. */
+@keyframes pptx-tr-wipe-from-left {
+	from {
+		-webkit-mask-image: linear-gradient(to right, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 300% 100%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 100% 0;
+		mask-image: linear-gradient(to right, #000 33.3%, transparent 66.7%);
+		mask-size: 300% 100%;
+		mask-repeat: no-repeat;
+		mask-position: 100% 0;
+	}
+	to {
+		-webkit-mask-image: linear-gradient(to right, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 300% 100%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 0% 0;
+		mask-image: linear-gradient(to right, #000 33.3%, transparent 66.7%);
+		mask-size: 300% 100%;
+		mask-repeat: no-repeat;
+		mask-position: 0% 0;
+	}
+}
+@keyframes pptx-tr-wipe-from-right {
+	from {
+		-webkit-mask-image: linear-gradient(to left, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 300% 100%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 0% 0;
+		mask-image: linear-gradient(to left, #000 33.3%, transparent 66.7%);
+		mask-size: 300% 100%;
+		mask-repeat: no-repeat;
+		mask-position: 0% 0;
+	}
+	to {
+		-webkit-mask-image: linear-gradient(to left, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 300% 100%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 100% 0;
+		mask-image: linear-gradient(to left, #000 33.3%, transparent 66.7%);
+		mask-size: 300% 100%;
+		mask-repeat: no-repeat;
+		mask-position: 100% 0;
+	}
+}
+@keyframes pptx-tr-wipe-from-top {
+	from {
+		-webkit-mask-image: linear-gradient(to bottom, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 100% 300%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 0 100%;
+		mask-image: linear-gradient(to bottom, #000 33.3%, transparent 66.7%);
+		mask-size: 100% 300%;
+		mask-repeat: no-repeat;
+		mask-position: 0 100%;
+	}
+	to {
+		-webkit-mask-image: linear-gradient(to bottom, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 100% 300%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 0 0%;
+		mask-image: linear-gradient(to bottom, #000 33.3%, transparent 66.7%);
+		mask-size: 100% 300%;
+		mask-repeat: no-repeat;
+		mask-position: 0 0%;
+	}
+}
+@keyframes pptx-tr-wipe-from-bottom {
+	from {
+		-webkit-mask-image: linear-gradient(to top, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 100% 300%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 0 0%;
+		mask-image: linear-gradient(to top, #000 33.3%, transparent 66.7%);
+		mask-size: 100% 300%;
+		mask-repeat: no-repeat;
+		mask-position: 0 0%;
+	}
+	to {
+		-webkit-mask-image: linear-gradient(to top, #000 33.3%, transparent 66.7%);
+		-webkit-mask-size: 100% 300%;
+		-webkit-mask-repeat: no-repeat;
+		-webkit-mask-position: 0 100%;
+		mask-image: linear-gradient(to top, #000 33.3%, transparent 66.7%);
+		mask-size: 100% 300%;
+		mask-repeat: no-repeat;
+		mask-position: 0 100%;
+	}
+}
+`;


### PR DESCRIPTION
## What does this change?

Three fixes to how classic (non-morph) slide transitions render, each verified against desktop PowerPoint:

- **Wipe direction**: `p:wipe/@dir` is the direction of TRAVEL, not the starting edge. The UI offers "From Left / From Right / ..." and stores the OPPOSITE token (UI "From Left" is written as `dir="r"`), and desktop PowerPoint reveals such a slide from the LEFT edge sweeping right. The token -> keyframe mapping is therefore inverted for the wipe alone - every other transition's token names the motion and stays as it was.
- **Wipe edge**: PowerPoint feathers the wipe with a WIDE, smooth gradient (the fade zone spans roughly a slide width in real renders, not a narrow band). The incoming layer is now masked with a 3x-oversized gradient whose position sweeps it across the slide; the band fully exits both edges, so the start is fully hidden and the end fully opaque. The old `clip-path: inset(...)` reveal had a hard edge no feather could be applied to. The four directional keyframe blocks moved to the new `slide-transition-wipe-keyframes.ts` module, with a geometry regression test pinning every direction's hidden-start/opaque-end.
- **The arriving half plays in react and angular**: for classic transitions the presentation overlay rendered ONLY the outgoing slide, relying on the live stage beneath for the arriving one - a wipe (whose outgoing half is `none`) sat opaque for the whole duration and the arriving slide popped in the instant the overlay tore down. The arriving slide now renders as its own layer carrying the incoming animation, stacked per `outgoingOnTop`; the uncover family (whose incoming half is `none`) keeps revealing the live stage, and morphs keep painting their own halves.
- **Angular**: the overlay's local duration resolver ignored the legacy `spd` token entirely, so spd-authored transitions played at hard-coded defaults while every other binding honoured the authored speed (COM-measured: fast 0.5s, med 0.75s, slow 1.0s). Morph durations now delegate to the shared resolver; classic transitions keep Angular's own floor/default policy (a documented divergence).

## Type of change

- [x] Bug fix (non-breaking)

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

The wipe mapping/feather live in shared, so every binding inherits them. The missing arriving half was react- and angular-specific (vue/svelte/vanilla already rendered both layers); the spd-ignoring duration resolver was angular-specific.

| Binding                      | Affected? | Fixed / implemented here? | Notes                                                                 |
| ---------------------------- | --------- | ------------------------- | --------------------------------------------------------------------- |
| React (`packages/react`)     | yes       | yes                       | shared wipe fix + arriving-half layer added (was missing entirely)    |
| Vue (`packages/vue`)         | yes       | yes (shared)              | already rendered both layers; inherits corrected mapping + feather    |
| Angular (`packages/angular`) | yes       | yes                       | shared wipe fix + arriving-half layer + duration resolver delegates to shared |
| Svelte (`packages/svelte`)   | yes       | yes (shared)              | already rendered both layers; inherits corrected mapping + feather    |
| Vanilla (`packages/vanilla`) | yes       | yes (shared)              | already rendered both layers; inherits corrected mapping + feather    |

All five were actually checked: manual browser verification of the wipe (forward direction and the feathered edge) across the react, angular and svelte demos, and per-binding unit tests for the mapping and the arriving-half layer.

### UI fix

- [x] I reproduced the bug (or confirmed its absence) in every binding above
- [x] Every affected binding is fixed in this PR

---

## Testing

- [x] Unit tests added or updated: the shared mapping test now covers every wipe token's opposite edge, and the new wipe mask-geometry test pins each direction's hidden-start/opaque-end (the from-top keyframes shipped an inversion once).
- [x] Regression test added that fails without this change.
- [x] No new e2e spec: no existing e2e spec asserts the slide-transition wipe (the `wipe` hits in `animation-entry-state.spec.ts` are element entrance builds, a different feature). Coverage is the unit tests above plus manual verification of the wipe forward across the react, angular and svelte demos. The morph/issue specs (`issue-131-fidelity`, `issue-144-morph`, `issue-160-morph-crossfade`, `morph-shape-swap`) were run locally across all five projects on this branch to confirm no transition regression.
- [x] Per-binding suites green for every touched binding (shared 7288, react 6708, angular 3260).

## Checks run locally

- [x] `bun run lint`
- [x] `bun run fmt:check`
- [x] `bun run typecheck`
- [x] `bun run test`

## Conventional Commits

- [x] Commit messages follow Conventional Commits (`fix(shared)`, `fix(react)`, `fix(angular)`).
