### PR TITLE
fix(react): mark building-block edits dirty

### DIFF
--- a/packages/react/src/viewer/hooks/useViewerBuildingBlocks.test.ts
+++ b/packages/react/src/viewer/hooks/useViewerBuildingBlocks.test.ts
@@ -12,30 +12,61 @@ import { PptxHandler } from 'pptx-viewer-core';
  * follows the same manual `createRoot` + `act` harness pattern used by
  * `CollaborationProvider.remount.test.tsx`.
  */
-import React, { act } from 'react';
+import React, { act, createRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { PowerPointViewerHandle } from '../types';
+import type { UseAutosaveInput } from './useAutosave';
 import { useViewerBuildingBlocks } from './useViewerBuildingBlocks';
 import type { ViewerBuildingBlocksResult } from './useViewerBuildingBlocks';
 
 let fixtureBytes: Uint8Array;
+let twoSlideFixtureBytes: Uint8Array;
+
+const { autosaveInputs } = vi.hoisted(() => ({ autosaveInputs: [] as UseAutosaveInput[] }));
+
+// Expose the dirty gate that the real building-block composition hands to
+// autosave; every other hook in the chain remains production code.
+// oxlint-disable-next-line prefer-ending-with-an-expect
+vi.mock(import('./useAutosave'), () => ({
+	useAutosave: (input: UseAutosaveInput) => {
+		autosaveInputs.push(input);
+		return { autosaveStatus: { state: 'idle' as const }, triggerAutosave: async () => {} };
+	},
+}));
 
 beforeAll(async () => {
-	const { handler, data } = await PptxHandler.create({
+	const oneSlide = await PptxHandler.create({
 		title: 'Building Blocks Fixture',
 		initialSlideCount: 1,
 	});
-	fixtureBytes = await handler.save(data.slides);
+	fixtureBytes = await oneSlide.handler.save(oneSlide.data.slides);
+	oneSlide.handler.dispose();
+
+	const twoSlides = await PptxHandler.create({
+		title: 'Two Slide Building Blocks Fixture',
+		initialSlideCount: 2,
+	});
+	twoSlideFixtureBytes = await twoSlides.handler.save(twoSlides.data.slides);
+	twoSlides.handler.dispose();
 });
 
 let container: HTMLDivElement;
 let root: Root;
 let latest: ViewerBuildingBlocksResult | null = null;
 
-function Harness({ content }: { content: Uint8Array }): React.ReactElement {
-	const result = useViewerBuildingBlocks({ content, canEdit: true });
+function Harness({
+	content,
+	handle,
+	onDirtyChange,
+}: {
+	content: Uint8Array;
+	handle?: React.RefObject<PowerPointViewerHandle | null>;
+	onDirtyChange?: (dirty: boolean) => void;
+}): React.ReactElement {
+	const result = useViewerBuildingBlocks({ content, canEdit: true, handle, onDirtyChange });
 	latest = result;
 	return React.createElement('div', { 'data-testid': 'harness' });
 }
@@ -65,10 +96,19 @@ async function flushUntil(isDone: () => boolean, timeoutMs = 10_000): Promise<vo
 
 beforeEach(() => {
 	latest = null;
+	autosaveInputs.length = 0;
 	container = document.createElement('div');
 	document.body.appendChild(container);
 	root = createRoot(container);
 });
+
+function latestAutosaveDirty(): boolean {
+	const input = autosaveInputs.at(-1);
+	if (!input) {
+		throw new Error('the composition never called useAutosave');
+	}
+	return input.isDirty;
+}
 
 afterEach(() => {
 	act(() => {
@@ -128,5 +168,60 @@ describe('useViewerBuildingBlocks', () => {
 
 		await flushUntil(() => latest?.loading === false);
 		expect(latest?.loading).toBeFalsy();
+	}, 15_000);
+
+	it('reports a committed edit to the host and opens the autosave dirty gate', async () => {
+		const handle = createRef<PowerPointViewerHandle>();
+		const dirtyChanges: boolean[] = [];
+		await act(async () => {
+			root.render(
+				React.createElement(Harness, {
+					content: fixtureBytes,
+					handle,
+					onDirtyChange: (dirty: boolean) => dirtyChanges.push(dirty),
+				}),
+			);
+		});
+		await flushUntil(() => latest?.loading === false);
+
+		expect(handle.current?.isDirty()).toBeFalsy();
+		expect(latestAutosaveDirty()).toBeFalsy();
+		expect(dirtyChanges).not.toContain(true);
+
+		await act(async () => {
+			handle.current?.addSlide();
+			await Promise.resolve();
+		});
+		await flushUntil(() => handle.current?.isDirty() === true);
+
+		expect(handle.current?.getSlideCount()).toBe(2);
+		expect(handle.current?.isDirty()).toBeTruthy();
+		expect(latestAutosaveDirty()).toBeTruthy();
+		expect(dirtyChanges).toContain(true);
+	}, 15_000);
+
+	it('does not report slide navigation as a document edit', async () => {
+		const handle = createRef<PowerPointViewerHandle>();
+		const dirtyChanges: boolean[] = [];
+		await act(async () => {
+			root.render(
+				React.createElement(Harness, {
+					content: twoSlideFixtureBytes,
+					handle,
+					onDirtyChange: (dirty: boolean) => dirtyChanges.push(dirty),
+				}),
+			);
+		});
+		await flushUntil(() => latest?.loading === false);
+
+		await act(async () => {
+			handle.current?.goTo(1);
+			await Promise.resolve();
+		});
+		await flushUntil(() => handle.current?.getActiveSlideIndex() === 1);
+
+		expect(handle.current?.isDirty()).toBeFalsy();
+		expect(latestAutosaveDirty()).toBeFalsy();
+		expect(dirtyChanges).not.toContain(true);
 	}, 15_000);
 });

--- a/packages/react/src/viewer/hooks/useViewerBuildingBlocksCore.ts
+++ b/packages/react/src/viewer/hooks/useViewerBuildingBlocksCore.ts
@@ -111,6 +111,10 @@ export function useViewerBuildingBlocksCore(
 	// declared just before `usePresentationSetup`) so both consumers share
 	// this one `useViewerOptions()` call/store instance.
 	const { options: viewerOptions } = useViewerOptions();
+	const { setIsDirty } = state;
+	const markDocumentDirty = useCallback(() => {
+		setIsDirty(true);
+	}, [setIsDirty]);
 
 	const history = useEditorHistory({
 		slides,
@@ -126,6 +130,7 @@ export function useViewerBuildingBlocksCore(
 		maxHistoryEntries: resolveHistoryDepth(viewerOptions),
 		hasActivePointerInteraction,
 		pointerCommitNonce: state.pointerCommitNonce,
+		onDirty: markDocumentDirty,
 		setSlides: state.setSlides,
 		setCanvasSize: state.setCanvasSize,
 		setActiveSlideIndex: state.setActiveSlideIndex,


### PR DESCRIPTION
## What does this change?

Connects the React building-block composition to the same history dirty callback already used by `PowerPointViewer`. Without this wiring, committed edits made through `useViewerBuildingBlocks` leave `state.isDirty` false, so the host receives no `onDirtyChange(true)` notification and autosave remains behind its clean-document gate.

The regression test mounts the real hook with a generated PPTX. It verifies that the document starts clean, adding a slide marks it dirty through the public handle, the host callback fires, autosave receives the dirty state, and slide navigation alone remains clean.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

| Binding | Affected? | Fixed / implemented here? | Notes |
| --- | --- | --- | --- |
| React (`packages/react`) | yes | yes | The defect is in the React-only `useViewerBuildingBlocks` composition. |
| Vue (`packages/vue`) | no | n/a | Does not expose this React hook or composition. |
| Angular (`packages/angular`) | no | n/a | Does not expose this React hook or composition. |
| Svelte (`packages/svelte`) | no | n/a | Does not expose this React hook or composition. |
| Vanilla (`packages/vanilla`) | no | n/a | Does not expose this React hook or composition. |

### UI fix

- [ ] I reproduced the bug in every binding above. This is not applicable because the affected API is React-specific; the other bindings do not expose it.
- [x] Every affected binding is fixed in this PR.

## Testing

- [x] Unit tests added for the changed React composition.
- [x] Regression test added and confirmed to fail without the production change.
- [ ] Framework-neutral e2e spec added. This is React host-hook plumbing rather than a cross-binding UI feature; the real-hook integration test covers the public API boundary.
- [ ] `bun run e2e` passes locally. Not run for this non-visual React-only wiring change.

A manual browser pass through a real `useViewerBuildingBlocks` host verified: clean initial state, edit marks unsaved and enables Save/Undo, Save produces a PPTX and resets clean state, reopening preserves the edit, and a repeated edit supports Undo/Redo.

## Checks run locally

Bun was unavailable in this shell, so the equivalent package-scoped commands were run directly:

- [x] `npx oxlint --deny-warnings` on both changed files
- [x] `npx oxfmt --check` on both changed files
- [x] `npx tsc --noEmit --pretty` in `packages/react`
- [x] Full React Vitest suite: 394 files, 6,725 tests passed

## Conventional Commits

- [x] My commit follows Conventional Commits.

This is my first open-source contribution series, so guidance on scope or repository conventions is very welcome.
