### PR TITLE
fix(core,shared): preserve numbered text through edits

### DIFF
--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphs.test.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphs.test.ts
@@ -37,6 +37,18 @@ function runProperties(paragraph: XmlObject): XmlObject[] {
 		.filter((rPr): rPr is XmlObject => Boolean(rPr) && typeof rPr === 'object');
 }
 
+/** Literal text from every ordinary run in one built paragraph. */
+function runTexts(paragraph: XmlObject): string[] {
+	const runs = paragraph['a:r'];
+	const list = Array.isArray(runs) ? runs : runs ? [runs] : [];
+	return list.map((run) => {
+		const text = (run as XmlObject)['a:t'];
+		return typeof text === 'string'
+			? text
+			: String((text as XmlObject | undefined)?.['#text'] ?? '');
+	});
+}
+
 describe('createParagraphsFromTextContent: paragraph direction is not flattened onto runs', () => {
 	const runtime = new ParagraphRuntime();
 	const segment = (text: string, style?: TextStyle): TextSegment =>
@@ -167,4 +179,67 @@ describe('createParagraphsFromTextContent: a runless paragraph stays runless', (
 		const [paragraph] = runtime.build('', undefined, [segment('')]);
 		expect(paragraph['a:r']).toBeDefined();
 	});
+});
+
+describe('createParagraphsFromTextContent: auto-number marker detection', () => {
+	const runtime = new ParagraphRuntime();
+
+	it('keeps real paragraph text that carries runtime numbering metadata', () => {
+		const content: TextSegment = {
+			text: 'First item',
+			style: {},
+			bulletInfo: {
+				autoNumType: 'arabicPeriod',
+				autoNumStartAt: 1,
+				paragraphIndex: 0,
+			},
+		};
+
+		const [paragraph] = runtime.build(content.text, undefined, [content]);
+
+		expect(runTexts(paragraph)).toStrictEqual(['First item']);
+		expect((paragraph['a:pPr'] as XmlObject)['a:buAutoNum']).toStrictEqual({
+			'@_type': 'arabicPeriod',
+		});
+	});
+
+	it.each([
+		['1.', { autoNumType: 'arabicPeriod' }],
+		['• ', { autoNumType: 'arabicPeriod' }],
+		[
+			'3)',
+			{
+				autoNumType: 'arabicPeriod',
+				autoNumStartAt: 2,
+				paragraphIndex: 1,
+			},
+		],
+	] as const)('keeps marker-like content %s that was not generated', (text, bulletInfo) => {
+		const content: TextSegment = { text, style: {}, bulletInfo };
+
+		const [paragraph] = runtime.build(content.text, undefined, [content]);
+
+		expect(runTexts(paragraph)).toStrictEqual([text]);
+	});
+
+	it.each([
+		['arabicPeriod', 2, 1, '3.'],
+		['arabicPeriod', 2, 1, '3. '],
+		['hindiNumPeriod', 21, 0, '२१. '],
+	] as const)(
+		'drops only the exact generated %s marker and preserves its content run',
+		(autoNumType, autoNumStartAt, paragraphIndex, markerText) => {
+			const bulletInfo = { autoNumType, autoNumStartAt, paragraphIndex };
+			const [paragraph] = runtime.build(`${markerText}Item`, undefined, [
+				{ text: markerText, style: {}, bulletInfo },
+				{ text: 'Item', style: {} },
+			]);
+
+			expect(runTexts(paragraph)).toStrictEqual(['Item']);
+			expect((paragraph['a:pPr'] as XmlObject)['a:buAutoNum']).toStrictEqual({
+				'@_type': autoNumType,
+				'@_startAt': String(autoNumStartAt),
+			});
+		},
+	);
 });

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphs.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphs.ts
@@ -1,5 +1,6 @@
 import { XmlObject, TextStyle, TextSegment } from '../../types';
 import type { BulletInfo } from '../../types';
+import { formatAutoNumberMarker } from '../../utils/auto-number-format';
 import {
 	buildParagraphPropertiesXml,
 	assembleParagraphXml,
@@ -15,14 +16,20 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 		if (!bullet) {
 			return false;
 		}
+		if (bullet.autoNumType) {
+			if (bullet.paragraphIndex === undefined) {
+				return false;
+			}
+			const ordinal = Math.max(1, (bullet.autoNumStartAt ?? 1) + bullet.paragraphIndex);
+			const marker = formatAutoNumberMarker(bullet.autoNumType, ordinal);
+			return segment.text === marker || segment.text === `${marker} `;
+		}
 		const marker = bullet.char
 			? `${bullet.char} `
 			: bullet.imageRelId || bullet.imageDataUrl
 				? '\u{1F4CE} '
-				: bullet.autoNumType
-					? undefined
-					: '• ';
-		return marker ? segment.text === marker : bullet.paragraphIndex !== undefined;
+				: '• ';
+		return segment.text === marker;
 	}
 
 	protected createParagraphsFromTextContent(

--- a/packages/react/src/viewer/components/ElementRenderer.formattext.test.tsx
+++ b/packages/react/src/viewer/components/ElementRenderer.formattext.test.tsx
@@ -120,4 +120,63 @@ describe('elementRenderer - inline formatting shortcut wiring', () => {
 		// Must not throw; the shortcut simply does nothing.
 		pressShortcut(getInlineEditor(), 'b');
 	});
+
+	it.each([
+		{
+			name: 'content-carrying first run',
+			segments: [
+				{
+					text: 'Item',
+					style: {},
+					bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+				},
+			],
+			contentSegmentIndex: 0,
+		},
+		{
+			name: 'dedicated marker run',
+			segments: [
+				{
+					text: '1. ',
+					style: {},
+					bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+				},
+				{ text: 'Item', style: {} },
+			],
+			contentSegmentIndex: 1,
+		},
+	])(
+		'excludes the rendered number for a $name from committed text',
+		({ segments, contentSegmentIndex }) => {
+			const onInlineEditChange = vi.fn<(text: string) => void>();
+			mount(
+				makeProps({
+					element: {
+						...makeTextElement(),
+						text: 'Item',
+						textSegments: segments,
+					} as PptxElement,
+					onInlineEditChange,
+				}),
+			);
+
+			const editor = getInlineEditor();
+			const marker = editor.querySelector<HTMLElement>('[data-pptx-bullet-marker]');
+			const content = editor.querySelector<HTMLElement>(
+				`[data-seg-idx="${String(contentSegmentIndex)}"]`,
+			);
+			expect(marker?.textContent).toBe('1.');
+			expect(marker?.contentEditable).toBe('false');
+			expect(content).not.toBeNull();
+
+			act(() => {
+				if (content) {
+					content.textContent = 'Item edited';
+				}
+				editor.dispatchEvent(new Event('input', { bubbles: true }));
+			});
+
+			expect(onInlineEditChange).toHaveBeenLastCalledWith('Item edited');
+		},
+	);
 });

--- a/packages/react/src/viewer/components/elements/InlineTextEditor.tsx
+++ b/packages/react/src/viewer/components/elements/InlineTextEditor.tsx
@@ -1,6 +1,6 @@
 import type { PptxElement, TextStyle } from 'pptx-viewer-core';
 import { hasTextProperties } from 'pptx-viewer-core';
-import { placeCaretAtEnd } from 'pptx-viewer-shared';
+import { placeCaretAtEnd, readEditableText } from 'pptx-viewer-shared';
 import React, { useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 
 import { DEFAULT_TEXT_COLOR } from '../../constants';
@@ -75,13 +75,14 @@ export function InlineTextEditor({
 	}
 	const seed = seedRef.current;
 
-	// Extract plain text from the contentEditable div
+	// Extract authored text from the contentEditable div. Rendered list markers
+	// are annotated presentation chrome and are intentionally excluded.
 	const extractText = useCallback((): string => {
 		const el = editorRef.current;
 		if (!el) {
 			return seed.initialText;
 		}
-		return el.innerText || '';
+		return readEditableText(el);
 	}, [seed]);
 
 	// Sync text to parent on every input via ref (no re-render)

--- a/packages/react/src/viewer/utils/text-paragraph-render.tsx
+++ b/packages/react/src/viewer/utils/text-paragraph-render.tsx
@@ -222,6 +222,8 @@ function renderBulletMarker(
 		return (
 			<img
 				key={`${elementId}-para-${paraIndex}-bullet-img`}
+				data-pptx-bullet-marker
+				contentEditable={false}
 				src={picture.src}
 				alt={picture.accessibleLabel}
 				style={{
@@ -242,6 +244,8 @@ function renderBulletMarker(
 		<span
 			key={`${elementId}-para-${paraIndex}-bullet`}
 			className='pptx-bullet'
+			data-pptx-bullet-marker
+			contentEditable={false}
 			style={para.bulletStyle as React.CSSProperties}
 			aria-label={picture?.accessibleLabel}
 		>

--- a/packages/shared/src/render/inline-text-extract.test.ts
+++ b/packages/shared/src/render/inline-text-extract.test.ts
@@ -38,6 +38,26 @@ describe('readEditableText', () => {
 		);
 	});
 
+	it('excludes rendered bullet markers from editable text', () => {
+		expect(
+			readEditableText(
+				elementFromHtml(
+					'<div><span data-pptx-bullet-marker contenteditable="false">1.</span><span>Item</span></div>',
+				),
+			),
+		).toBe('Item');
+	});
+
+	it('keeps paragraph breaks when every paragraph starts with a rendered marker', () => {
+		expect(
+			readEditableText(
+				elementFromHtml(
+					'<div><span data-pptx-bullet-marker>1.</span><span>First</span></div><div><span data-pptx-bullet-marker>2.</span><span>Second</span></div>',
+				),
+			),
+		).toBe('First\nSecond');
+	});
+
 	it('does not prefix a newline for the very first block', () => {
 		expect(readEditableText(elementFromHtml('<div>only</div>'))).toBe('only');
 	});

--- a/packages/shared/src/render/inline-text-extract.ts
+++ b/packages/shared/src/render/inline-text-extract.ts
@@ -23,6 +23,13 @@ export function readEditableText(root: Node): string {
 			if (!(child instanceof HTMLElement)) {
 				continue;
 			}
+			// A list marker is presentation chrome, not authored paragraph text.
+			// React renders it inside the contenteditable so edit mode matches view
+			// mode; excluding the annotated node prevents a semantic bullet from
+			// being committed as literal text (for example, "1.Item").
+			if (child.hasAttribute('data-pptx-bullet-marker')) {
+				continue;
+			}
 			if (child.tagName === 'BR') {
 				out += '\n';
 				continue;

--- a/packages/shared/src/render/outline-view.test.ts
+++ b/packages/shared/src/render/outline-view.test.ts
@@ -134,6 +134,60 @@ describe('groupElementParagraphs', () => {
 		expect(paragraphGroupText(groups[0])).toBe('Item');
 	});
 
+	it('keeps real numbered content that carries paragraph metadata', () => {
+		const element = textElement('a', {
+			textSegments: [
+				{
+					text: 'Item',
+					style: {},
+					bulletInfo: {
+						autoNumType: 'arabicPeriod',
+						autoNumStartAt: 2,
+						paragraphIndex: 1,
+					},
+				},
+			],
+		});
+		const groups = groupElementParagraphs(element);
+		expect(groups[0].marker).toBeUndefined();
+		expect(paragraphGroupText(groups[0])).toBe('Item');
+	});
+
+	it.each(['3.', '3. '])('lifts the generated numbered marker %j out of the text', (marker) => {
+		const element = textElement('a', {
+			textSegments: [
+				{
+					text: marker,
+					style: {},
+					bulletInfo: {
+						autoNumType: 'arabicPeriod',
+						autoNumStartAt: 2,
+						paragraphIndex: 1,
+					},
+				},
+				{ text: 'Item', style: {} },
+			],
+		});
+		const groups = groupElementParagraphs(element);
+		expect(groups[0].marker?.text).toBe(marker);
+		expect(paragraphGroupText(groups[0])).toBe('Item');
+	});
+
+	it('keeps marker-like numbered text without a runtime paragraph index', () => {
+		const element = textElement('a', {
+			textSegments: [
+				{
+					text: '1.',
+					style: {},
+					bulletInfo: { autoNumType: 'arabicPeriod' },
+				},
+			],
+		});
+		const groups = groupElementParagraphs(element);
+		expect(groups[0].marker).toBeUndefined();
+		expect(paragraphGroupText(groups[0])).toBe('1.');
+	});
+
 	it('renders a soft line break as a space, never as a paragraph split', () => {
 		const element = textElement('a', {
 			textSegments: [

--- a/packages/shared/src/render/outline-view.ts
+++ b/packages/shared/src/render/outline-view.ts
@@ -34,6 +34,8 @@
 import type { PptxElement, PptxSlide, TextSegment, TextStyle } from 'pptx-viewer-core';
 import { hasTextProperties } from 'pptx-viewer-core';
 
+import { isBulletMarkerSegment } from './bullet-toggle';
+
 // ---------------------------------------------------------------------------
 // DOM contract
 // ---------------------------------------------------------------------------
@@ -256,14 +258,15 @@ function isBulletMarker(segment: TextSegment): boolean {
 	if (!bullet) {
 		return false;
 	}
+	if (bullet.autoNumType) {
+		return bullet.paragraphIndex !== undefined && isBulletMarkerSegment(segment);
+	}
 	const marker = bullet.char
 		? `${bullet.char} `
 		: bullet.imageRelId || bullet.imageDataUrl
 			? '\u{1F4CE} '
-			: bullet.autoNumType
-				? undefined
-				: '• ';
-	return marker ? segment.text === marker : bullet.paragraphIndex !== undefined;
+			: '• ';
+	return segment.text === marker;
 }
 
 function isParagraphSeparator(segment: TextSegment): boolean {

--- a/packages/shared/src/render/remap-text.test.ts
+++ b/packages/shared/src/render/remap-text.test.ts
@@ -116,6 +116,84 @@ describe('remapTextToSegments', () => {
 			const result = remapTextToSegments('New item', original, {});
 			expect(result[0].bulletInfo).toStrictEqual(bulletInfo);
 		});
+
+		it.each(['1.Item edited', '1. Item edited'])(
+			'removes the rendered number from edited text %j without consuming content',
+			(newText) => {
+				const bulletInfo = {
+					autoNumType: 'arabicPeriod',
+					autoNumStartAt: 1,
+					paragraphIndex: 0,
+				};
+				const original: TextSegment[] = [{ text: '1. ', style: {}, bulletInfo }, seg('Item')];
+				const result = remapTextToSegments(newText, original, {});
+
+				expect(result.map((segment) => segment.text)).toStrictEqual(['1. ', 'Item edited']);
+				expect(result[0].bulletInfo).toStrictEqual(bulletInfo);
+			},
+		);
+
+		it('removes a rendered character bullet without consuming content', () => {
+			const bulletInfo = { char: '•' };
+			const original: TextSegment[] = [{ text: '• ', style: {}, bulletInfo }, seg('Item')];
+			const result = remapTextToSegments('•Item edited', original, {});
+
+			expect(result.map((segment) => segment.text)).toStrictEqual(['• ', 'Item edited']);
+			expect(result[0].bulletInfo).toStrictEqual(bulletInfo);
+		});
+
+		it.each(['1. Item edited', '1.  Item edited'])(
+			'preserves an authored leading space in edited text %j',
+			(newText) => {
+				const bulletInfo = { autoNumType: 'arabicPeriod', paragraphIndex: 0 };
+				const original: TextSegment[] = [{ text: '1. ', style: {}, bulletInfo }, seg(' Item')];
+				const result = remapTextToSegments(newText, original, {});
+
+				expect(result.map((segment) => segment.text)).toStrictEqual(['1. ', ' Item edited']);
+			},
+		);
+
+		it('keeps paragraph metadata on the marker and content styles on their runs', () => {
+			const paragraphProperties = { paragraphSpacingBefore: 8 };
+			const endParaRunProperties = { '@_sz': '1800' };
+			const original: TextSegment[] = [
+				{
+					text: '1. ',
+					style: { color: '#FF0000' },
+					bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+					paragraphLevel: 2,
+					paragraphProperties,
+					endParaRunProperties,
+				},
+				seg('Bold', { bold: true }),
+				seg(' plain', { italic: true }),
+			];
+			const result = remapTextToSegments('1.Bold plus plain', original, {});
+
+			expect(result.map((segment) => segment.text)).toStrictEqual(['1. ', 'Bold', ' plus plain']);
+			expect(result[0].paragraphLevel).toBe(2);
+			expect(result[0].paragraphProperties).toBe(paragraphProperties);
+			expect(result[0].endParaRunProperties).toBe(endParaRunProperties);
+			expect(result[1].style.bold).toBeTruthy();
+			expect(result[2].style.italic).toBeTruthy();
+		});
+
+		it('keeps marker-like content when an auto-number has no runtime paragraph index', () => {
+			const bulletInfo = { autoNumType: 'arabicPeriod' };
+			const original: TextSegment[] = [{ text: '1.', style: {}, bulletInfo }];
+			const result = remapTextToSegments('1.Item', original, {});
+
+			expect(result.map((segment) => segment.text)).toStrictEqual(['1.Item']);
+			expect(result[0].bulletInfo).toStrictEqual(bulletInfo);
+		});
+
+		it('keeps marker-like text typed into a marker-only empty paragraph', () => {
+			const bulletInfo = { autoNumType: 'arabicPeriod', paragraphIndex: 0 };
+			const original: TextSegment[] = [{ text: '1.', style: {}, bulletInfo }];
+			const result = remapTextToSegments('1.Item', original, {});
+
+			expect(result.map((segment) => segment.text)).toStrictEqual(['1.', '1.Item']);
+		});
 	});
 
 	describe('segment metadata preservation', () => {

--- a/packages/shared/src/render/remap-text.ts
+++ b/packages/shared/src/render/remap-text.ts
@@ -5,6 +5,46 @@
  */
 import type { TextSegment, TextStyle } from 'pptx-viewer-core';
 
+import { resolveParagraphBullet } from './bullet-list';
+import { isBulletMarkerSegment } from './bullet-toggle';
+
+/**
+ * Remove marker text from editor surfaces that seed it as ordinary text.
+ * Depending on the binding, the gap can be CSS (`"1.Item"`) or the parsed
+ * marker's trailing space (`"1. Item"`). React instead annotates its rendered
+ * marker so `readEditableText` can exclude it at the DOM boundary.
+ */
+function withoutRenderedBulletPrefix(
+	text: string,
+	originalSegments: readonly TextSegment[],
+	dedicatedMarker: TextSegment | undefined,
+): string {
+	if (!dedicatedMarker) {
+		return text;
+	}
+	const resolved = resolveParagraphBullet(dedicatedMarker);
+	if (!resolved || !text.startsWith(resolved.marker)) {
+		return text;
+	}
+
+	const withoutMarker = text.slice(resolved.marker.length);
+	const originalContent = originalSegments
+		.slice(1)
+		.map((segment) => segment.text)
+		.join('');
+	// Empty list paragraphs do not render a marker, so marker-like text typed
+	// into them is authored content and must not be stripped.
+	if (originalContent.trim().length === 0) {
+		return text;
+	}
+	const originalLeadingSpaces = originalContent.length - originalContent.trimStart().length;
+	const editedLeadingSpaces = withoutMarker.length - withoutMarker.trimStart().length;
+	if (editedLeadingSpaces > originalLeadingSpaces) {
+		return withoutMarker.slice(1);
+	}
+	return withoutMarker;
+}
+
 /**
  * Whether an original segment is ATOMIC: its rendered text is not what is
  * literally stored (a field re-substitutes its live value at render, from
@@ -96,6 +136,27 @@ export function remapTextToSegments(
 			return paraNewText.length > 0
 				? [{ text: paraNewText, style: { ...baseFallbackStyle } }]
 				: [{ text: '', style: { ...baseFallbackStyle } }];
+		}
+
+		const firstSegment = paraOrigSegments[0];
+		const dedicatedMarker =
+			isBulletMarkerSegment(firstSegment) &&
+			(!firstSegment.bulletInfo?.autoNumType ||
+				firstSegment.bulletInfo.paragraphIndex !== undefined)
+				? firstSegment
+				: undefined;
+		if (dedicatedMarker) {
+			const contentSegments = paraOrigSegments.slice(1);
+			const contentText = withoutRenderedBulletPrefix(
+				paraNewText,
+				paraOrigSegments,
+				dedicatedMarker,
+			);
+			const content =
+				contentSegments.length > 0
+					? remapParagraph(contentText, contentSegments)
+					: [{ text: contentText, style: { ...dedicatedMarker.style } }];
+			return [dedicatedMarker, ...content];
 		}
 
 		const paragraphBulletInfo = paraOrigSegments[0].bulletInfo;


### PR DESCRIPTION
## What does this change?

Preserves authored text when an existing auto-numbered paragraph is edited, viewed in Outline, saved, downloaded, and reopened.

On current `main`, the rendered number can leak into the contenteditable text and the display-only marker can participate in rich-text remapping. In the Japanese numbered fixture, appending text then opening Outline removes the first character from every row (`Lorem` becomes `orem`). A broad marker predicate in Outline and the core writer can also hide or omit a real content run merely because it carries `bulletInfo`.

This change keeps those responsibilities explicit:

- rendered glyph and picture markers are non-editable DOM chrome and are excluded from React committed text;
- shared remapping preserves a parsed dedicated marker, including paragraph spacing/indent metadata, and remaps only authored content runs;
- Outline and the core writer discard a numbered segment only when its text exactly matches the existing auto-number formatter; content-carrying, missing-index, and near-match segments remain content.

The implementation reuses the existing `resolveParagraphBullet`, `isBulletMarkerSegment`, and `formatAutoNumberMarker` helpers rather than adding a second numbering implementation. Tests were added to existing test files.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

| Binding | Affected? | Fixed / implemented here? | Notes |
| --- | --- | --- | --- |
| React (`packages/react`) | yes | yes | Semantic markers are excluded at the DOM boundary; full browser flow verified. |
| Vue (`packages/vue`) | yes | yes | Uses the shared remapper and core writer. |
| Angular (`packages/angular`) | yes | yes | Uses the shared remapper and core writer. |
| Svelte (`packages/svelte`) | yes | yes | Uses the shared remapper and core writer. |
| Vanilla (`packages/vanilla`) | yes | yes | Uses the shared remapper and core writer. |

### UI fix

- [ ] I reproduced the complete browser flow in every binding above. The React flow was reproduced end to end; the shared boundaries are covered directly for all bindings.
- [x] Every affected binding uses the fixed shared remap and core save paths.

## Testing

- [x] Regression tests added to existing core, shared, and React test files.
- [x] `oxfmt --check`, `oxlint`, and root TypeScript checks pass.
- [x] Full shared suite: 479 files passed, 2 skipped; 7,349 tests passed, 3 skipped.
- [x] Full React suite plus the focused core writer test: 394 files and 6,742 tests passed.
- [x] Shared package build passes.

Manual browser verification used the repository Japanese fixture with four `arabicPeriod` paragraphs: two inline edits, an Outline edit, Save, download, and fresh reopen all retained the complete text with no duplicated numbers. Saved `slide5.xml` kept all four `a:buAutoNum` properties and only authored content in `a:t`; `marL`, hanging indent, bullet size, `spcBef`, and `spcAft` matched the original.

This PR is intentionally scoped to editing existing listed paragraphs. Inheriting and incrementing numbering after Enter is a separate behavior and is not claimed here.

## Conventional Commits

- [x] Commit message follows Conventional Commits (`fix(core,shared)`).