### PR TITLE
fix: use point units in font-size controls

### DIFF
--- a/packages/angular/src/viewer/inspector-helpers.test.ts
+++ b/packages/angular/src/viewer/inspector-helpers.test.ts
@@ -120,7 +120,7 @@ describe('fontSizeOf', () => {
 
 	it('returns authored fontSize when present', () => {
 		const el = makeText({ textStyle: { fontSize: 24 } } as Partial<PptxElement>);
-		expect(fontSizeOf(el)).toBe(24);
+		expect(fontSizeOf(el)).toBe(18);
 	});
 
 	it('returns 18 for elements without text properties', () => {

--- a/packages/angular/src/viewer/inspector-helpers.ts
+++ b/packages/angular/src/viewer/inspector-helpers.ts
@@ -17,5 +17,6 @@ export {
 	isItalic,
 	isUnderline,
 	shapeStylePatch,
+	textFontSizePatch,
 	textStylePatch,
 } from '../internal/shared';

--- a/packages/angular/src/viewer/inspector-panel.component.ts
+++ b/packages/angular/src/viewer/inspector-panel.component.ts
@@ -35,6 +35,7 @@ import {
 	isElementLocked,
 	rebuildDrawingShapesIfCleared,
 	resolvePalette,
+	textFontSizePtToPx,
 } from '../internal/shared';
 import { ActionSettingsPanelComponent } from './action-settings-panel.component';
 import { AnimationAuthorPanelComponent } from './animation-author-panel.component';
@@ -55,6 +56,7 @@ import {
 	shapeStylePatch,
 	strokeColorOf,
 	textColorOf,
+	textFontSizePatch,
 	textStylePatch,
 } from './inspector-helpers';
 import { IsMobileService } from './is-mobile';
@@ -281,8 +283,9 @@ import { TextWarpGalleryComponent } from './text-warp-gallery.component';
 								id="insp-font-size"
 								class="pptx-ng-inspector__input pptx-ng-inspector__input--number"
 								type="number"
-								inputmode="numeric"
+								inputmode="decimal"
 								min="1"
+								step="any"
 								[value]="seed().fontSize"
 								(change)="onFontSizeChange($event)"
 							/>
@@ -1093,7 +1096,11 @@ export class InspectorPanelComponent {
 			return;
 		}
 		const cur = this.el();
-		this.editor.updateElement(this.slideIndex(), cur.id, textStylePatch(cur, { fontSize: val }));
+		this.editor.updateElement(
+			this.slideIndex(),
+			cur.id,
+			textFontSizePatch(cur, textFontSizePtToPx(val)),
+		);
 	}
 
 	protected onBoldToggle(): void {

--- a/packages/angular/src/viewer/ribbon-font-controls.component.test.ts
+++ b/packages/angular/src/viewer/ribbon-font-controls.component.test.ts
@@ -9,7 +9,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { COMMON_FONT_SIZES } from '../internal/shared';
-import { FONT_SIZES } from './ribbon-font-controls.component';
+import { componentSource } from './component-source.test-support';
+import { FONT_SIZES, steppedFontSizePt } from './ribbon-font-controls.component';
+
+const ribbonSource = componentSource(import.meta.dirname, 'ribbon-font-controls.component.ts');
+const inspectorSource = componentSource(import.meta.dirname, 'inspector-panel.component.ts');
 
 describe('ribbonFontControlsComponent FONT_SIZES', () => {
 	it('matches the shared font-size ladder exactly', () => {
@@ -22,5 +26,26 @@ describe('ribbonFontControlsComponent FONT_SIZES', () => {
 		expect(FONT_SIZES).toContain(72);
 		expect(FONT_SIZES).not.toContain(66);
 		expect(FONT_SIZES).not.toContain(80);
+	});
+});
+
+describe('ordinary text font size units', () => {
+	it('converts model pixels to points and point edits back to pixels in both controls', () => {
+		expect(ribbonSource).toContain('textFontSizePxToPt(fontSize)');
+		expect(ribbonSource).toContain(
+			'this.patchFontSize(textFontSizePtToPx(Number((event.target as HTMLSelectElement).value)))',
+		);
+		expect(ribbonSource).toContain('this.patchFontSize(textFontSizePtToPx(steppedFontSizePt(');
+		expect(ribbonSource).toContain('textFontSizePatch(element, fontSize)');
+		expect(inspectorSource).toContain('fontSize: fontSizeOf(cur)');
+		expect(inspectorSource).toContain('textFontSizePatch(cur, textFontSizePtToPx(val))');
+	});
+
+	it('keeps authored fractional point sizes visible and editable', () => {
+		expect(ribbonSource).toContain('!fontSizes.includes(curFontSize())');
+		expect(inspectorSource).toContain('inputmode="decimal"');
+		expect(inspectorSource).toContain('step="any"');
+		expect(steppedFontSizePt(48.1, 1)).toBe(54);
+		expect(steppedFontSizePt(48.1, -1)).toBe(48);
 	});
 });

--- a/packages/angular/src/viewer/ribbon-font-controls.component.ts
+++ b/packages/angular/src/viewer/ribbon-font-controls.component.ts
@@ -16,7 +16,12 @@ import {
 import { TranslatePipe } from '@ngx-translate/core';
 import type { PptxElement } from 'pptx-viewer-core';
 
-import { COMMON_FONT_SIZES } from '../internal/shared';
+import {
+	COMMON_FONT_SIZES,
+	textFontSizePatch,
+	textFontSizePtToPx,
+	textFontSizePxToPt,
+} from '../internal/shared';
 import {
 	buildFontCatalog,
 	resolveDefaultFontFamily,
@@ -38,6 +43,15 @@ import {
  * so it cannot drift from the other bindings' Font control group.
  */
 export const FONT_SIZES = COMMON_FONT_SIZES;
+
+/** Next PowerPoint point-size preset in the requested direction. */
+export function steppedFontSizePt(current: number, direction: 1 | -1): number {
+	const next =
+		direction === 1
+			? FONT_SIZES.find((size) => size > current)
+			: [...FONT_SIZES].reverse().find((size) => size < current);
+	return next ?? (direction === 1 ? FONT_SIZES[FONT_SIZES.length - 1] : FONT_SIZES[0]) ?? current;
+}
 /** Font-colour swatches in the Home/Text colour popover (mirrors React/Vue). */
 const FONT_COLOR_PRESETS = [
 	'#000000',
@@ -129,6 +143,9 @@ const CHANGE_CASE_OPTIONS = [
 				[attr.aria-label]="'pptx.ribbon.fontSize' | translate"
 				(change)="setFontSize($event)"
 			>
+				@if (!fontSizes.includes(curFontSize())) {
+					<option [value]="curFontSize()" selected>{{ curFontSize() }}</option>
+				}
 				@for (s of fontSizes; track s) {
 					<option [value]="s" [selected]="s === curFontSize()">{{ s }}</option>
 				}
@@ -355,7 +372,8 @@ export class RibbonFontControlsComponent {
 	}
 	protected curFontSize(): number {
 		// Mirror React's HomeSection default (24) shown when nothing is selected.
-		return Math.round(this.curStyle()?.fontSize ?? 24);
+		const fontSize = this.curStyle()?.fontSize;
+		return fontSize === undefined ? 24 : textFontSizePxToPt(fontSize);
 	}
 	/** Current font colour of the selection (for the swatch + active-state ring). */
 	protected curColor(): string {
@@ -412,20 +430,18 @@ export class RibbonFontControlsComponent {
 		this.patch({ fontFamily: (event.target as HTMLSelectElement).value });
 	}
 	protected setFontSize(event: Event): void {
-		this.patch({ fontSize: Number((event.target as HTMLSelectElement).value) });
+		this.patchFontSize(textFontSizePtToPx(Number((event.target as HTMLSelectElement).value)));
 	}
 	/** Step the selection's font size up or down through the FONT_SIZES ladder. */
 	protected stepFontSize(direction: 1 | -1): void {
-		const current = this.curFontSize();
-		const sizes = FONT_SIZES;
-		let idx = sizes.findIndex((s) => s >= current);
-		if (idx < 0) {
-			idx = sizes.length - 1;
+		this.patchFontSize(textFontSizePtToPx(steppedFontSizePt(this.curFontSize(), direction)));
+	}
+	private patchFontSize(fontSize: number): void {
+		const element = this.selectedElement();
+		if (!element || !isTextElement(element)) {
+			return;
 		}
-		const next = sizes[Math.min(sizes.length - 1, Math.max(0, idx + direction))];
-		if (next !== undefined) {
-			this.patch({ fontSize: next });
-		}
+		this.editor.updateElement(this.slideIndex(), element.id, textFontSizePatch(element, fontSize));
 	}
 	/** Clear character formatting (bold/italic/underline/strikethrough) on the selection. */
 	protected clearFormatting(): void {

--- a/packages/react/src/viewer/components/elements/ConnectorElementRenderer.degenerate.test.tsx
+++ b/packages/react/src/viewer/components/elements/ConnectorElementRenderer.degenerate.test.tsx
@@ -88,4 +88,18 @@ describe('connector with a zero extent on one axis', () => {
 		expect(markup).toContain(`viewBox="0 0 400 ${MIN_ELEMENT_SIZE}"`);
 		expect(markup).toContain('d="M 0 0 L 400 0"');
 	});
+
+	it('renders connector label model font sizes as CSS pixels', () => {
+		const el = {
+			...verticalConnector(),
+			width: 200,
+			text: 'Label',
+			textStyle: { fontSize: 64 },
+			textSegments: [{ text: 'Label', style: { fontSize: 32 } }],
+		} as PptxElement;
+		const markup = render(el);
+		expect(markup).toContain('font-size:64px');
+		expect(markup).toContain('font-size:32px');
+		expect(markup).not.toContain('font-size:64pt');
+	});
 });

--- a/packages/react/src/viewer/components/elements/ConnectorTextOverlay.tsx
+++ b/packages/react/src/viewer/components/elements/ConnectorTextOverlay.tsx
@@ -41,7 +41,7 @@ export function ConnectorTextOverlay({
 				className='px-1'
 				style={{
 					fontFamily: connectorTextStyle?.fontFamily ?? 'inherit',
-					fontSize: connectorTextStyle?.fontSize ? `${connectorTextStyle.fontSize}pt` : '10pt',
+					fontSize: connectorTextStyle?.fontSize ? `${connectorTextStyle.fontSize}px` : '10px',
 					color: connectorTextStyle?.color ?? '#000000',
 					fontWeight: connectorTextStyle?.bold ? 'bold' : 'normal',
 					fontStyle: connectorTextStyle?.italic ? 'italic' : 'normal',
@@ -56,7 +56,7 @@ export function ConnectorTextOverlay({
 						key={idx}
 						style={{
 							fontFamily: seg.style?.fontFamily ?? connectorTextStyle?.fontFamily ?? 'inherit',
-							fontSize: seg.style?.fontSize ? `${seg.style.fontSize}pt` : undefined,
+							fontSize: seg.style?.fontSize ? `${seg.style.fontSize}px` : undefined,
 							color: seg.style?.color ?? connectorTextStyle?.color ?? '#000000',
 							fontWeight: seg.style?.bold ? 'bold' : connectorTextStyle?.bold ? 'bold' : 'normal',
 							fontStyle: seg.style?.italic

--- a/packages/react/src/viewer/components/inspector/ShapeTextPanels.test.tsx
+++ b/packages/react/src/viewer/components/inspector/ShapeTextPanels.test.tsx
@@ -1,10 +1,5 @@
 // @vitest-environment happy-dom
-/**
- * B6 (wave-4): recent colours. The inspector's TEXT colour picker (surface
- * A3) is a `DebouncedColorInput`, not `ColorPickerRow`, so it did not render
- * a "Recent colours" row at all until this wave; `RecentColorsRow` closes
- * that gap without duplicating the row's markup.
- */
+/** ShapeTextPanels interaction tests, including font size and recent colours. */
 import type { PptxElement } from 'pptx-viewer-core';
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -46,7 +41,45 @@ function textElement(): PptxElement {
 	} as PptxElement;
 }
 
-describe('shapeTextPanels text colour recent-colours row (wave-4 B6, A3)', () => {
+describe('shapeTextPanels', () => {
+	it('shows exact point sizes and converts edits back to model pixels', () => {
+		const onUpdateTextStyle = vi.fn();
+		const selectedElement = textElement();
+		selectedElement.textStyle = { color: '#000000', fontSize: 48.1 * (96 / 72) };
+
+		act(() => {
+			root.render(
+				<RecentColorsProvider value={{ recentColors: [], pushColor: () => {} }}>
+					<ShapeTextPanels
+						selectedElement={selectedElement}
+						canEdit
+						onUpdateElement={() => {}}
+						onUpdateElementStyle={() => {}}
+						onUpdateTextStyle={onUpdateTextStyle}
+					/>
+				</RecentColorsProvider>,
+			);
+		});
+
+		const input = container.querySelector(
+			'[data-pptx-text-card] input[type="number"]',
+		) as HTMLInputElement;
+		expect(input.value).toBe('48.1');
+		expect(input.step).toBe('any');
+		expect(onUpdateTextStyle).not.toHaveBeenCalled();
+
+		act(() => {
+			const nativeSetter = Object.getOwnPropertyDescriptor(
+				window.HTMLInputElement.prototype,
+				'value',
+			)!.set!;
+			nativeSetter.call(input, '10.5');
+			input.dispatchEvent(new Event('input', { bubbles: true }));
+		});
+		const patch = onUpdateTextStyle.mock.lastCall?.[0] as { fontSize?: number } | undefined;
+		expect(patch?.fontSize).toBeCloseTo(10.5 * (96 / 72));
+	});
+
 	it('renders the recent-colours row under the text colour picker', () => {
 		act(() => {
 			root.render(

--- a/packages/react/src/viewer/components/inspector/ShapeTextPanels.tsx
+++ b/packages/react/src/viewer/components/inspector/ShapeTextPanels.tsx
@@ -1,5 +1,6 @@
 import type { PptxElement, ShapeStyle, TextStyle } from 'pptx-viewer-core';
 import { hasShapeProperties, hasTextProperties } from 'pptx-viewer-core';
+import { textFontSizePtToPx, textFontSizePxToPt } from 'pptx-viewer-shared';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -97,8 +98,15 @@ export function ShapeTextPanels({
 								className={INPUT}
 								min={6}
 								max={200}
-								value={selectedElement.textStyle?.fontSize ?? 18}
-								onChange={(e) => onUpdateTextStyle({ fontSize: Number(e.target.value) })}
+								step='any'
+								value={
+									selectedElement.textStyle?.fontSize !== undefined
+										? textFontSizePxToPt(selectedElement.textStyle.fontSize)
+										: 18
+								}
+								onChange={(e) =>
+									onUpdateTextStyle({ fontSize: textFontSizePtToPx(Number(e.target.value)) })
+								}
 							/>
 						</label>
 						<label className='flex flex-col gap-1'>

--- a/packages/react/src/viewer/components/toolbar/HomeSection.tsx
+++ b/packages/react/src/viewer/components/toolbar/HomeSection.tsx
@@ -1,6 +1,11 @@
 import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, PptxLayoutOption, PptxLayoutPreview } from 'pptx-viewer-core';
-import { COMMON_FONT_SIZES, resolveDefaultFontFamily } from 'pptx-viewer-shared';
+import {
+	COMMON_FONT_SIZES,
+	resolveDefaultFontFamily,
+	textFontSizePtToPx,
+	textFontSizePxToPt,
+} from 'pptx-viewer-shared';
 import type { SlideTemplateId } from 'pptx-viewer-shared';
 import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -73,7 +78,10 @@ function extractFontInfo(
 
 	return {
 		fontFamily,
-		fontSize: fontSize !== undefined && fontSize !== null ? String(fontSize) : defaults.fontSize,
+		fontSize:
+			fontSize !== undefined && fontSize !== null
+				? String(textFontSizePxToPt(fontSize))
+				: defaults.fontSize,
 	};
 }
 
@@ -247,7 +255,12 @@ export function HomeSection(p: HomeSectionProps): React.ReactElement {
 											type='button'
 											className='flex items-center gap-2 w-full px-3 py-1.5 text-xs text-foreground hover:bg-muted transition-colors'
 											onClick={() => {
-												p.onUpdateTextStyle?.({ fontSize: s });
+												p.onUpdateTextStyle?.({
+													fontSize:
+														p.selectedElement && hasTextProperties(p.selectedElement)
+															? textFontSizePtToPx(s)
+															: s,
+												});
 												setSizeMenuOpen(false);
 											}}
 										>

--- a/packages/react/src/viewer/components/toolbar/RibbonCommandEffects.test.tsx
+++ b/packages/react/src/viewer/components/toolbar/RibbonCommandEffects.test.tsx
@@ -1,13 +1,13 @@
 // @vitest-environment happy-dom
 /**
- * Two ribbon controls that rendered with the right label and did the wrong
- * thing (or nothing).
+ * Ribbon controls that rendered with the right label and did the wrong thing
+ * (or nothing).
  *
  * `Toolbar.test.tsx` renders to static markup, which proves a control exists;
- * these mount for real and click, because both defects here were invisible to a
- * markup assertion: Design > Slide Size opened the Document Properties dialog,
- * and Transitions > Preview re-committed the transition the slide already had,
- * which is an edit with nothing to see.
+ * these mount for real and click because callback/unit defects are invisible
+ * to a markup assertion. Examples include Design > Slide Size opening the
+ * wrong dialog, a font preset emitting the wrong unit, and Transitions >
+ * Preview re-committing the slide's existing transition.
  */
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -19,6 +19,8 @@ vi.mock(import('react-i18next'), () => ({
 }));
 
 const { DesignSection } = await import('./DesignTransitionsReviewSection');
+const { HomeSection } = await import('./HomeSection');
+const { TextSection } = await import('./TextSection');
 const { TransitionsSection } = await import('./TransitionsSection');
 const { TRANSITION_PREVIEW_ATTR } = await import('pptx-viewer-shared');
 
@@ -71,6 +73,156 @@ describe('design > Slide Size', () => {
 
 		expect(onOpenSlideSize).toHaveBeenCalledOnce();
 		expect(onOpenDocumentProperties).not.toHaveBeenCalled();
+	});
+});
+
+describe('home > font size', () => {
+	it('converts a selected point size to model pixels', () => {
+		const onUpdateTextStyle = vi.fn();
+		act(() => {
+			root.render(
+				<HomeSection
+					canEdit
+					clipboardPayload={null}
+					onCopy={() => {}}
+					onCut={() => {}}
+					onPaste={() => {}}
+					layoutOptions={[]}
+					onInsertSlideFromLayout={() => {}}
+					selectedElement={
+						{
+							type: 'text',
+							id: 'font-size',
+							x: 0,
+							y: 0,
+							width: 100,
+							height: 20,
+							text: 'Hello',
+							textStyle: { fontSize: 16 },
+						} as import('pptx-viewer-core').PptxElement
+					}
+					onUpdateTextStyle={onUpdateTextStyle}
+				/>,
+			);
+		});
+
+		const picker = container.querySelector<HTMLButtonElement>(
+			'button[aria-label="pptx.ribbon.fontSize"]',
+		);
+		expect(picker).not.toBeNull();
+		act(() => picker!.click());
+
+		const tenPointOption = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+			(button) => button.textContent?.trim() === '10',
+		);
+		expect(tenPointOption).toBeDefined();
+		act(() => tenPointOption!.click());
+
+		const patch = onUpdateTextStyle.mock.lastCall?.[0] as { fontSize?: number } | undefined;
+		expect(patch?.fontSize).toBeCloseTo(10 * (96 / 72));
+	});
+
+	it('keeps point units when the shared callback targets a table cell', () => {
+		const onUpdateTextStyle = vi.fn();
+		act(() => {
+			root.render(
+				<HomeSection
+					canEdit
+					clipboardPayload={null}
+					onCopy={() => {}}
+					onCut={() => {}}
+					onPaste={() => {}}
+					layoutOptions={[]}
+					onInsertSlideFromLayout={() => {}}
+					selectedElement={
+						{
+							type: 'table',
+							id: 'table-cell-font-size',
+							x: 0,
+							y: 0,
+							width: 100,
+							height: 40,
+							tableData: { rows: [], columnWidths: [] },
+						} as import('pptx-viewer-core').PptxElement
+					}
+					onUpdateTextStyle={onUpdateTextStyle}
+				/>,
+			);
+		});
+
+		act(() =>
+			container
+				.querySelector<HTMLButtonElement>('button[aria-label="pptx.ribbon.fontSize"]')
+				?.click(),
+		);
+		const tenPointOption = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+			(button) => button.textContent?.trim() === '10',
+		);
+		act(() => tenPointOption?.click());
+		expect(onUpdateTextStyle).toHaveBeenCalledWith({ fontSize: 10 });
+	});
+});
+
+describe('text > font size stepper', () => {
+	it('steps ordinary text by two PowerPoint points in model pixels', () => {
+		const onUpdateTextStyle = vi.fn();
+		act(() => {
+			root.render(
+				<TextSection
+					canEdit
+					selectedElement={
+						{
+							type: 'text',
+							id: 'font-size-step',
+							x: 0,
+							y: 0,
+							width: 100,
+							height: 20,
+							text: 'Hello',
+							textStyle: { fontSize: 48.1 * (96 / 72) },
+						} as import('pptx-viewer-core').PptxElement
+					}
+					onUpdateTextStyle={onUpdateTextStyle}
+					onTransformTextCase={() => {}}
+				/>,
+			);
+		});
+		act(() =>
+			container
+				.querySelector<HTMLButtonElement>('button[title="pptx.text.increaseFontSize"]')
+				?.click(),
+		);
+		expect(onUpdateTextStyle.mock.lastCall?.[0]?.fontSize).toBeCloseTo(50.1 * (96 / 72));
+	});
+
+	it('steps the 18-point fallback in point units when no size is explicit', () => {
+		const onUpdateTextStyle = vi.fn();
+		act(() => {
+			root.render(
+				<TextSection
+					canEdit
+					selectedElement={
+						{
+							type: 'text',
+							id: 'font-size-fallback-step',
+							x: 0,
+							y: 0,
+							width: 100,
+							height: 20,
+							text: 'Hello',
+						} as import('pptx-viewer-core').PptxElement
+					}
+					onUpdateTextStyle={onUpdateTextStyle}
+					onTransformTextCase={() => {}}
+				/>,
+			);
+		});
+		act(() =>
+			container
+				.querySelector<HTMLButtonElement>('button[title="pptx.text.increaseFontSize"]')
+				?.click(),
+		);
+		expect(onUpdateTextStyle.mock.lastCall?.[0]?.fontSize).toBeCloseTo(20 * (96 / 72));
 	});
 });
 

--- a/packages/react/src/viewer/components/toolbar/TextSection.tsx
+++ b/packages/react/src/viewer/components/toolbar/TextSection.tsx
@@ -1,6 +1,6 @@
 import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, TextStyle } from 'pptx-viewer-core';
-import { CHARACTER_SPACING_OPTIONS } from 'pptx-viewer-shared';
+import { CHARACTER_SPACING_OPTIONS, textFontSizePtToPx } from 'pptx-viewer-shared';
 import React, { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -251,8 +251,9 @@ export function TextSection(p: TextSectionProps): React.ReactElement {
 								if (!canFormat || !p.selectedElement) {
 									return;
 								}
-								const current = effectiveTs?.fontSize ?? 18;
-								p.onUpdateTextStyle({ fontSize: current + 2 });
+								const current = effectiveTs?.fontSize ?? (isTextEl ? textFontSizePtToPx(18) : 18);
+								const delta = isTextEl ? textFontSizePtToPx(2) : 2;
+								p.onUpdateTextStyle({ fontSize: current + delta });
 							}}
 							className={gB}
 							title={t('pptx.text.increaseFontSize')}
@@ -267,8 +268,10 @@ export function TextSection(p: TextSectionProps): React.ReactElement {
 								if (!canFormat || !p.selectedElement) {
 									return;
 								}
-								const current = effectiveTs?.fontSize ?? 18;
-								p.onUpdateTextStyle({ fontSize: Math.max(1, current - 2) });
+								const current = effectiveTs?.fontSize ?? (isTextEl ? textFontSizePtToPx(18) : 18);
+								const delta = isTextEl ? textFontSizePtToPx(2) : 2;
+								const minimum = isTextEl ? textFontSizePtToPx(1) : 1;
+								p.onUpdateTextStyle({ fontSize: Math.max(minimum, current - delta) });
 							}}
 							className={gB}
 							title={t('pptx.text.decreaseFontSize')}

--- a/packages/react/src/viewer/components/toolbar/Toolbar.test.tsx
+++ b/packages/react/src/viewer/components/toolbar/Toolbar.test.tsx
@@ -636,6 +636,34 @@ describe('toolbar - Home tab', () => {
 		expect(html).toContain('>24</span>');
 	});
 
+	it('font size display converts model pixels to exact PowerPoint points', () => {
+		const html = render(
+			React.createElement(HomeSection, {
+				canEdit: true,
+				clipboardPayload: null,
+				onCopy: vi.fn<() => void>(),
+				onCut: vi.fn<() => void>(),
+				onPaste: vi.fn<() => void>(),
+				layoutOptions: [],
+				onInsertSlideFromLayout: vi.fn<() => void>(),
+				selectedElement: {
+					type: 'text',
+					id: 'font-size',
+					x: 0,
+					y: 0,
+					width: 100,
+					height: 20,
+					text: 'Hello',
+					textStyle: { fontSize: 32 },
+					textSegments: [{ text: 'Hello', style: { fontSize: 48.1 * (96 / 72) } }],
+				} as never,
+				onUpdateTextStyle: vi.fn<() => void>(),
+			}),
+		);
+		expect(html).toContain('>48.1</span>');
+		expect(html).not.toContain('64.133333');
+	});
+
 	it('paste is disabled when no clipboard payload', () => {
 		const html = render(
 			React.createElement(HomeSection, {

--- a/packages/shared/src/render/inspector-helpers.test.ts
+++ b/packages/shared/src/render/inspector-helpers.test.ts
@@ -1,7 +1,7 @@
 import type { PptxElement } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
-import { fontSizeOf } from './inspector-helpers';
+import { fontSizeOf, textFontSizePatch } from './inspector-helpers';
 
 function textElement(fontSize?: number): PptxElement {
 	return {
@@ -28,8 +28,9 @@ function shapeElement(): PptxElement {
 }
 
 describe('fontSizeOf', () => {
-	it('returns the element textStyle.fontSize when set', () => {
-		expect(fontSizeOf(textElement(24))).toBe(24);
+	it('returns the element model size in points when set', () => {
+		expect(fontSizeOf(textElement(24))).toBe(18);
+		expect(fontSizeOf(textElement(48.1 * (96 / 72)))).toBe(48.1);
 	});
 
 	it('falls back to 18 (PowerPoint default text style) when unset', () => {
@@ -42,17 +43,36 @@ describe('fontSizeOf', () => {
 
 	it('prefers the deck presentation default over the 18pt last resort', () => {
 		expect(
-			fontSizeOf(textElement(undefined), { type: 'body', levelStyles: { 0: { fontSize: 24 } } }),
+			fontSizeOf(textElement(undefined), {
+				type: 'body',
+				levelStyles: { 0: { fontSize: 32 } },
+			}),
 		).toBe(24);
 	});
 
 	it('ignores the presentation default when the element sets its own size', () => {
 		expect(
-			fontSizeOf(textElement(30), { type: 'body', levelStyles: { 0: { fontSize: 24 } } }),
+			fontSizeOf(textElement(40), { type: 'body', levelStyles: { 0: { fontSize: 24 } } }),
 		).toBe(30);
 	});
 
 	it('falls back to 18 when the presentation default has no level-0 font size', () => {
 		expect(fontSizeOf(textElement(undefined), { type: 'body', levelStyles: {} })).toBe(18);
+	});
+});
+
+describe('textFontSizePatch', () => {
+	it('updates the element style and every ordinary text run', () => {
+		const element = textElement(16) as Extract<PptxElement, { textStyle?: unknown }>;
+		(element as { textSegments?: unknown }).textSegments = [
+			{ text: 'First', style: { fontSize: 12, bold: true } },
+			{ text: 'Second', style: { fontSize: 20, italic: true } },
+		];
+		const patch = textFontSizePatch(element, 24);
+		expect(patch.textStyle).toMatchObject({ fontSize: 24 });
+		expect(patch.textSegments).toStrictEqual([
+			{ text: 'First', style: { fontSize: 24, bold: true } },
+			{ text: 'Second', style: { fontSize: 24, italic: true } },
+		]);
 	});
 });

--- a/packages/shared/src/render/inspector-helpers.ts
+++ b/packages/shared/src/render/inspector-helpers.ts
@@ -9,6 +9,8 @@
 import type { PlaceholderDefaults, PptxElement } from 'pptx-viewer-core';
 import { hasShapeProperties, hasTextProperties } from 'pptx-viewer-core';
 
+import { textFontSizePxToPt } from './text-format-presets';
+
 const DEFAULT_FILL = '#ffffff';
 const DEFAULT_STROKE = '#000000';
 const DEFAULT_TEXT_COLOR = '#000000';
@@ -63,10 +65,10 @@ export function textColorOf(el: PptxElement): string {
  */
 export function fontSizeOf(el: PptxElement, presentationDefault?: PlaceholderDefaults): number {
 	if (hasTextProperties(el) && el.textStyle?.fontSize !== undefined) {
-		return el.textStyle.fontSize;
+		return textFontSizePxToPt(el.textStyle.fontSize);
 	}
 	const deckDefault = presentationDefault?.levelStyles?.[0]?.fontSize;
-	return deckDefault ?? DEFAULT_FONT_SIZE;
+	return deckDefault === undefined ? DEFAULT_FONT_SIZE : textFontSizePxToPt(deckDefault);
 }
 
 /** Returns whether the element's text is bold (false when absent). */
@@ -139,5 +141,20 @@ export function textStylePatch(el: PptxElement, changes: TextStyleChanges): Part
 			...base,
 			...changes,
 		},
+	} as Partial<PptxElement>;
+}
+
+/** Apply an ordinary-text model pixel size to the element and all of its runs. */
+export function textFontSizePatch(el: PptxElement, fontSize: number): Partial<PptxElement> {
+	const patch = textStylePatch(el, { fontSize });
+	if (!hasTextProperties(el) || !el.textSegments) {
+		return patch;
+	}
+	return {
+		...patch,
+		textSegments: el.textSegments.map((segment) => ({
+			...segment,
+			style: { ...segment.style, fontSize },
+		})),
 	} as Partial<PptxElement>;
 }

--- a/packages/shared/src/render/text-format-presets.test.ts
+++ b/packages/shared/src/render/text-format-presets.test.ts
@@ -6,6 +6,8 @@ import {
 	COMMON_FONT_FAMILIES,
 	COMMON_FONT_SIZES,
 	LINE_SPACING_OPTIONS,
+	textFontSizePtToPx,
+	textFontSizePxToPt,
 } from './text-format-presets';
 
 describe('font preset lists', () => {
@@ -29,6 +31,12 @@ describe('font preset lists', () => {
 		expect(COMMON_FONT_SIZES[COMMON_FONT_SIZES.length - 1]).toBe(96);
 		const sorted = [...COMMON_FONT_SIZES].sort((a, b) => a - b);
 		expect([...COMMON_FONT_SIZES]).toStrictEqual(sorted);
+	});
+
+	it('converts regular-text font sizes between model pixels and control points', () => {
+		expect(textFontSizePxToPt(64)).toBe(48);
+		expect(textFontSizePxToPt(48.1 * (96 / 72))).toBe(48.1);
+		expect(textFontSizePtToPx(10.5)).toBeCloseTo(14);
 	});
 });
 

--- a/packages/shared/src/render/text-format-presets.ts
+++ b/packages/shared/src/render/text-format-presets.ts
@@ -13,6 +13,22 @@
 import type { ChangeCaseMode } from './text-case-transform';
 
 /**
+ * Regular-text font sizes are stored in slide/CSS pixels in the shared model,
+ * while PowerPoint's font controls and the preset list below use points.
+ */
+export function textFontSizePxToPt(fontSizePx: number): number {
+	// DrawingML stores regular text sizes in hundredths of a point. Normalising
+	// to that precision removes binary floating-point noise without discarding
+	// valid authored values such as 10.5 pt or 48.1 pt.
+	return Math.round(fontSizePx * (72 / 96) * 100) / 100;
+}
+
+/** Convert a PowerPoint font-control value in points to the model's pixels. */
+export function textFontSizePtToPx(fontSizePt: number): number {
+	return fontSizePt * (96 / 72);
+}
+
+/**
  * Font families offered by the Home-tab font dropdown, alphabetically.
  *
  * Covers the families PowerPoint's own list leads with (the Office UI faces,

--- a/packages/svelte/src/viewer/components/ConnectorView.test.ts
+++ b/packages/svelte/src/viewer/components/ConnectorView.test.ts
@@ -88,6 +88,22 @@ describe('connectorView arrow markers', () => {
 		expect(path?.getAttribute('fill')).toBe('#123456');
 		expect(path?.hasAttribute('stroke')).toBeFalsy();
 	});
+
+	it('renders connector label model font sizes as CSS pixels', () => {
+		const element = {
+			...connector({ strokeColor: '#123456' }),
+			text: 'Label',
+			textStyle: { fontSize: 64 },
+			textSegments: [{ text: 'Label', style: { fontSize: 32 } }],
+		} as PptxElement;
+		const rendered = render(element);
+		expect(
+			rendered.querySelector('.pptx-svelte-connector-text-block')?.getAttribute('style'),
+		).toContain('font-size: 64px');
+		expect(
+			rendered.querySelector('.pptx-svelte-connector-text span')?.getAttribute('style'),
+		).toContain('font-size: 32px');
+	});
 });
 
 /**

--- a/packages/svelte/src/viewer/components/TextFormatGroup.svelte
+++ b/packages/svelte/src/viewer/components/TextFormatGroup.svelte
@@ -10,7 +10,12 @@
 	 * Disabled (greyed) whenever the selection has no text properties.
 	 */
 	import { hasTextProperties } from 'pptx-viewer-core';
-	import { fontSizeOf, isBold, isItalic, isUnderline } from 'pptx-viewer-shared';
+	import {
+		fontSizeOf,
+		isBold,
+		isItalic,
+		isUnderline,
+	} from 'pptx-viewer-shared';
 
 	import { useTranslator } from '../../i18n/context';
 	import type { EditorState } from '../editor/editor-state.svelte';
@@ -105,9 +110,10 @@
 		type="number"
 		min="1"
 		max="400"
+		step="any"
 		aria-label={t('pptx.ribbon.fontSize')}
 		title={t('pptx.ribbon.fontSize')}
-		value={Math.round(fontSize)}
+		value={fontSize}
 		onchange={(e) => setSize(e.currentTarget.value)}
 	/>
 	<button

--- a/packages/svelte/src/viewer/components/ribbon/home/home-drawing-text.svelte.test.ts
+++ b/packages/svelte/src/viewer/components/ribbon/home/home-drawing-text.svelte.test.ts
@@ -3,6 +3,7 @@ import { flushSync, mount, unmount } from 'svelte';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { EditorState } from '../../../editor/editor-state.svelte';
+import TextFormatGroup from '../../TextFormatGroup.svelte';
 import DrawingGroup from './DrawingGroup.svelte';
 import ParagraphDropdowns from './ParagraphDropdowns.svelte';
 import TextShadowToggle from './TextShadowToggle.svelte';
@@ -20,7 +21,7 @@ afterEach(() => {
 	cleanup = undefined;
 });
 
-function makeEditor(withText = false): EditorState {
+function makeEditor(withText = false, fontSize?: number): EditorState {
 	const editor = new EditorState({ getCurrent: () => 0, getHandler: () => null });
 	editor.editable = true;
 	editor.setSlides([
@@ -38,7 +39,7 @@ function makeEditor(withText = false): EditorState {
 							width: 100,
 							height: 20,
 							text: 'Hi',
-							textStyle: {},
+							textStyle: fontSize === undefined ? {} : { fontSize },
 						},
 					]
 				: [],
@@ -158,5 +159,24 @@ describe('home text shadow toggle', () => {
 		flushSync();
 		el = editor.slides[0]?.elements[0];
 		expect(el?.type === 'text' ? el.textStyle?.textShadowColor : 'x').toBeUndefined();
+	});
+});
+
+describe('home text font size', () => {
+	it('shows points and converts fractional point edits back to model pixels', () => {
+		const editor = makeEditor(true, 48.1 * (96 / 72));
+		const target = mountComponent(TextFormatGroup, editor);
+		const input = target.querySelector<HTMLInputElement>('[aria-label="Font size"]');
+
+		expect(input?.value).toBe('48.1');
+		expect(input?.step).toBe('any');
+		input!.value = '10.1';
+		input!.dispatchEvent(new Event('change', { bubbles: true }));
+		flushSync();
+
+		const element = editor.slides[0]?.elements[0];
+		expect(element?.type === 'text' ? element.textStyle?.fontSize : undefined).toBeCloseTo(
+			10.1 * (96 / 72),
+		);
 	});
 });

--- a/packages/svelte/src/viewer/editor/editor-format-mutations.test.ts
+++ b/packages/svelte/src/viewer/editor/editor-format-mutations.test.ts
@@ -63,10 +63,10 @@ describe('text format patches', () => {
 	});
 
 	it('sets and adjusts font size (clamped)', () => {
-		expect(setFontSizePatch(textEl(), 32).textStyle).toMatchObject({ fontSize: 32 });
-		expect(setFontSizePatch(textEl(), 0).textStyle).toMatchObject({ fontSize: 1 });
-		expect(adjustFontSizePatch(textEl(), 4).textStyle).toMatchObject({ fontSize: 22 });
-		expect(adjustFontSizePatch(textEl(), -100).textStyle).toMatchObject({ fontSize: 1 });
+		expect(setFontSizePatch(textEl(), 32).textStyle?.fontSize).toBeCloseTo(32 * (96 / 72));
+		expect(setFontSizePatch(textEl(), 0).textStyle?.fontSize).toBeCloseTo(1 * (96 / 72));
+		expect(adjustFontSizePatch(textEl(), 4).textStyle?.fontSize).toBeCloseTo(17.5 * (96 / 72));
+		expect(adjustFontSizePatch(textEl(), -100).textStyle?.fontSize).toBeCloseTo(1 * (96 / 72));
 	});
 
 	it('sets text colour and highlight colour', () => {

--- a/packages/svelte/src/viewer/editor/editor-format-mutations.ts
+++ b/packages/svelte/src/viewer/editor/editor-format-mutations.ts
@@ -5,6 +5,8 @@ import {
 	shapeFillChange,
 	shapeOutlineChange,
 	shapeStylePatch,
+	textFontSizePatch,
+	textFontSizePtToPx,
 	textStylePatch,
 } from 'pptx-viewer-shared';
 
@@ -31,7 +33,7 @@ const MIN_FONT = 1,
 	MAX_FONT = 400;
 
 function clampFont(size: number): number {
-	return Math.min(MAX_FONT, Math.max(MIN_FONT, Math.round(size)));
+	return Math.min(MAX_FONT, Math.max(MIN_FONT, size));
 }
 
 /** Toggleable boolean text-style flags. */
@@ -45,12 +47,12 @@ export function toggleTextFlagPatch(el: PptxElement, flag: TextFlag): Partial<Pp
 
 /** Set an absolute font size (clamped to a sane range). */
 export function setFontSizePatch(el: PptxElement, size: number): Partial<PptxElement> {
-	return textStylePatch(el, { fontSize: clampFont(size) });
+	return textFontSizePatch(el, textFontSizePtToPx(clampFont(size)));
 }
 
 /** Nudge the font size by `delta` points (clamped). */
 export function adjustFontSizePatch(el: PptxElement, delta: number): Partial<PptxElement> {
-	return textStylePatch(el, { fontSize: clampFont(fontSizeOf(el) + delta) });
+	return setFontSizePatch(el, fontSizeOf(el) + delta);
 }
 
 /** Set the text (foreground) colour. */

--- a/packages/svelte/src/viewer/style/connector-label.ts
+++ b/packages/svelte/src/viewer/style/connector-label.ts
@@ -20,7 +20,7 @@ export function connectorLabelContainerStyle(textStyle: TextStyle | undefined): 
 export function connectorLabelBlockStyle(textStyle: TextStyle | undefined): CssStyleMap {
 	return {
 		fontFamily: textStyle?.fontFamily ?? 'inherit',
-		fontSize: textStyle?.fontSize ? `${textStyle.fontSize}pt` : '10pt',
+		fontSize: textStyle?.fontSize ? `${textStyle.fontSize}px` : '10px',
 		color: textStyle?.color ?? '#000000',
 		fontWeight: textStyle?.bold ? 'bold' : 'normal',
 		fontStyle: textStyle?.italic ? 'italic' : 'normal',
@@ -42,7 +42,7 @@ export function connectorLabelSegmentStyle(
 		textDecoration: s?.underline ? 'underline' : 'none',
 	};
 	if (s?.fontSize) {
-		style.fontSize = `${s.fontSize}pt`;
+		style.fontSize = `${s.fontSize}px`;
 	}
 	return style;
 }

--- a/packages/vanilla/src/viewer/editor/editor-format-mutations.test.ts
+++ b/packages/vanilla/src/viewer/editor/editor-format-mutations.test.ts
@@ -85,16 +85,16 @@ describe('editor-format-mutations text', () => {
 
 	it('sets and steps the font size, clamped', () => {
 		const set = setFontSize(textElement(), 40) as { textStyle: { fontSize?: number } };
-		expect(set.textStyle.fontSize).toBe(40);
+		expect(set.textStyle.fontSize).toBeCloseTo(40 * (96 / 72));
 		const grown = adjustFontSize(textElement(), 4) as { textStyle: { fontSize?: number } };
-		expect(grown.textStyle.fontSize).toBe(22);
+		expect(grown.textStyle.fontSize).toBeCloseTo(17.5 * (96 / 72));
 		const clamped = setFontSize(textElement(), -100) as { textStyle: { fontSize?: number } };
-		expect(clamped.textStyle.fontSize).toBe(1);
+		expect(clamped.textStyle.fontSize).toBeCloseTo(1 * (96 / 72));
 	});
 
 	it('reads the effective format state', () => {
 		const state = readTextFormatState(textElement());
-		expect(state).toMatchObject({ bold: false, italic: false, underline: false, fontSize: 18 });
+		expect(state).toMatchObject({ bold: false, italic: false, underline: false, fontSize: 13.5 });
 	});
 
 	it('sets text colour on style + runs', () => {

--- a/packages/vanilla/src/viewer/editor/editor-format-mutations.ts
+++ b/packages/vanilla/src/viewer/editor/editor-format-mutations.ts
@@ -8,7 +8,12 @@ import type {
 } from 'pptx-viewer-core';
 import { hasShapeProperties, hasTextProperties } from 'pptx-viewer-core';
 import type { ChangeCaseMode } from 'pptx-viewer-shared';
-import { applyCaseTransformToSegments, remapTextToSegments } from 'pptx-viewer-shared';
+import {
+	applyCaseTransformToSegments,
+	remapTextToSegments,
+	textFontSizePtToPx,
+	textFontSizePxToPt,
+} from 'pptx-viewer-shared';
 
 import { currentInlineEditorText } from './inline-text-editor';
 
@@ -92,13 +97,14 @@ export function canFormatShape(el: PptxElement | undefined): el is PptxElementWi
 export function readTextFormatState(el: PptxElement | undefined): TextFormatState {
 	const ts: TextStyle | undefined = canFormatText(el) ? el.textStyle : undefined;
 	const firstRun = canFormatText(el) ? el.textSegments?.find((s) => s.text)?.style : undefined;
+	const fontSizePx = ts?.fontSize ?? firstRun?.fontSize;
 	return {
 		bold: Boolean(ts?.bold ?? firstRun?.bold),
 		italic: Boolean(ts?.italic ?? firstRun?.italic),
 		underline: Boolean(ts?.underline ?? firstRun?.underline),
 		strikethrough: Boolean(ts?.strikethrough ?? firstRun?.strikethrough),
 		hasTextShadow: Boolean(ts?.textShadowColor ?? firstRun?.textShadowColor),
-		fontSize: ts?.fontSize ?? firstRun?.fontSize ?? DEFAULT_FONT_SIZE,
+		fontSize: fontSizePx === undefined ? DEFAULT_FONT_SIZE : textFontSizePxToPt(fontSizePx),
 		fontFamily: ts?.fontFamily ?? firstRun?.fontFamily,
 		placeholderType: (el as { placeholderType?: string } | undefined)?.placeholderType,
 		color: ts?.color ?? firstRun?.color,
@@ -132,8 +138,8 @@ export function toggleTextProp(el: PptxElement, key: TextToggleKey): Partial<Ppt
 
 /** Set the font size (pt) element-wide, clamped to sane bounds. */
 export function setFontSize(el: PptxElement, size: number): Partial<PptxElement> {
-	const clamped = Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, Math.round(size)));
-	return patchTextStyle(el, { fontSize: clamped });
+	const clamped = Math.min(MAX_FONT_SIZE, Math.max(MIN_FONT_SIZE, size));
+	return patchTextStyle(el, { fontSize: textFontSizePtToPx(clamped) });
 }
 
 /** Step the font size by `delta` points from the current effective size. */

--- a/packages/vanilla/src/viewer/ui/ribbon/ribbon.test.ts
+++ b/packages/vanilla/src/viewer/ui/ribbon/ribbon.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { EditActions } from '../../editor/editor-edit-ops';
 import type { FindReplaceActions } from '../../editor/editor-find-replace-actions';
+import { readTextFormatState } from '../../editor/editor-format-mutations';
 import { createTranslator } from '../../i18n';
+import { createFontGroup } from './home/font-group';
 import { createRibbon } from './ribbon';
 import type { RibbonHandlers, RibbonInsertHandlers } from './ribbon-types';
 
@@ -375,5 +377,50 @@ describe('createRibbon', () => {
 			// An unrelated View action stays, proving the hide is scoped to that id.
 			expect(ribbon.el.querySelector(`[aria-label="${t('pptx.view.normal')}"]`)).not.toBeNull();
 		});
+	});
+});
+
+describe('home font size', () => {
+	it('shows points and sends a point preset to the format action', () => {
+		const t = createTranslator();
+		const setFontSize = vi.fn();
+		const group = createFontGroup(document, t, {
+			toggleBold: vi.fn(),
+			toggleItalic: vi.fn(),
+			toggleUnderline: vi.fn(),
+			toggleStrikethrough: vi.fn(),
+			toggleTextShadow: vi.fn(),
+			setFontFamily: vi.fn(),
+			setFontSize,
+			changeFontSize: vi.fn(),
+			setTextColor: vi.fn(),
+			setHighlightColor: vi.fn(),
+			setCharacterSpacing: vi.fn(),
+			changeCase: vi.fn(),
+			clearFormatting: vi.fn(),
+		});
+		group.update({
+			canFormat: true,
+			editable: true,
+			text: readTextFormatState({
+				type: 'text',
+				id: 'font-size',
+				x: 0,
+				y: 0,
+				width: 100,
+				height: 20,
+				text: 'Hello',
+				textStyle: { fontSize: 48.1 * (96 / 72) },
+			}),
+		});
+
+		const dropdown = group.el.querySelector<HTMLElement>('.pptxv-font-size-dd');
+		expect(dropdown?.querySelector('.pptxv-dropdown-text')?.textContent).toBe('48.1');
+		dropdown?.querySelector<HTMLButtonElement>('.pptxv-dropdown-trigger')?.click();
+		const tenPoint = [
+			...(dropdown?.querySelectorAll<HTMLButtonElement>('[role="option"]') ?? []),
+		].find((option) => option.textContent === '10');
+		tenPoint?.click();
+		expect(setFontSize).toHaveBeenCalledWith(10);
 	});
 });

--- a/packages/vue/src/viewer/components/ConnectorRenderer.test.ts
+++ b/packages/vue/src/viewer/components/ConnectorRenderer.test.ts
@@ -124,6 +124,25 @@ describe('connectorRenderer', () => {
 		expect(path.attributes('fill')).toBe('#ff0000');
 		expect(path.attributes('stroke')).toBeUndefined();
 	});
+
+	it('renders connector label model font sizes as CSS pixels', () => {
+		const wrapper = mount(ConnectorRenderer, {
+			props: {
+				element: connector({
+					text: 'Label',
+					textStyle: { fontSize: 64 },
+					textSegments: [{ text: 'Label', style: { fontSize: 32 } }],
+				}),
+				zIndex: 0,
+			},
+		});
+		expect(wrapper.get('.pptx-vue-connector-text__block').attributes('style')).toContain(
+			'font-size: 64px',
+		);
+		expect(wrapper.get('.pptx-vue-connector-text__run').attributes('style')).toContain(
+			'font-size: 32px',
+		);
+	});
 });
 
 // ── Bent connector routing ────────────────────────────────────────────────────

--- a/packages/vue/src/viewer/components/ConnectorTextOverlay.vue
+++ b/packages/vue/src/viewer/components/ConnectorTextOverlay.vue
@@ -50,7 +50,7 @@ const blockStyle = computed<CSSProperties>(() => {
 	const ts = props.textStyle;
 	return {
 		fontFamily: ts?.fontFamily ?? 'inherit',
-		fontSize: ts?.fontSize ? `${ts.fontSize}pt` : '10pt',
+		fontSize: ts?.fontSize ? `${ts.fontSize}px` : '10px',
 		color: ts?.color ?? '#000000',
 		fontWeight: ts?.bold ? 'bold' : 'normal',
 		fontStyle: ts?.italic ? 'italic' : 'normal',
@@ -64,7 +64,7 @@ function segStyle(seg: TextSegment): CSSProperties {
 	const ts = props.textStyle;
 	return {
 		fontFamily: s?.fontFamily ?? ts?.fontFamily ?? 'inherit',
-		fontSize: s?.fontSize ? `${s.fontSize}pt` : undefined,
+		fontSize: s?.fontSize ? `${s.fontSize}px` : undefined,
 		color: s?.color ?? ts?.color ?? '#000000',
 		fontWeight: s?.bold ? 'bold' : ts?.bold ? 'bold' : 'normal',
 		fontStyle: s?.italic ? 'italic' : ts?.italic ? 'italic' : 'normal',

--- a/packages/vue/src/viewer/components/inspector/TextPanel.test.ts
+++ b/packages/vue/src/viewer/components/inspector/TextPanel.test.ts
@@ -29,23 +29,34 @@ describe('textPanel', () => {
 
 	it('renders current font size and color', () => {
 		const wrapper = mount(TextPanel, {
-			props: { element: textEl({ fontSize: 24, color: '#112233', fontFamily: 'Georgia' }) },
+			props: {
+				element: textEl({
+					fontSize: 48.1 * (96 / 72),
+					color: '#112233',
+					fontFamily: 'Georgia',
+				}),
+			},
 		});
-		expect((wrapper.find('input[type="number"]').element as HTMLInputElement).value).toBe('24');
+		const size = wrapper.find('input[type="number"]').element as HTMLInputElement;
+		expect(size.value).toBe('48.1');
+		expect(size.step).toBe('any');
 		expect((wrapper.find('input[type="color"]').element as HTMLInputElement).value).toBe('#112233');
 		expect((wrapper.find('select').element as HTMLSelectElement).value).toBe('Georgia');
 	});
 
 	it('emits a full merged textStyle patch when size changes', async () => {
-		const wrapper = mount(TextPanel, {
-			props: { element: textEl({ bold: true, color: '#000000' }) },
-		});
+		const element = textEl({ bold: true, color: '#000000' });
+		element.textSegments = [{ text: 'Hello', style: { fontSize: 16, italic: true } }];
+		const wrapper = mount(TextPanel, { props: { element } });
 		const num = wrapper.find('input[type="number"]');
-		(num.element as HTMLInputElement).value = '32';
+		(num.element as HTMLInputElement).value = '48.1';
 		await num.trigger('input');
 
 		const patch = wrapper.emitted('update')?.[0]?.[0] as Partial<PptxElement>;
-		expect(patch).toStrictEqual({ textStyle: { bold: true, color: '#000000', fontSize: 32 } });
+		expect(patch.textStyle).toMatchObject({ bold: true, color: '#000000' });
+		expect(patch.textStyle?.fontSize).toBeCloseTo(48.1 * (96 / 72));
+		expect(patch.textSegments?.[0]?.style).toMatchObject({ italic: true });
+		expect(patch.textSegments?.[0]?.style.fontSize).toBeCloseTo(48.1 * (96 / 72));
 	});
 
 	it('toggles bold against current textStyle', async () => {

--- a/packages/vue/src/viewer/components/inspector/TextPanel.vue
+++ b/packages/vue/src/viewer/components/inspector/TextPanel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { PptxElement, PptxTextWarpPreset, TextStyle } from 'pptx-viewer-core';
 import { hasTextProperties } from 'pptx-viewer-core';
+import { textFontSizePatch, textFontSizePtToPx, textFontSizePxToPt } from 'pptx-viewer-shared';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -77,7 +78,9 @@ const textStyle = computed<TextStyle | undefined>(() =>
 );
 
 const fontFamily = computed<string>(() => textStyle.value?.fontFamily ?? '');
-const fontSize = computed<number>(() => textStyle.value?.fontSize ?? 18);
+const fontSize = computed<number>(() =>
+	textStyle.value?.fontSize !== undefined ? textFontSizePxToPt(textStyle.value.fontSize) : 18,
+);
 const color = computed<string>(() => textStyle.value?.color ?? '#000000');
 const align = computed<AlignValue | undefined>(() => textStyle.value?.align);
 const vAlign = computed<VAlignValue | undefined>(() => textStyle.value?.vAlign);
@@ -93,7 +96,8 @@ function onFontFamily(event: Event): void {
 
 function onFontSize(event: Event): void {
 	const raw = Number.parseFloat((event.target as HTMLInputElement).value);
-	patchTextStyle({ fontSize: Number.isFinite(raw) ? Math.max(1, raw) : 1 });
+	const points = Number.isFinite(raw) ? Math.max(1, raw) : 1;
+	emit('update', textFontSizePatch(props.element, textFontSizePtToPx(points)));
 }
 
 function onColor(event: Event): void {
@@ -172,7 +176,7 @@ function onTextEffectPatch(patch: Partial<TextStyle>): void {
 						type="number"
 						class="pptx-vue-text-input w-full bg-muted border border-border rounded px-2 py-1"
 						min="1"
-						step="1"
+						step="any"
 						:value="fontSize"
 						@input="onFontSize"
 					/>

--- a/packages/vue/src/viewer/components/ribbon/HomeSection.test.ts
+++ b/packages/vue/src/viewer/components/ribbon/HomeSection.test.ts
@@ -49,19 +49,54 @@ describe('homeSection - font size box (shared fontSizeOf)', () => {
 		expect(wrapper.find('[aria-label="Font size"]').text()).toBe('18');
 	});
 
-	it('shows the element textStyle fontSize when set', () => {
-		const wrapper = mountHome({ selectedElement: textShape({ textStyle: { fontSize: 32 } }) });
-		expect(wrapper.find('[aria-label="Font size"]').text()).toBe('32');
+	it('shows the element model size as exact PowerPoint points', () => {
+		const wrapper = mountHome({
+			selectedElement: textShape({ textStyle: { fontSize: 48.1 * (96 / 72) } }),
+		});
+		expect(wrapper.find('[aria-label="Font size"]').text()).toBe('48.1');
 	});
 
 	it('prefers the first text segment style over the element textStyle', () => {
 		const wrapper = mountHome({
 			selectedElement: textShape({
-				textStyle: { fontSize: 32 },
-				textSegments: [{ text: 'hi', style: { fontSize: 40 } }],
+				textStyle: { fontSize: 32 * (96 / 72) },
+				textSegments: [{ text: 'hi', style: { fontSize: 40 * (96 / 72) } }],
 			}),
 		});
 		expect(wrapper.find('[aria-label="Font size"]').text()).toBe('40');
+	});
+
+	it('converts a point preset back to model pixels', async () => {
+		const onUpdateTextStyle = vi.fn();
+		const wrapper = mountHome({
+			selectedElement: textShape({ textStyle: { fontSize: 16 } }),
+			onUpdateTextStyle,
+		});
+		await wrapper.find('[aria-label="Font size"]').trigger('click');
+		const option = wrapper.findAll('button').find((button) => button.text().trim() === '10');
+		expect(option).toBeDefined();
+		await option!.trigger('click');
+		expect(onUpdateTextStyle.mock.lastCall?.[0]?.fontSize).toBeCloseTo(10 * (96 / 72));
+	});
+
+	it('keeps point units when the shared callback targets a table cell', async () => {
+		const onUpdateTextStyle = vi.fn();
+		const wrapper = mountHome({
+			selectedElement: {
+				type: 'table',
+				id: 'table-cell-font-size',
+				x: 0,
+				y: 0,
+				width: 100,
+				height: 40,
+				tableData: { rows: [], columnWidths: [] },
+			} as PptxElement,
+			onUpdateTextStyle,
+		});
+		await wrapper.find('[aria-label="Font size"]').trigger('click');
+		const option = wrapper.findAll('button').find((button) => button.text().trim() === '10');
+		await option!.trigger('click');
+		expect(onUpdateTextStyle).toHaveBeenCalledWith({ fontSize: 10 });
 	});
 
 	it('falls back to 18pt for a non-text element (e.g. an image)', () => {

--- a/packages/vue/src/viewer/components/ribbon/HomeSection.vue
+++ b/packages/vue/src/viewer/components/ribbon/HomeSection.vue
@@ -11,7 +11,12 @@ import { ChevronDown, ClipboardPaste, Copy, Paintbrush, Scissors } from 'lucide-
  */
 import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, PptxLayoutPreview, TextStyle } from 'pptx-viewer-core';
-import { DEFAULT_FONT_SIZE, fontSizeOf, resolveDefaultFontFamily } from 'pptx-viewer-shared';
+import {
+	DEFAULT_FONT_SIZE,
+	resolveDefaultFontFamily,
+	textFontSizePtToPx,
+	textFontSizePxToPt,
+} from 'pptx-viewer-shared';
 import type { SlideTemplateId } from 'pptx-viewer-shared';
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -75,36 +80,32 @@ const { t } = useI18n();
  * placeholder and its minor font elsewhere. It used to show a hardcoded
  * "Segoe UI", which misreported every themed deck.
  *
- * Font size falls back through shared's `fontSizeOf`, which mirrors this same
- * fix for size: PowerPoint's presentation-level default text style
- * (`p:defaultTextStyle`) is 18pt, so a shape with no explicit size renders at
- * 18pt in real PowerPoint. This box used to show a hardcoded 24pt with no
- * relation to that default (also present, unfixed, in React's own
- * `toolbar/HomeSection.tsx`). `fontSizeOf` is only reached once this
- * component's own segment-level override (finer-grained than what the shared
- * reader itself considers) has had a chance to answer first.
+ * Explicit model font sizes are CSS pixels, while the control displays
+ * PowerPoint points. An element without an explicit size keeps the existing
+ * 18pt presentation fallback.
  */
 function extractFontInfo(element?: PptxElement | null): { fontFamily: string; fontSize: string } {
 	const placeholderType = (element as { placeholderType?: string } | null | undefined)
 		?.placeholderType;
 	const fontFamilyDefault = resolveDefaultFontFamily(placeholderType, props.themeFonts);
 	if (!element) {
-		// `fontSizeOf` requires a real element (it narrows internally via
-		// `hasTextProperties`); with nothing selected there is none to pass, so
-		// this mirrors its own last-resort fallback directly.
 		return { fontFamily: fontFamilyDefault, fontSize: String(DEFAULT_FONT_SIZE) };
 	}
 	if (!hasTextProperties(element)) {
-		return { fontFamily: fontFamilyDefault, fontSize: String(fontSizeOf(element)) };
+		return { fontFamily: fontFamilyDefault, fontSize: String(DEFAULT_FONT_SIZE) };
 	}
 
 	const segStyle = element.textSegments?.[0]?.style;
 	const textStyle = element.textStyle;
 
 	const fontFamily = segStyle?.fontFamily ?? textStyle?.fontFamily ?? fontFamilyDefault;
-	const fontSize = segStyle?.fontSize ?? fontSizeOf(element);
+	const fontSize = segStyle?.fontSize ?? textStyle?.fontSize;
 
-	return { fontFamily, fontSize: String(fontSize) };
+	return {
+		fontFamily,
+		fontSize:
+			fontSize !== undefined ? String(textFontSizePxToPt(fontSize)) : String(DEFAULT_FONT_SIZE),
+	};
 }
 
 const fontInfo = computed(() => extractFontInfo(props.selectedElement));
@@ -142,7 +143,10 @@ function handlePickFont(f: string): void {
 }
 
 function handlePickSize(s: number): void {
-	props.onUpdateTextStyle?.({ fontSize: s });
+	props.onUpdateTextStyle?.({
+		fontSize:
+			props.selectedElement && hasTextProperties(props.selectedElement) ? textFontSizePtToPx(s) : s,
+	});
 	sizeMenu.close();
 }
 </script>

--- a/packages/vue/src/viewer/components/ribbon/TextSection.test.ts
+++ b/packages/vue/src/viewer/components/ribbon/TextSection.test.ts
@@ -74,3 +74,33 @@ describe('textSection font-colour popover', () => {
 		expect(wrapper.find('[data-testid="pptx-color-recent"]').exists()).toBeFalsy();
 	});
 });
+
+describe('textSection font-size stepper', () => {
+	it('steps ordinary text by two PowerPoint points in model pixels', async () => {
+		const onUpdateTextStyle = vi.fn();
+		const wrapper = mountSection({
+			selectedElement: textShape({ textStyle: { fontSize: 48.1 * (96 / 72) } }),
+			onUpdateTextStyle,
+		});
+		const increase = wrapper
+			.findAll('button')
+			.find((button) => button.attributes('title') === 'Increase Font Size');
+		expect(increase).toBeDefined();
+		await increase!.trigger('click');
+		expect(onUpdateTextStyle.mock.lastCall?.[0]?.fontSize).toBeCloseTo(50.1 * (96 / 72));
+	});
+
+	it('steps the 18-point fallback in point units when no size is explicit', async () => {
+		const onUpdateTextStyle = vi.fn();
+		const wrapper = mountSection({
+			selectedElement: textShape(),
+			onUpdateTextStyle,
+		});
+		const increase = wrapper
+			.findAll('button')
+			.find((button) => button.attributes('title') === 'Increase Font Size');
+		expect(increase).toBeDefined();
+		await increase!.trigger('click');
+		expect(onUpdateTextStyle.mock.lastCall?.[0]?.fontSize).toBeCloseTo(20 * (96 / 72));
+	});
+});

--- a/packages/vue/src/viewer/components/ribbon/TextSection.vue
+++ b/packages/vue/src/viewer/components/ribbon/TextSection.vue
@@ -23,6 +23,7 @@ import {
 import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, TextStyle } from 'pptx-viewer-core';
 import type { ChangeCaseMode } from 'pptx-viewer-shared';
+import { textFontSizePtToPx } from 'pptx-viewer-shared';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -167,16 +168,19 @@ function handleIncreaseFontSize(): void {
 	if (!canFormat.value || !props.selectedElement) {
 		return;
 	}
-	const current = effectiveTs.value?.fontSize ?? 18;
-	props.onUpdateTextStyle({ fontSize: current + 2 });
+	const current = effectiveTs.value?.fontSize ?? (isTextEl.value ? textFontSizePtToPx(18) : 18);
+	const delta = isTextEl.value ? textFontSizePtToPx(2) : 2;
+	props.onUpdateTextStyle({ fontSize: current + delta });
 }
 
 function handleDecreaseFontSize(): void {
 	if (!canFormat.value || !props.selectedElement) {
 		return;
 	}
-	const current = effectiveTs.value?.fontSize ?? 18;
-	props.onUpdateTextStyle({ fontSize: Math.max(1, current - 2) });
+	const current = effectiveTs.value?.fontSize ?? (isTextEl.value ? textFontSizePtToPx(18) : 18);
+	const delta = isTextEl.value ? textFontSizePtToPx(2) : 2;
+	const minimum = isTextEl.value ? textFontSizePtToPx(1) : 1;
+	props.onUpdateTextStyle({ fontSize: Math.max(minimum, current - delta) });
 }
 
 function handleClearFormatting(): void {


### PR DESCRIPTION
## Summary

- show and edit ordinary-text font sizes in PowerPoint points across React, Vue, Angular, Svelte, and Vanilla while retaining CSS pixels in the shared model
- preserve fractional point sizes and keep preset selection, grow/shrink, element styles, and explicit run styles synchronized
- render connector-label model font sizes as CSS pixels in React, Vue, and Svelte, matching the existing Angular and Vanilla behavior
- leave table and chart font-size paths on their existing point-based contracts

## Why this is a bug

Ordinary DrawingML text is parsed into the model in CSS pixels and converted back to points when saved. The controls in each binding were reading or writing that model value as if it were already points. For example, an imported 48.1 pt run could appear as 64.13, while selecting 48 could save as 36 pt.

The conversion now happens only at the UI boundary. A 48.1 pt run displays as 48.1; entering 10.5 stores 14 model pixels and saves as `a:rPr/@sz=1050`; selecting 12 stores 16 model pixels. Fractional values are not rounded to whole numbers.

## Scope decisions

- The shared helpers define the px/pt conversion once for all bindings.
- Whole-element changes update both the element text style and explicit run styles so the visible text changes immediately.
- Text with no explicit size uses the existing 18 pt fallback before grow/shrink.
- Table-cell and chart font sizes are already modeled in points, so they are intentionally not converted. Regression coverage protects that boundary.
- Connector labels use the ordinary-text pixel model. React, Vue, and Svelte previously rendered those pixels as CSS points; their renderers now match Angular and Vanilla.

## Verification

Focused regression suites:

- shared: 2 files / 15 tests
- React: 4 files / 154 tests
- Vue: 4 files / 50 tests
- Angular: 2 files / 32 tests
- Svelte: 3 files / 25 tests
- Vanilla: 2 files / 33 tests
- core parser/save path: 2 files / 118 tests

Also completed:

- typechecks for shared and all five bindings
- production builds for shared and all five bindings
- formatting, lint, and diff checks
- independent code review with no remaining findings
- browser checks in all five demos for display, fractional edits where exposed, presets, explicit runs, and grow/shrink
- React check against the existing `descender-clip.pptx` fixture: 48.1 pt display, 10.5 pt to 14 px, 12 pt to 16 px, and 12 to 14 to 12 pt grow/shrink

Svelte reports three pre-existing `PrintDialog.svelte` warnings and no type errors.

## Review note

This is my first open-source contribution series, so I would appreciate guidance if any scope or convention should be adjusted.