### PR TITLE
fix(shared): preserve paragraph metadata through text edits

### DIFF
--- a/packages/shared/src/render/remap-text.test.ts
+++ b/packages/shared/src/render/remap-text.test.ts
@@ -118,6 +118,163 @@ describe('remapTextToSegments', () => {
 		});
 	});
 
+	describe('paragraph metadata preservation', () => {
+		it('keeps paragraph properties, level and end-run properties after a text edit', () => {
+			const paragraphProperties = {
+				paragraphSpacingBefore: 8,
+				paragraphSpacingAfter: 12,
+				lineSpacing: 1.5,
+			};
+			const endParaRunProperties = { '@_sz': '1800' };
+			const original: TextSegment[] = [
+				{
+					text: 'Original',
+					style: { fontSize: 18 },
+					paragraphLevel: 2,
+					paragraphProperties,
+					endParaRunProperties,
+				},
+			];
+
+			const result = remapTextToSegments('Edited', original, {});
+
+			expect(result[0].paragraphLevel).toBe(2);
+			expect(result[0].paragraphProperties).toBe(paragraphProperties);
+			expect(result[0].endParaRunProperties).toBe(endParaRunProperties);
+		});
+
+		it('keeps each paragraph own metadata on its first remapped segment', () => {
+			const firstProperties = { paragraphSpacingAfter: 6 };
+			const secondProperties = { paragraphSpacingBefore: 10 };
+			const original: TextSegment[] = [
+				{
+					text: 'First',
+					style: { bold: true },
+					paragraphProperties: firstProperties,
+				},
+				breakSeg(),
+				{
+					text: 'Second',
+					style: { italic: true },
+					paragraphProperties: secondProperties,
+				},
+			];
+
+			const result = remapTextToSegments('First edited\nSecond edited', original, {});
+			const paragraphs = result.filter((segment) => !segment.isParagraphBreak);
+
+			expect(paragraphs[0].paragraphProperties).toBe(firstProperties);
+			expect(paragraphs[1].paragraphProperties).toBe(secondProperties);
+		});
+
+		it('keeps metadata only on the first run of a remapped paragraph', () => {
+			const paragraphProperties = { paragraphSpacingBefore: 5 };
+			const original: TextSegment[] = [
+				{
+					text: 'Bold',
+					style: { bold: true },
+					paragraphProperties,
+				},
+				seg(' plain', { italic: true }),
+			];
+
+			const result = remapTextToSegments('Bold edited plain', original, {});
+
+			expect(result).toHaveLength(2);
+			expect(result[0].paragraphProperties).toBe(paragraphProperties);
+			expect(result[1].paragraphProperties).toBeUndefined();
+		});
+
+		it('keeps paragraph metadata when all paragraph text is deleted', () => {
+			const paragraphProperties = { paragraphSpacingBefore: 4 };
+			const original: TextSegment[] = [
+				{
+					text: 'Delete me',
+					style: {},
+					paragraphLevel: 1,
+					paragraphProperties,
+				},
+			];
+
+			const result = remapTextToSegments('', original, {});
+
+			expect(result[0].text).toBe('');
+			expect(result[0].paragraphLevel).toBe(1);
+			expect(result[0].paragraphProperties).toBe(paragraphProperties);
+		});
+
+		it('does not impose paragraph metadata policy on a newly appended paragraph', () => {
+			const paragraphProperties = { paragraphSpacingAfter: 9 };
+			const original: TextSegment[] = [
+				{
+					text: 'Existing',
+					style: { bold: true },
+					paragraphLevel: 2,
+					paragraphProperties,
+				},
+			];
+
+			const result = remapTextToSegments('Existing\nNew', original, {});
+			const paragraphs = result.filter((segment) => !segment.isParagraphBreak);
+
+			expect(paragraphs[0].paragraphProperties).toBe(paragraphProperties);
+			expect(paragraphs[1].style.bold).toBeTruthy();
+			expect(paragraphs[1].paragraphLevel).toBeUndefined();
+			expect(paragraphs[1].paragraphProperties).toBeUndefined();
+		});
+
+		it('does not copy marker-carried paragraph metadata to an appended paragraph', () => {
+			const paragraphProperties = { paragraphSpacingAfter: 9 };
+			const original: TextSegment[] = [
+				{
+					text: '1.',
+					style: {},
+					bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+					paragraphLevel: 2,
+					paragraphProperties,
+					endParaRunProperties: { '@_sz': '1800' },
+				},
+				seg('Item'),
+			];
+
+			const result = remapTextToSegments('1.Item\n1.New', original, {});
+			const lastBreakIndex = result.reduce(
+				(index, segment, current) => (segment.isParagraphBreak ? current : index),
+				-1,
+			);
+			const appended = result[lastBreakIndex + 1];
+
+			expect(appended?.bulletInfo).toStrictEqual({
+				autoNumType: 'arabicPeriod',
+				paragraphIndex: 0,
+			});
+			expect(appended?.paragraphLevel).toBeUndefined();
+			expect(appended?.paragraphProperties).toBeUndefined();
+			expect(appended?.endParaRunProperties).toBeUndefined();
+		});
+
+		it('keeps metadata carried by an empty non-final paragraph terminator', () => {
+			const paragraphProperties = { paragraphSpacingAfter: 7 };
+			const endParaRunProperties = { '@_sz': '1400' };
+			const original: TextSegment[] = [
+				{
+					text: '\n',
+					style: { fontSize: 14 },
+					isParagraphBreak: true,
+					paragraphProperties,
+					endParaRunProperties,
+				},
+				seg('After'),
+			];
+
+			const result = remapTextToSegments('\nAfter edit', original, {});
+
+			expect(result[0].text).toBe('');
+			expect(result[0].paragraphProperties).toBe(paragraphProperties);
+			expect(result[0].endParaRunProperties).toBe(endParaRunProperties);
+		});
+	});
+
 	describe('segment metadata preservation', () => {
 		it('preserves equationXml on an untouched commit (click in, click away)', () => {
 			const omml = { 'm:oMath': { 'm:r': { 'm:t': 'x' } } };

--- a/packages/shared/src/render/remap-text.ts
+++ b/packages/shared/src/render/remap-text.ts
@@ -57,6 +57,38 @@ function copySegmentMetadata(from: TextSegment, to: TextSegment): TextSegment {
 }
 
 /**
+ * Restore paragraph-scoped metadata on the first remapped run. Core and the
+ * save writer deliberately carry these values on that run only; remapping the
+ * characters must not turn an authored paragraph back into a default one.
+ */
+function restoreParagraphMetadata(
+	from: TextSegment | undefined,
+	segments: TextSegment[],
+): TextSegment[] {
+	if (segments.length === 0) {
+		return segments;
+	}
+	const [first, ...rest] = segments;
+	const restored = { ...first };
+	// `remapParagraph` may itself return a donor segment. Clear its paragraph
+	// fields first so an extra paragraph cannot accidentally inherit metadata
+	// merely because it reused the final paragraph for run styling.
+	delete restored.paragraphLevel;
+	delete restored.paragraphProperties;
+	delete restored.endParaRunProperties;
+	if (from?.paragraphLevel !== undefined) {
+		restored.paragraphLevel = from.paragraphLevel;
+	}
+	if (from?.paragraphProperties !== undefined) {
+		restored.paragraphProperties = from.paragraphProperties;
+	}
+	if (from?.endParaRunProperties !== undefined) {
+		restored.endParaRunProperties = from.endParaRunProperties;
+	}
+	return [restored, ...rest];
+}
+
+/**
  * Strategy:
  * 1. Split both original segments and new text into paragraphs by "\n".
  * 2. Distribute new characters proportionally across segments.
@@ -74,19 +106,26 @@ export function remapTextToSegments(
 		return [{ text: newText, style: fallbackStyle }];
 	}
 
-	// Split original segments into paragraphs by paragraph-break markers.
-	const originalParagraphs: TextSegment[][] = [[]];
+	// Split original segments into paragraphs by paragraph-break markers. Keep
+	// each terminator because an authored empty paragraph has no content run, so
+	// core carries its paragraph metadata on the terminator itself.
+	const originalParagraphs: Array<{ segments: TextSegment[]; terminator?: TextSegment }> = [
+		{ segments: [] },
+	];
 	for (const seg of originalSegments) {
 		if (seg.text === '\n' || seg.isParagraphBreak) {
-			originalParagraphs.push([]);
+			originalParagraphs[originalParagraphs.length - 1].terminator = seg;
+			originalParagraphs.push({ segments: [] });
 		} else {
-			originalParagraphs[originalParagraphs.length - 1].push(seg);
+			originalParagraphs[originalParagraphs.length - 1].segments.push(seg);
 		}
 	}
 
 	const newParagraphTexts = newText.split('\n');
 
-	const firstContentSeg = originalParagraphs.flat().find((s) => s.text.trim().length > 0);
+	const firstContentSeg = originalParagraphs
+		.flatMap((paragraph) => paragraph.segments)
+		.find((s) => s.text.trim().length > 0);
 	const baseFallbackStyle: TextStyle = firstContentSeg?.style
 		? { ...firstContentSeg.style }
 		: fallbackStyle;
@@ -188,19 +227,23 @@ export function remapTextToSegments(
 	}
 
 	const output: TextSegment[] = [];
-	const lastOrigPara = originalParagraphs[originalParagraphs.length - 1];
+	const lastOrigPara = originalParagraphs[originalParagraphs.length - 1]?.segments;
 
 	for (let pi = 0; pi < newParagraphTexts.length; pi++) {
 		if (pi > 0) {
-			const precedingOrigPara = originalParagraphs[pi - 1] ?? [];
+			const precedingOrigPara = originalParagraphs[pi - 1]?.segments ?? [];
 			const breakStyle = precedingOrigPara[0]?.style
 				? { ...precedingOrigPara[0].style }
 				: { ...baseFallbackStyle };
 			output.push({ text: '\n', style: breakStyle, isParagraphBreak: true });
 		}
 
-		const origPara = originalParagraphs[pi] ?? lastOrigPara ?? [];
-		const paraSegments = remapParagraph(newParagraphTexts[pi], origPara);
+		const originalParagraph = originalParagraphs[pi];
+		const origPara = originalParagraph?.segments ?? lastOrigPara ?? [];
+		const paraSegments = restoreParagraphMetadata(
+			originalParagraph?.segments[0] ?? originalParagraph?.terminator,
+			remapParagraph(newParagraphTexts[pi], origPara),
+		);
 		output.push(...paraSegments);
 	}
 


### PR DESCRIPTION
## Summary

- preserve paragraph properties, list level, and end-paragraph run properties when existing text is remapped after an edit
- retain metadata carried by the terminator of an empty non-final paragraph
- keep paragraph metadata on the first remapped run only
- leave newly appended paragraph inheritance as a separate editing-policy change

## User-visible bug

A normal inline text edit rebuilt the paragraph from its text and run style but dropped the paragraph-scoped state stored on its first segment. After blur and save, authored indentation, spacing before/after, line spacing, paragraph level, and `a:endParaRPr` could disappear even when the paragraph structure had not changed.

The fix stays in the shared remapper used across the viewer bindings and follows core's existing first-segment ownership model. It does not change auto-number sequencing, generated marker handling, soft line breaks, or Enter-created paragraph inheritance. Structural insertion/deletion remains positional because the remapper receives flat text without paragraph identities. Angular's separate ordinary inline-commit path, which clears `textSegments`, is also outside this PR.

## Validation

- `vitest run packages/shared/src/render/remap-text.test.ts` (26 passed)
- shared suite excluding two local Node 25 web-storage environment failures (477 files, 7,317 tests passed; 2 files and 3 tests skipped)
- `npm run typecheck --workspace=pptx-viewer-shared`
- `npm run build --workspace=pptx-viewer-shared`
- manual browser save/reopen on real PPTX fixtures: retained exact paragraph margins, hanging indent, before/after spacing, line height, and `lvl` in both CSS and OOXML

This is my first open-source contribution series, so guidance on scope or repository conventions is very welcome.