### PR TITLE
fix(react,shared): toggle shortcuts from selected text

### DIFF
--- a/packages/react/src/viewer/components/ElementRenderer.formattext.test.tsx
+++ b/packages/react/src/viewer/components/ElementRenderer.formattext.test.tsx
@@ -90,6 +90,18 @@ function getInlineEditor(): HTMLElement {
 	return editor as HTMLElement;
 }
 
+function selectSegment(editor: HTMLElement, index: number): void {
+	const segment = editor.querySelector<HTMLElement>(`[data-seg-idx="${String(index)}"]`);
+	if (!segment) {
+		throw new Error(`segment ${String(index)} not rendered`);
+	}
+	const range = document.createRange();
+	range.selectNodeContents(segment);
+	const selection = window.getSelection();
+	selection?.removeAllRanges();
+	selection?.addRange(range);
+}
+
 describe('elementRenderer - inline formatting shortcut wiring', () => {
 	it('toggles bold through onFormatText on Ctrl+B while inline editing', () => {
 		const onFormatText = vi.fn<(updates: Partial<TextStyle>) => void>();
@@ -113,6 +125,40 @@ describe('elementRenderer - inline formatting shortcut wiring', () => {
 		expect(onFormatText.mock.calls[0][0]).toStrictEqual({ italic: false });
 		expect(onFormatText.mock.calls[1][0]).toStrictEqual({ underline: true });
 	});
+
+	it.each([
+		{ key: 'b', property: 'bold', firstValue: true, selectedValue: false, expected: true },
+		{ key: 'b', property: 'bold', firstValue: false, selectedValue: true, expected: false },
+		{ key: 'i', property: 'italic', firstValue: true, selectedValue: false, expected: true },
+		{ key: 'i', property: 'italic', firstValue: false, selectedValue: true, expected: false },
+		{ key: 'u', property: 'underline', firstValue: true, selectedValue: false, expected: true },
+		{ key: 'u', property: 'underline', firstValue: false, selectedValue: true, expected: false },
+	] as const)(
+		'toggles $property from the selected non-first run',
+		({ key, property, firstValue, selectedValue, expected }) => {
+			const onFormatText = vi.fn<(updates: Partial<TextStyle>) => void>();
+			mount(
+				makeProps({
+					element: {
+						...makeTextElement(),
+						text: 'Always Target',
+						textSegments: [
+							{ text: 'Always ', style: { [property]: firstValue } },
+							{ text: 'Target', style: { [property]: selectedValue } },
+						],
+					} as PptxElement,
+					onFormatText,
+				}),
+			);
+
+			const editor = getInlineEditor();
+			selectSegment(editor, 1);
+			pressShortcut(editor, key);
+
+			expect(onFormatText).toHaveBeenCalledOnce();
+			expect(onFormatText.mock.calls[0][0]).toStrictEqual({ [property]: expected });
+		},
+	);
 
 	it('is inert when no handler is provided', () => {
 		mount(makeProps({ onFormatText: undefined }));

--- a/packages/react/src/viewer/components/elements/InlineTextEditor.tsx
+++ b/packages/react/src/viewer/components/elements/InlineTextEditor.tsx
@@ -1,6 +1,6 @@
 import type { PptxElement, TextStyle } from 'pptx-viewer-core';
 import { hasTextProperties } from 'pptx-viewer-core';
-import { placeCaretAtEnd, readEditableText } from 'pptx-viewer-shared';
+import { getInlineEditorSelection, placeCaretAtEnd, readEditableText } from 'pptx-viewer-shared';
 import React, { useRef, useEffect, useLayoutEffect, useCallback } from 'react';
 
 import { DEFAULT_TEXT_COLOR } from '../../constants';
@@ -175,6 +175,20 @@ export function InlineTextEditor({
 		transformOrigin: warpStyle?.transformOrigin || 'center',
 	};
 
+	const nextInlineStyleValue = (property: 'bold' | 'italic' | 'underline'): boolean => {
+		if (!hasTextProperties(element)) {
+			return true;
+		}
+		// Range formatting is based on the first selected run, not the first run
+		// in the text box. Keep the existing first-run fallback for a collapsed caret.
+		const selection = getInlineEditorSelection(element.textSegments);
+		const segment = selection
+			? element.textSegments?.[selection.startSegIdx]
+			: element.textSegments?.[0];
+		const style = segment?.style ?? element.textStyle;
+		return !style?.[property];
+	};
+
 	return (
 		<div
 			ref={editorRef}
@@ -208,17 +222,15 @@ export function InlineTextEditor({
 					if (key === 'b' || key === 'i' || key === 'u') {
 						e.preventDefault();
 						e.stopPropagation();
-						const seg = hasTextProperties(element) ? element.textSegments?.[0] : undefined;
-						const ts = seg?.style ?? (hasTextProperties(element) ? element.textStyle : undefined);
 						switch (key) {
 							case 'b':
-								onFormatText({ bold: !ts?.bold });
+								onFormatText({ bold: nextInlineStyleValue('bold') });
 								break;
 							case 'i':
-								onFormatText({ italic: !ts?.italic });
+								onFormatText({ italic: nextInlineStyleValue('italic') });
 								break;
 							case 'u':
-								onFormatText({ underline: !ts?.underline });
+								onFormatText({ underline: nextInlineStyleValue('underline') });
 								break;
 						}
 						return;

--- a/packages/react/src/viewer/utils/inline-selection-utils.test.ts
+++ b/packages/react/src/viewer/utils/inline-selection-utils.test.ts
@@ -1,7 +1,8 @@
+// @vitest-environment happy-dom
 import type { TextSegment, TextStyle } from 'pptx-viewer-core';
 import { describe, it, expect } from 'vitest';
 
-import { applyStyleToSelectedSegments } from './inline-selection-utils';
+import { applyStyleToSelectedSegments, getInlineEditorSelection } from './inline-selection-utils';
 import type { InlineTextSelection } from './inline-selection-utils';
 
 function seg(text: string, style: Partial<TextStyle> = {}): TextSegment {
@@ -197,5 +198,164 @@ describe('applyStyleToSelectedSegments', () => {
 		expect(newSelection.startOffset).toBe(0);
 		expect(newSelection.endSegIdx).toBe(3);
 		expect(newSelection.endOffset).toBe(2);
+	});
+});
+
+describe('getInlineEditorSelection', () => {
+	function mountEditor(segments: TextSegment[], rendered = segments.map((_, index) => index)) {
+		const editor = document.createElement('div');
+		editor.dataset.inlineEditor = '';
+		for (const index of rendered) {
+			const span = document.createElement('span');
+			span.dataset.segIdx = String(index);
+			span.textContent = segments[index].text;
+			editor.appendChild(span);
+		}
+		document.body.appendChild(editor);
+		return editor;
+	}
+
+	function select(start: Node, startOffset: number, end: Node, endOffset: number): void {
+		const range = document.createRange();
+		range.setStart(start, startOffset);
+		range.setEnd(end, endOffset);
+		const selection = window.getSelection()!;
+		selection.removeAllRanges();
+		selection.addRange(range);
+	}
+
+	it('moves a boundary at the end of one run to the selected next run', () => {
+		const segments = [seg('First'), seg(' '), seg('item')];
+		const editor = mountEditor(segments);
+		select(editor.childNodes[1].firstChild!, 1, editor.childNodes[2].firstChild!, 4);
+
+		expect(getInlineEditorSelection(segments)).toStrictEqual({
+			startSegIdx: 2,
+			startOffset: 0,
+			endSegIdx: 2,
+			endOffset: 4,
+		});
+		editor.remove();
+	});
+
+	it('moves a boundary at the start of one run to the selected previous run', () => {
+		const segments = [seg('First'), seg(' '), seg('item')];
+		const editor = mountEditor(segments);
+		select(editor.childNodes[0].firstChild!, 0, editor.childNodes[1].firstChild!, 0);
+
+		expect(getInlineEditorSelection(segments)).toStrictEqual({
+			startSegIdx: 0,
+			startOffset: 0,
+			endSegIdx: 0,
+			endOffset: 5,
+		});
+		editor.remove();
+	});
+
+	it('skips non-rendered paragraph separators at a boundary', () => {
+		const segments = [seg('A'), paraBrk(), seg('B')];
+		const editor = mountEditor(segments, [0, 2]);
+		select(editor.childNodes[0].firstChild!, 1, editor.childNodes[1].firstChild!, 1);
+
+		expect(getInlineEditorSelection(segments)).toStrictEqual({
+			startSegIdx: 2,
+			startOffset: 0,
+			endSegIdx: 2,
+			endOffset: 1,
+		});
+		editor.remove();
+	});
+
+	it('skips rendered empty runs at a boundary', () => {
+		const segments = [seg('A'), seg(''), seg(''), seg('B')];
+		const editor = mountEditor(segments);
+		select(editor.childNodes[0].firstChild!, 1, editor.childNodes[3].firstChild!, 1);
+
+		expect(getInlineEditorSelection(segments)).toStrictEqual({
+			startSegIdx: 3,
+			startOffset: 0,
+			endSegIdx: 3,
+			endOffset: 1,
+		});
+		editor.remove();
+	});
+
+	it('normalizes a backwards browser selection at a run boundary', () => {
+		const segments = [seg('First'), seg(' '), seg('item')];
+		const editor = mountEditor(segments);
+		const selection = window.getSelection()!;
+		selection.setBaseAndExtent(
+			editor.childNodes[2].firstChild!,
+			4,
+			editor.childNodes[1].firstChild!,
+			1,
+		);
+
+		expect(getInlineEditorSelection(segments)).toStrictEqual({
+			startSegIdx: 2,
+			startOffset: 0,
+			endSegIdx: 2,
+			endOffset: 4,
+		});
+		editor.remove();
+	});
+
+	it('returns null for a structural range with no selected characters', () => {
+		const segments = [seg('A'), seg(''), seg('B')];
+		const editor = mountEditor(segments);
+		select(editor.childNodes[0].firstChild!, 1, editor.childNodes[2].firstChild!, 0);
+
+		expect(getInlineEditorSelection(segments)).toBeNull();
+		editor.remove();
+	});
+
+	it.each([
+		{ name: 'paragraph separator', segment: paraBrk() },
+		{
+			name: 'display-only bullet marker',
+			segment: { text: '• ', style: {}, bulletInfo: { char: '•' } } as TextSegment,
+		},
+	])('returns null when only a $name is selected', ({ segment }) => {
+		const segments = [seg('A'), segment];
+		const editor = mountEditor(segments);
+		select(
+			editor.childNodes[0].firstChild!,
+			1,
+			editor.childNodes[1].firstChild!,
+			segment.text.length,
+		);
+
+		expect(getInlineEditorSelection(segments)).toBeNull();
+		editor.remove();
+	});
+
+	it('uses the live DOM length after a run grows during editing', () => {
+		const segments = [seg('A'), seg('B')];
+		const editor = mountEditor(segments);
+		editor.childNodes[0].textContent = 'AAAA';
+		select(editor.childNodes[0].firstChild!, 2, editor.childNodes[1].firstChild!, 1);
+
+		expect(getInlineEditorSelection(segments)).toStrictEqual({
+			startSegIdx: 0,
+			startOffset: 2,
+			endSegIdx: 1,
+			endOffset: 1,
+		});
+		editor.remove();
+	});
+
+	it('uses live text typed into an initially empty run', () => {
+		const segments = [seg('')];
+		const editor = mountEditor(segments);
+		editor.childNodes[0].textContent = 'Typed';
+		select(editor.childNodes[0].firstChild!, 0, editor.childNodes[0].firstChild!, 5);
+
+		expect(getInlineEditorSelection(segments)).toStrictEqual({
+			startSegIdx: 0,
+			startOffset: 0,
+			endSegIdx: 0,
+			endOffset: 5,
+		});
+		editor.remove();
 	});
 });

--- a/packages/shared/src/render/inline-editor-selection.ts
+++ b/packages/shared/src/render/inline-editor-selection.ts
@@ -1,0 +1,132 @@
+import type { TextSegment } from 'pptx-viewer-core';
+
+import { isBulletMarkerSegment } from './bullet-toggle';
+import type { InlineTextSelection } from './inline-selection-utils';
+
+interface SegmentPosition {
+	segIdx: number;
+	offset: number;
+	span: Element;
+	textLength: number;
+}
+
+/**
+ * Read the current browser selection and, if it falls within an
+ * `[data-inline-editor]` element, return the segment-level range.
+ *
+ * Returns `null` when there is no editable text selected, the selection is
+ * collapsed (just a cursor), or the selection is outside the inline editor.
+ */
+export function getInlineEditorSelection(
+	segments: TextSegment[] | undefined,
+): InlineTextSelection | null {
+	if (!segments?.length) {
+		return null;
+	}
+	const selection = window.getSelection();
+	if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+		return null;
+	}
+
+	// A Range is always in document order, including for a backwards selection.
+	const range = selection.getRangeAt(0);
+	const editor = findEditorContainer(range.startContainer);
+	if (!editor || !editor.contains(range.endContainer) || range.toString().length === 0) {
+		return null;
+	}
+	const start = getSegmentPosition(editor, range.startContainer, range.startOffset, segments);
+	const end = getSegmentPosition(editor, range.endContainer, range.endOffset, segments);
+	if (!start || !end) {
+		return null;
+	}
+
+	const renderedSpans = Array.from(editor.querySelectorAll('[data-seg-idx]'));
+	const startSpanIndex = renderedSpans.indexOf(start.span);
+	const endSpanIndex = renderedSpans.indexOf(end.span);
+	if (startSpanIndex < 0 || endSpanIndex < startSpanIndex) {
+		return null;
+	}
+	const selectedSpans = renderedSpans.slice(startSpanIndex, endSpanIndex + 1);
+	const first = selectedSpans.find(
+		(span) =>
+			isEditableSpan(span, segments) && (span !== start.span || start.offset < start.textLength),
+	);
+	const last = [...selectedSpans]
+		.reverse()
+		.find((span) => isEditableSpan(span, segments) && (span !== end.span || end.offset > 0));
+	if (!first || !last) {
+		return null;
+	}
+
+	return {
+		startSegIdx: getSegmentIndex(first),
+		startOffset: first === start.span ? start.offset : 0,
+		endSegIdx: getSegmentIndex(last),
+		endOffset: last === end.span ? end.offset : (last.textContent?.length ?? 0),
+	};
+}
+
+function isEditableSpan(span: Element, segments: TextSegment[]): boolean {
+	const segment = segments[getSegmentIndex(span)];
+	return Boolean(
+		segment &&
+		!segment.isParagraphBreak &&
+		segment.text !== '\n' &&
+		!isBulletMarkerSegment(segment) &&
+		(span.textContent?.length ?? 0) > 0,
+	);
+}
+
+function getSegmentIndex(span: Element): number {
+	return Number(span.getAttribute('data-seg-idx'));
+}
+
+function findEditorContainer(node: Node): Element | null {
+	const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+	return element?.closest('[data-inline-editor]') ?? null;
+}
+
+function getSegmentPosition(
+	editor: Element,
+	node: Node,
+	offset: number,
+	segments: TextSegment[],
+): SegmentPosition | null {
+	const element = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
+	const span = element?.closest('[data-seg-idx]');
+	if (!span || !editor.contains(span)) {
+		return null;
+	}
+	const segIdx = getSegmentIndex(span);
+	if (!Number.isInteger(segIdx) || segIdx < 0 || segIdx >= segments.length) {
+		return null;
+	}
+	return {
+		segIdx,
+		offset: getTextOffsetWithin(span, node, offset),
+		span,
+		textLength: span.textContent?.length ?? 0,
+	};
+}
+
+function getTextOffsetWithin(container: Element, targetNode: Node, targetOffset: number): number {
+	if (targetNode === container || targetNode.nodeType === Node.ELEMENT_NODE) {
+		const parent = targetNode === container ? container : targetNode;
+		let count = 0;
+		for (let index = 0; index < targetOffset && index < parent.childNodes.length; index++) {
+			count += parent.childNodes[index].textContent?.length ?? 0;
+		}
+		return count;
+	}
+
+	const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+	let charCount = 0;
+	let node: Node | null;
+	while ((node = walker.nextNode())) {
+		if (node === targetNode) {
+			return charCount + targetOffset;
+		}
+		charCount += (node as Text).length;
+	}
+	return charCount;
+}

--- a/packages/shared/src/render/inline-selection-utils.ts
+++ b/packages/shared/src/render/inline-selection-utils.ts
@@ -6,6 +6,8 @@
  */
 import type { TextSegment, TextStyle } from 'pptx-viewer-core';
 
+export { getInlineEditorSelection } from './inline-editor-selection';
+
 /** Describes which segments (and offsets within them) are selected. */
 export interface InlineTextSelection {
 	startSegIdx: number;
@@ -25,121 +27,6 @@ export function getPendingSelectionRestore(): InlineTextSelection | null {
 	const sel = pendingRestore;
 	pendingRestore = null;
 	return sel;
-}
-
-/**
- * Read the current browser selection and, if it falls within an
- * `[data-inline-editor]` element, return the segment-level range.
- *
- * Returns `null` when there is no selection, the selection is collapsed
- * (just a cursor), or the selection is outside the inline editor.
- */
-export function getInlineEditorSelection(
-	segments: TextSegment[] | undefined,
-): InlineTextSelection | null {
-	if (!segments || segments.length === 0) {
-		return null;
-	}
-
-	const sel = window.getSelection();
-	if (!sel || sel.rangeCount === 0 || sel.isCollapsed) {
-		return null;
-	}
-
-	const { anchorNode, anchorOffset, focusNode, focusOffset } = sel;
-	if (!anchorNode || !focusNode) {
-		return null;
-	}
-
-	const editor = findEditorContainer(anchorNode);
-	if (!editor || !editor.contains(focusNode)) {
-		return null;
-	}
-
-	const anchorInfo = getSegmentPosition(editor, anchorNode, anchorOffset, segments);
-	const focusInfo = getSegmentPosition(editor, focusNode, focusOffset, segments);
-	if (!anchorInfo || !focusInfo) {
-		return null;
-	}
-
-	// Normalize so start <= end.
-	const [start, end] =
-		anchorInfo.absOffset <= focusInfo.absOffset ? [anchorInfo, focusInfo] : [focusInfo, anchorInfo];
-
-	return {
-		startSegIdx: start.segIdx,
-		startOffset: start.offsetInSeg,
-		endSegIdx: end.segIdx,
-		endOffset: end.offsetInSeg,
-	};
-}
-
-function findEditorContainer(node: Node): Element | null {
-	const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
-	return el?.closest('[data-inline-editor]') ?? null;
-}
-
-function getSegmentPosition(
-	editor: Element,
-	node: Node,
-	offset: number,
-	segments: TextSegment[],
-): { segIdx: number; offsetInSeg: number; absOffset: number } | null {
-	const el = node.nodeType === Node.ELEMENT_NODE ? (node as Element) : node.parentElement;
-	if (!el) {
-		return null;
-	}
-
-	const segSpan = el.closest('[data-seg-idx]');
-	if (!segSpan || !editor.contains(segSpan)) {
-		return null;
-	}
-
-	const segIdx = parseInt(segSpan.getAttribute('data-seg-idx')!, 10);
-	if (isNaN(segIdx) || segIdx < 0 || segIdx >= segments.length) {
-		return null;
-	}
-
-	const offsetInSeg = getTextOffsetWithin(segSpan, node, offset);
-
-	// Absolute offset = sum of all segment text lengths before this one + offset.
-	let absOffset = 0;
-	for (let i = 0; i < segIdx; i++) {
-		absOffset += segments[i].text.length;
-	}
-	absOffset += offsetInSeg;
-
-	return { segIdx, offsetInSeg, absOffset };
-}
-
-/**
- * Compute the character offset of a DOM position (node + offset) relative to
- * the text content of a container element.
- */
-function getTextOffsetWithin(container: Element, targetNode: Node, targetOffset: number): number {
-	// When the target IS the container (or an element child), offset is a
-	// child-index count, not a character count.
-	if (targetNode === container || targetNode.nodeType === Node.ELEMENT_NODE) {
-		const parent = targetNode === container ? container : targetNode;
-		let count = 0;
-		for (let i = 0; i < targetOffset && i < parent.childNodes.length; i++) {
-			count += (parent.childNodes[i].textContent || '').length;
-		}
-		return count;
-	}
-
-	// Walk text nodes in document order and accumulate lengths until we hit the
-	// target text node.
-	const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
-	let charCount = 0;
-	let node: Node | null;
-	while ((node = walker.nextNode())) {
-		if (node === targetNode) {
-			return charCount + targetOffset;
-		}
-		charCount += (node as Text).length;
-	}
-	return charCount;
 }
 
 /**

--- a/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
@@ -6,7 +6,7 @@
  * parity bug this pins.
  */
 import type { PptxElement } from 'pptx-viewer-core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { openInlineEditor } from './inline-text-editor';
 
@@ -55,6 +55,88 @@ describe('openInlineEditor caret placement', () => {
 		session.cancel();
 		overlayRoot.remove();
 	});
+
+	it.each([
+		{
+			name: 'ordinary adjacent run',
+			text: 'First item',
+			segments: [
+				{ text: 'First', style: {} },
+				{ text: ' ', style: {} },
+				{ text: 'item', style: {} },
+			],
+			startChild: 1,
+			startOffset: 1,
+			endChild: 2,
+			endOffset: 4,
+			expectedIndex: 2,
+		},
+		{
+			name: 'paragraph separator',
+			text: 'AB',
+			segments: [
+				{ text: 'A', style: {} },
+				{ text: '\n', style: {}, isParagraphBreak: true },
+				{ text: 'B', style: {} },
+			],
+			startChild: 0,
+			startOffset: 1,
+			endChild: 2,
+			endOffset: 1,
+			expectedIndex: 2,
+		},
+		{
+			name: 'display-only bullet marker',
+			text: 'Item',
+			segments: [
+				{ text: '• ', style: {}, bulletInfo: { char: '•' } },
+				{ text: 'Item', style: {} },
+			],
+			startChild: 0,
+			startOffset: 2,
+			endChild: 1,
+			endOffset: 4,
+			expectedIndex: 1,
+		},
+	] as const)(
+		'reports only selected text after a $name boundary',
+		({ text, segments, startChild, startOffset, endChild, endOffset, expectedIndex }) => {
+			const overlayRoot = document.createElement('div');
+			document.body.appendChild(overlayRoot);
+			const onSelectionChange = vi.fn();
+			const session = openInlineEditor({
+				doc: document,
+				overlayRoot,
+				box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+				scale: 1,
+				element: {
+					...textElement(),
+					text,
+					textSegments: [...segments],
+				} as PptxElement,
+				onCommit: () => {},
+				onSelectionChange,
+				onClose: () => {},
+			});
+			const range = document.createRange();
+			range.setStart(session.el.childNodes[startChild].firstChild!, startOffset);
+			range.setEnd(session.el.childNodes[endChild].firstChild!, endOffset);
+			const selection = window.getSelection()!;
+			selection.removeAllRanges();
+			selection.addRange(range);
+			session.el.dispatchEvent(new PointerEvent('pointerup'));
+
+			expect(onSelectionChange).toHaveBeenCalledWith({
+				startSegIdx: expectedIndex,
+				startOffset: 0,
+				endSegIdx: expectedIndex,
+				endOffset,
+			});
+
+			session.cancel();
+			overlayRoot.remove();
+		},
+	);
 });
 
 describe('openInlineEditor commit ordering', () => {


### PR DESCRIPTION
## What does this change?

Fixes Ctrl/Cmd+B/I/U in the React inline editor when the selected text is not the first formatted run in the text box. The toggle direction now comes from the first selected editable run, and shared DOM selection mapping normalizes exact run boundaries without treating paragraph separators, rendered bullet markers, or empty runs as selected text.

## User-visible bug

Given `First item` where the first run and the selected `item` run have different formatting, the shortcut always inspected the first run. A user could unbold `item`, but the next Cmd+B could emit "unbold" again instead of restoring bold. Italic and underline had the same problem.

Mouse selection adds one important boundary case: selecting `item` can be represented by the browser as a range beginning at the end of the preceding space run. The shared selection mapper now resolves endpoints from the rendered DOM order and live text lengths, then skips non-editable paragraph, bullet-marker, and empty spans.

This follows the existing design rather than changing it:

- selected-range formatting still applies only to the selected characters
- a collapsed caret still uses the existing whole-element fallback
- mixed selections still use the first relevant run to choose the toggle direction
- live contenteditable text remains authoritative until commit

The DOM mapping was extracted into a focused shared module so the existing selection utility stays below the repository's source-file size limit.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

| Binding | Affected? | Fixed / implemented here? | Notes |
| --- | --- | --- | --- |
| React (`packages/react`) | yes | yes | Live demo: selected non-first run toggled B/I/U off and on; adjacent runs stayed unchanged; blur and saved PPTX preserved the styles. |
| Vue (`packages/vue`) | no | no change | Live demo and existing tests confirm its whole-element shortcut toggles off/on correctly. It has no selected-run formatting path. |
| Angular (`packages/angular`) | no | no change | Live demo confirms its textarea-based whole-element shortcut toggles off/on correctly. It has no selected-run formatting path. |
| Svelte (`packages/svelte`) | no | no change | Live demo confirms inline B/I/U is not persisted. That pre-existing feature gap is separate from this selected-run bug. |
| Vanilla (`packages/vanilla`) | yes, shared range mapping | yes | Uses the shared mapper for toolbar selection state. Added boundary regressions for ordinary runs, paragraph separators, and display-only bullet markers. Inline B/I/U shortcuts themselves remain a separate pre-existing gap. |

### UI fix

- [x] I reproduced the bug (or confirmed its absence) in every binding above
- [x] Every affected binding is fixed in this PR

---

## Testing

- [x] Unit tests added or updated for each binding I changed
- [x] Regression test added that fails without this change
- [ ] Framework-neutral e2e spec added or updated in `e2e/`
- [ ] `bun run e2e` passes locally, or I have named the projects I ran

No e2e spec was added because this corrects an existing React shortcut rather than adding a cross-binding UI feature. The exact mouse-selection, B/I/U off/on, blur, save, reopen, and OOXML persistence flow was exercised in the React demo. Structural selection boundaries are covered in shared-path React and Vanilla unit tests.

Focused final checks:

- React: 34 tests passed across shortcut wiring, DOM selection mapping, and live inline-edit formatting
- Vanilla: 5 inline-editor tests passed
- Vue: 5 existing inline-shortcut tests passed
- shared, React, and Vanilla typechecks passed
- shared and React production builds passed
- full React, shared, and Vanilla suites were also run; the only failures were the local Node 25 experimental `localStorage` global, and those exact files passed with `NODE_OPTIONS=--no-experimental-webstorage`

## Checks run locally

- [x] `bun run lint` (equivalent local `oxlint` command; Bun is unavailable in this environment)
- [x] `bun run fmt:check` (equivalent local `oxfmt --check` command)
- [ ] `bun run typecheck` (affected package typechecks passed individually)
- [ ] `bun run test` (focused and package suites described above)

## Conventional Commits

- [x] My commit messages follow Conventional Commits

## Screenshots / recordings

This is a keyboard and selection-state correction rather than a visual layout change. The live browser review used real mouse selection and verified computed run styles before and after every shortcut. The saved PPTX was reopened, and its OOXML retained `b="1"`, `i="1"`, and `u="sng"` on the selected run.

This is part of my first open-source contribution series, so guidance on scope or repository conventions is very welcome.
