### PR TITLE
fix: preserve table-cell font sizes across renderers

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -63,10 +63,17 @@ interface CellPaint {
 	background: string;
 	/** Computed `color`, i.e. what the cell's own text actually paints in. */
 	color: string;
+	fontSize: number;
 	borderTop: string;
 	borderTopWidth: number;
-	/** Per-run spans inside the cell: their text, weight, colour and family. */
-	runs: Array<{ text: string; fontWeight: string; color: string; fontFamily: string }>;
+	/** Per-run spans inside the cell: their text, weight, colour, family and size. */
+	runs: Array<{
+		text: string;
+		fontWeight: string;
+		color: string;
+		fontFamily: string;
+		fontSize: number;
+	}>;
 }
 
 interface TablePaint {
@@ -128,6 +135,7 @@ async function measureTable(page: Page, containing?: string): Promise<TablePaint
 						fontWeight: runStyle.fontWeight,
 						color: runStyle.color,
 						fontFamily: runStyle.fontFamily,
+						fontSize: Number.parseFloat(runStyle.fontSize) || 0,
 					};
 				});
 				cells.push({
@@ -138,6 +146,7 @@ async function measureTable(page: Page, containing?: string): Promise<TablePaint
 					width: rect.width,
 					background: style.backgroundColor,
 					color: style.color,
+					fontSize: Number.parseFloat(style.fontSize) || 0,
 					borderTop: style.borderTopStyle,
 					borderTopWidth: Number.parseFloat(style.borderTopWidth) || 0,
 					runs,
@@ -305,6 +314,35 @@ test.describe('table styling', () => {
 		expect(Number(plain!.fontWeight) || 400).toBeLessThan(700);
 		expect(distance(bold!.color, { r: 192, g: 0, b: 0 })).toBeLessThan(30);
 		expect(bold!.fontFamily).toContain('Georgia');
+	});
+
+	test('keeps the authored font size after editing a rich-text cell', async ({ page }) => {
+		await gotoSlide(page, 4);
+		const original = await measureTable(page);
+		const mixed = original.cells.find((cell) => cell.text.includes('Revenue grew 42%'));
+		expect(mixed, 'the mixed-format cell should be rendered').toBeTruthy();
+		const firstRunSize = mixed!.runs.find((run) => run.text.includes('Revenue'))?.fontSize;
+		expect(firstRunSize).toBeGreaterThan(0);
+		expect(firstRunSize).toBeCloseTo(16, 2);
+
+		const cell = canvasCell(page, 'Revenue grew 42%');
+		const cellBox = await cell.boundingBox();
+		expect(cellBox, 'the mixed-format cell should have a layout box').not.toBeNull();
+		await page.mouse.dblclick(cellBox!.x + cellBox!.width / 2, cellBox!.y + cellBox!.height / 2);
+		const input = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('td input')
+			.first();
+		await expect(input).toBeVisible();
+		await input.fill('Edited cell');
+		await input.press('Enter');
+		await expect(canvasCell(page, 'Edited cell')).toBeVisible();
+
+		const edited = await measureTable(page);
+		const editedCell = edited.cells.find((candidate) => candidate.text === 'Edited cell');
+		expect(editedCell, 'the edited cell should be rendered').toBeTruthy();
+		expect(editedCell!.fontSize).toBeCloseTo(firstRunSize!, 2);
 	});
 
 	test('resolves a built-in style GUID the deck does not define', async ({ page }) => {

--- a/packages/angular/src/viewer/table-cell-style.ts
+++ b/packages/angular/src/viewer/table-cell-style.ts
@@ -133,8 +133,7 @@ export function cellRunStyle(style: PptxTableCellStyle | undefined): StyleMap {
 	}
 	const map: StyleMap = {};
 	if (style.fontSize) {
-		// PptxTableCellStyle.fontSize is already in px (converted from EMU).
-		map['font-size'] = `${style.fontSize}px`;
+		map['font-size'] = `${style.fontSize}pt`;
 	}
 	if (style.bold) {
 		map['font-weight'] = 'bold';

--- a/packages/angular/src/viewer/table-renderer.component.test.ts
+++ b/packages/angular/src/viewer/table-renderer.component.test.ts
@@ -578,9 +578,8 @@ describe('cellRunStyle', () => {
 		expect(cellRunStyle({ color: '#FF0000' })['color']).toBe('#FF0000');
 	});
 
-	it('maps fontSize to font-size in px', () => {
-		// PptxTableCellStyle.fontSize is already in px (converted from EMU by the parser).
-		expect(cellRunStyle({ fontSize: 14 })['font-size']).toBe('14px');
+	it('maps fractional cell font sizes to CSS points', () => {
+		expect(cellRunStyle({ fontSize: 14.5 })['font-size']).toBe('14.5pt');
 	});
 
 	it('does not include layout properties like background-color', () => {

--- a/packages/core/src/converter/SvgExporter.test.ts
+++ b/packages/core/src/converter/SvgExporter.test.ts
@@ -371,7 +371,7 @@ describe('svgExporter', () => {
 					tableData: {
 						rows: [
 							{
-								cells: [{ text: 'Name', style: { bold: true } }, { text: 'Score' }],
+								cells: [{ text: 'Name', style: { bold: true, fontSize: 12 } }, { text: 'Score' }],
 							},
 							{
 								cells: [{ text: 'Alice' }, { text: '95' }],
@@ -388,6 +388,8 @@ describe('svgExporter', () => {
 		expect(svg).toContain('>Name</text>');
 		expect(svg).toContain('>Alice</text>');
 		expect(svg).toContain('>95</text>');
+		expect(svg).toContain('font-size="16"');
+		expect(svg).toContain('font-size="18"');
 	});
 
 	// ── Group element ────────────────────────────────────────────

--- a/packages/core/src/converter/SvgExporter.ts
+++ b/packages/core/src/converter/SvgExporter.ts
@@ -440,7 +440,11 @@ function renderTable(el: PptxElement, defaults: ReturnType<typeof resolveDefault
 			const bgColor = cell.style?.backgroundColor ?? 'none';
 			const borderColor = cell.style?.borderColor ?? '#CCCCCC';
 			const textColor = cell.style?.color ?? '#000000';
-			const fontSize = cell.style?.fontSize ?? defaults.defaultFontSize;
+			// Table-cell sizes are stored in points, while the SVG viewBox uses CSS pixels.
+			const fontSize =
+				cell.style?.fontSize !== undefined
+					? cell.style.fontSize * (96 / 72)
+					: defaults.defaultFontSize;
 			const bold = cell.style?.bold;
 
 			parts.push(

--- a/packages/core/src/converter/elements/TableElementProcessor.ts
+++ b/packages/core/src/converter/elements/TableElementProcessor.ts
@@ -179,7 +179,7 @@ export class TableElementProcessor implements ElementProcessor {
 			rules.push(`vertical-align:${style.vAlign}`);
 		}
 		if (style?.fontSize) {
-			rules.push(`font-size:${Math.round(style.fontSize)}px`);
+			rules.push(`font-size:${style.fontSize}pt`);
 		}
 		const safeColor = cssColorSafe(style?.color);
 		if (safeColor) {

--- a/packages/core/src/converter/table-element-processor.test.ts
+++ b/packages/core/src/converter/table-element-processor.test.ts
@@ -173,6 +173,7 @@ describe('tableElementProcessor', () => {
 								backgroundColor: '#FF0000',
 								align: 'center',
 								bold: true,
+								fontSize: 14.5,
 							},
 						},
 					],
@@ -185,6 +186,7 @@ describe('tableElementProcessor', () => {
 		expect(result).not.toBeNull();
 		expect(result).toContain('background:#FF0000');
 		expect(result).toContain('text-align:center');
+		expect(result).toContain('font-size:14.5pt');
 	});
 
 	it('should render first row as header by default', async () => {

--- a/packages/core/src/core/types/table.ts
+++ b/packages/core/src/core/types/table.ts
@@ -27,6 +27,7 @@
  * ```
  */
 export interface PptxTableCellStyle {
+	/** Font size in points (`a:rPr@sz / 100`). */
 	fontSize?: number;
 	bold?: boolean;
 	italic?: boolean;

--- a/packages/react/src/viewer/utils/table-render-data-banding.test.tsx
+++ b/packages/react/src/viewer/utils/table-render-data-banding.test.tsx
@@ -75,6 +75,13 @@ describe('programmatic table banding', () => {
 		expect(cellStyles(markup)[2]).toContain('background-color:#00ff00');
 	});
 
+	it('renders fractional cell font sizes in PowerPoint points', () => {
+		const element = insertedTable();
+		element.tableData!.rows[1].cells[0].style = { fontSize: 14.5 };
+		const markup = renderToStaticMarkup(renderTableElement(element, {}));
+		expect(cellStyles(markup)[2]).toContain('font-size:14.5pt');
+	});
+
 	it('floors an unstyled body cell at the dark slide-text colour', () => {
 		const element = insertedTable();
 		element.tableData!.firstRowHeader = false;

--- a/packages/shared/src/render/table-style.test.ts
+++ b/packages/shared/src/render/table-style.test.ts
@@ -60,7 +60,7 @@ describe('cellStyleToCss', () => {
 			color: '#FF0000',
 		} as PptxTableCellStyle;
 		const css = cellStyleToCss(style);
-		expect(css.fontSize).toBe('18px');
+		expect(css.fontSize).toBe('18pt');
 		expect(css.fontWeight).toBe('bold');
 		expect(css.fontStyle).toBe('italic');
 		expect(css.textDecorationLine).toBe('underline');

--- a/packages/shared/src/render/table-style.ts
+++ b/packages/shared/src/render/table-style.ts
@@ -265,7 +265,9 @@ export function cellStyleToCss(style?: PptxTableCellStyle): TableCellCss {
 		css.fontFamily = style.fontFamily;
 	}
 	if (style.fontSize) {
-		css.fontSize = `${style.fontSize}px`;
+		// Table-cell controls and the OOXML save path use PowerPoint points.
+		// Emitting the same number as CSS pixels makes edited cells 25% smaller.
+		css.fontSize = `${style.fontSize}pt`;
 	}
 	if (style.bold) {
 		css.fontWeight = 'bold';

--- a/packages/svelte/src/viewer/components/table-view.test.ts
+++ b/packages/svelte/src/viewer/components/table-view.test.ts
@@ -204,6 +204,15 @@ describe('tableView', () => {
 		expect(td.style.backgroundSize).toBe('cover');
 	});
 
+	it('renders fractional cell font sizes in PowerPoint points', () => {
+		const tableData: PptxTableData = {
+			columnWidths: [1],
+			rows: [{ cells: [{ text: 'Sized', style: { fontSize: 14.5 } }] }],
+		};
+		const td = mountEl(buildTableElement(tableData)).querySelector('td') as HTMLElement;
+		expect(td.style.fontSize).toBe('14.5pt');
+	});
+
 	it('renders an explicit zero cell margin as zero padding, not the base default', () => {
 		const tableData: PptxTableData = {
 			columnWidths: [1],

--- a/packages/vanilla/src/viewer/render/elements/table.test.ts
+++ b/packages/vanilla/src/viewer/render/elements/table.test.ts
@@ -204,6 +204,15 @@ describe('renderTableElement', () => {
 		expect(td.style.backgroundSize).toBe('cover');
 	});
 
+	it('renders fractional cell font sizes in PowerPoint points', () => {
+		const tableData: PptxTableData = {
+			columnWidths: [1],
+			rows: [{ cells: [{ text: 'Sized', style: { fontSize: 14.5 } }] }],
+		};
+		const td = renderTable(buildTableElement(tableData)).querySelector('td') as HTMLElement;
+		expect(td.style.fontSize).toBe('14.5pt');
+	});
+
 	it('renders an explicit zero cell margin as zero padding, not the base default', () => {
 		// A binding could clobber the shared padding by spreading its own base
 		// style AFTER the computed cell CSS; asserting the exact 0px value (not

--- a/packages/vue/src/viewer/components/TableRenderer.test.ts
+++ b/packages/vue/src/viewer/components/TableRenderer.test.ts
@@ -171,6 +171,15 @@ describe('tableRenderer', () => {
 		expect(cell.attributes('style')).toContain('background-color: #ff0000');
 	});
 
+	it('renders fractional cell font sizes in PowerPoint points', () => {
+		const sized: PptxTableData = {
+			columnWidths: [1],
+			rows: [{ cells: [{ text: 'Sized', style: { fontSize: 14.5 } }] }],
+		};
+		const wrapper = mount(TableRenderer, { props: { element: table(sized), zIndex: 0 } });
+		expect(wrapper.get('td').attributes('style')).toContain('font-size: 14.5pt');
+	});
+
 	it('defaults body-cell text to the dark slide colour when none is set', () => {
 		// Without this fallback an unstyled cell inherits the dark-UI chrome
 		// `foreground` (near-white) and is invisible on a light table.


### PR DESCRIPTION
## What does this change?

Preserves authored table-cell font sizes when rendering and after editing. Table cell sizes are stored in PowerPoint points, but the cell-level fallback was emitted as CSS pixels, so a 12pt cell became 12px instead of 16px when rich runs were replaced by edited plain text.

The point-based contract is now explicit and handled consistently by the five viewers, HTML conversion, and SVG export. This does not add rounding or change the separate pixel-based `TextSegment` path.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

| Binding                      | Affected? | Fixed / implemented here? | Notes |
| ---------------------------- | --------- | ------------------------- | ----- |
| React (`packages/react`)     | yes       | yes                       | Uses the corrected shared cell-style mapper |
| Vue (`packages/vue`)         | yes       | yes                       | Uses the corrected shared cell-style mapper |
| Angular (`packages/angular`) | yes       | yes                       | Uses shared cell styles plus one Angular-specific fallback, both corrected |
| Svelte (`packages/svelte`)   | yes       | yes                       | Uses the corrected shared cell-style mapper |
| Vanilla (`packages/vanilla`) | yes       | yes                       | Uses the corrected shared cell-style mapper |

### UI fix

- [x] I reproduced the bug (or confirmed its absence) in every binding above
- [x] Every affected binding is fixed in this PR

All five bindings run the same regression flow: render an authored 12pt rich-text table cell, edit it to plain text, and verify that its computed size stays 16px.

---

## Testing

- [x] Unit tests added or updated for each binding I changed
- [x] Regression test added that fails without this change
- [x] Framework-neutral e2e spec added or updated in `e2e/`
- [x] Named Playwright projects pass locally: React, Vue, Angular, Svelte, and Vanilla

Checks run locally:

- 253 focused unit tests passed across core, shared, and all five bindings
- `e2e/table-styling.spec.ts`: 45/45 passed across all five Playwright projects
- E2E neutrality check passed
- Formatting and lint checks passed for all changed files
- Type checks passed for core, shared, React, Vue, Angular, Svelte, and Vanilla
- Core, shared, React, and Angular builds passed

Full-suite spot checks also completed 11,415 core tests and 7,347 shared tests. The remaining failures were unrelated environment-sensitive suites: three crypto timeouts and nine Node 25 local-storage failures.

## Checks run locally

- [ ] `bun run lint`
- [ ] `bun run fmt:check`
- [ ] `bun run typecheck`
- [ ] `bun run test`

The equivalent affected-package checks were run directly because Bun is not installed in this local shell; CI will run the repository commands from a clean install.

## Conventional Commits

- [x] My commit messages follow Conventional Commits

## Screenshots / recordings

The framework-neutral browser regression checks computed font size before and after the table-cell edit in all five demos.
