### PR TITLE
fix(angular): preserve rich text through inline edits

### DIFF
--- a/e2e/text-layout-parity.spec.ts
+++ b/e2e/text-layout-parity.spec.ts
@@ -34,7 +34,7 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
-import { fixture, loadDeckAt, slideStage, thumbnail } from './support/deck';
+import { fixture, loadDeck, loadDeckAt, slideStage, thumbnail } from './support/deck';
 import { acrossFrameworks, splitReference } from './support/parity';
 import { diffTextRuns } from './support/text-run-diff';
 import { measureTextRuns } from './support/text-runs';
@@ -95,6 +95,36 @@ function expectRunParity(results: { framework: { name: string }; value: ElementR
 }
 
 test.describe('cross-binding text layout', () => {
+	test('an unchanged inline edit preserves rich runs and list structure', async ({ page }) => {
+		await loadDeck(page, TEXT_LAYOUT);
+		await slideStage(page).waitFor();
+		await page.waitForTimeout(400);
+		const undo = page.getByRole('button', { name: /^undo/iu }).first();
+		await expect(undo).toBeDisabled();
+
+		const target = page
+			.locator('[data-pptx-viewport] [data-element-id]')
+			.filter({ hasText: 'Alpha Beta' })
+			.first();
+		await target.waitFor();
+		const elementId = await target.getAttribute('data-element-id');
+		expect(elementId).not.toBeNull();
+		const before = (await measureTextRuns(page)).find((element) => element.elementId === elementId);
+		expect(before, 'found the rich-text element before editing').toBeDefined();
+
+		await target.dblclick();
+		const editor = page.locator('[data-inline-editor]');
+		await editor.waitFor();
+		const stageBox = (await slideStage(page).boundingBox())!;
+		await page.mouse.click(stageBox.x + stageBox.width * 0.95, stageBox.y + stageBox.height * 0.95);
+		await expect(editor).toBeHidden();
+
+		const after = (await measureTextRuns(page)).find((element) => element.elementId === elementId);
+		expect(after, 'found the rich-text element after editing').toBeDefined();
+		expect(diffTextRuns([before!], [after!]).join('\n')).toBe('');
+		await expect(undo).toBeDisabled();
+	});
+
 	test('autofit, wrap="none", default fonts and run splitting agree run for run', async ({
 		browser,
 	}, testInfo) => {

--- a/packages/angular/src/viewer/master-view-canvas.component.ts
+++ b/packages/angular/src/viewer/master-view-canvas.component.ts
@@ -15,6 +15,7 @@ import type {
 	MasterViewWrite,
 } from '../internal/shared';
 import {
+	buildInlineTextCommitPatch,
 	DEFAULT_MASTER_PAGE_SIZE,
 	deleteMasterViewElements,
 	masterViewPseudoSlide,
@@ -166,9 +167,14 @@ export class MasterViewCanvasComponent {
 	}
 
 	protected commitText(event: { id: string; text: string; height?: number }): void {
+		const element = this.pseudoSlide()?.elements.find((candidate) => candidate.id === event.id);
+		const textPatch = buildInlineTextCommitPatch(element, event.text);
+		if (!textPatch && event.height === undefined) {
+			this.editingId.set(null);
+			return;
+		}
 		this.updateMasterElement(event.id, {
-			text: event.text,
-			textSegments: [],
+			...textPatch,
 			// `a:spAutoFit`: see `slide-canvas.component.ts`'s `commitText`.
 			...(event.height !== undefined ? { height: event.height } : {}),
 		});

--- a/packages/angular/src/viewer/viewer-canvas-editing.service.ts
+++ b/packages/angular/src/viewer/viewer-canvas-editing.service.ts
@@ -17,7 +17,7 @@
 import { inject, Injectable, signal } from '@angular/core';
 import type { InkPptxElement, PptxSlide, PptxTableData, TextStyle } from 'pptx-viewer-core';
 
-import { publishLiveInlineText } from '../internal/shared';
+import { buildInlineTextCommitPatch, publishLiveInlineText } from '../internal/shared';
 import { CollaborationService } from './collaboration.service';
 import { EditorStateService } from './editor-state.service';
 import { textStylePatch } from './inspector-helpers';
@@ -110,15 +110,20 @@ export class ViewerCanvasEditingService {
 		);
 	}
 
-	/** Commit an inline text edit: replace the element's text (one history entry). */
+	/** Commit an inline text edit without flattening its rich-text runs. */
 	onTextCommit(event: { id: string; text: string; height?: number }): void {
 		const host = this.requireHost();
 		// Push any queued interim frame out first so it cannot land after the
 		// committed text and revert it.
 		this.collab.livePatcher.flush();
+		const element = host.activeSlide()?.elements.find((el) => el.id === event.id);
+		const textPatch = buildInlineTextCommitPatch(element, event.text);
+		if (!textPatch && event.height === undefined) {
+			this.editingId.set(null);
+			return;
+		}
 		this.editor.updateElement(host.activeSlideIndex(), event.id, {
-			text: event.text,
-			textSegments: [],
+			...textPatch,
 			// `a:spAutoFit`: the shape's new height, already decided by
 			// `slide-canvas.component.ts`'s `commitText` (it holds the live
 			// editor DOM node this needs to measure).

--- a/packages/shared/src/render/index.ts
+++ b/packages/shared/src/render/index.ts
@@ -1318,6 +1318,8 @@ export * from './editor-mutations';
 export * from './editor-gestures';
 // Read a contenteditable inline-edit surface's plain text back out.
 export * from './inline-text-extract';
+// No-op detection plus rich-run preservation for committed inline text.
+export * from './inline-text-commit';
 
 // inspector option lists (wave 2)
 // Stroke/dash pattern picker: the 12 ST_PresetLineDashVal values.

--- a/packages/shared/src/render/inline-text-commit.test.ts
+++ b/packages/shared/src/render/inline-text-commit.test.ts
@@ -1,0 +1,69 @@
+import type { PptxElement } from 'pptx-viewer-core';
+import { describe, expect, it } from 'vitest';
+
+import { buildInlineTextCommitPatch } from './inline-text-commit';
+
+function textElement(overrides: Partial<PptxElement> = {}): PptxElement {
+	return {
+		id: 'tx_1',
+		type: 'text',
+		x: 0,
+		y: 0,
+		width: 300,
+		height: 40,
+		text: 'Hello',
+		...overrides,
+	} as PptxElement;
+}
+
+describe('buildInlineTextCommitPatch', () => {
+	it('skips an unchanged rich-text commit', () => {
+		const element = textElement({
+			text: 'Alpha Beta\nBulleted item',
+			textSegments: [
+				{ text: 'Alpha ', style: { bold: true } },
+				{ text: 'Beta', style: { italic: true } },
+				{ text: '\n', style: {}, isParagraphBreak: true },
+				{ text: 'Bulleted item', style: {}, bulletInfo: { char: '•' } },
+			],
+		});
+
+		expect(buildInlineTextCommitPatch(element, 'Alpha Beta\nBulleted item')).toBeUndefined();
+	});
+
+	it('preserves rich runs and paragraph metadata while changing text', () => {
+		const bulletInfo = { char: '•' };
+		const paragraphProperties = { paragraphSpacingBefore: 8 };
+		const element = textElement({
+			text: 'Alpha Beta\nBulleted item',
+			textSegments: [
+				{ text: 'Alpha ', style: { bold: true } },
+				{ text: 'Beta', style: { italic: true } },
+				{ text: '\n', style: {}, isParagraphBreak: true },
+				{
+					text: 'Bulleted item',
+					style: { underline: true },
+					bulletInfo,
+					paragraphLevel: 1,
+					paragraphProperties,
+				},
+			],
+		});
+
+		const patch = buildInlineTextCommitPatch(element, 'Alpha expanded Beta\nBulleted item edited');
+		const segments = (patch as typeof element).textSegments!;
+
+		expect(segments.map((segment) => segment.text)).toStrictEqual([
+			'Alpha ',
+			'expanded Beta',
+			'\n',
+			'Bulleted item edited',
+		]);
+		expect(segments[0].style.bold).toBeTruthy();
+		expect(segments[1].style.italic).toBeTruthy();
+		expect(segments[3].style.underline).toBeTruthy();
+		expect(segments[3].bulletInfo).toBe(bulletInfo);
+		expect(segments[3].paragraphLevel).toBe(1);
+		expect(segments[3].paragraphProperties).toBe(paragraphProperties);
+	});
+});

--- a/packages/shared/src/render/inline-text-commit.ts
+++ b/packages/shared/src/render/inline-text-commit.ts
@@ -1,0 +1,33 @@
+import type { PptxElement } from 'pptx-viewer-core';
+import { hasTextProperties } from 'pptx-viewer-core';
+
+import { remapTextToSegments } from './remap-text';
+
+/**
+ * Reconcile a committed plain-text edit with an element's existing rich runs.
+ *
+ * Editor surfaces expose plain text, but the model still owns per-run styles,
+ * bullets, fields and paragraph properties. An unchanged blur is not an edit;
+ * a changed value is remapped onto the authored segments instead of flattening
+ * them.
+ */
+export function buildInlineTextCommitPatch(
+	element: PptxElement | undefined,
+	text: string,
+): Partial<PptxElement> | undefined {
+	if (!element || !hasTextProperties(element)) {
+		return undefined;
+	}
+	const currentText = element.textSegments?.length
+		? element.textSegments
+				.map((segment) => (segment.isParagraphBreak || segment.isLineBreak ? '\n' : segment.text))
+				.join('')
+		: (element.text ?? '');
+	if (currentText === text) {
+		return undefined;
+	}
+	return {
+		text,
+		textSegments: remapTextToSegments(text, element.textSegments, element.textStyle),
+	} as Partial<PptxElement>;
+}


### PR DESCRIPTION
## What does this change?

Preserves authored rich-text runs when Angular commits an inline text edit on a normal slide or in a master/layout. Angular previously replaced `textSegments` with an empty array on every blur, so bold, italic, underline, hyperlinks, bullets, fields, paragraph levels, and paragraph spacing could be flattened even when the user changed only plain text.

The model decision now lives in `pptx-viewer-shared`: unchanged text produces no mutation or undo step, while changed text is remapped onto the existing runs. Angular's two commit paths are thin callers of that shared helper.

This does not change Enter behavior, list numbering policy, or paragraph inheritance. Those are separate behaviors from preserving the existing authored structure.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

| Binding                      | Affected? | Fixed / implemented here? | Notes |
| ---------------------------- | --------- | ------------------------- | ----- |
| React (`packages/react`)     | no        | no                        | Already remaps committed text onto existing runs |
| Vue (`packages/vue`)         | no        | no                        | Already remaps committed text onto existing runs |
| Angular (`packages/angular`) | yes       | yes                       | Fixed for normal slides and master/layout editing |
| Svelte (`packages/svelte`)   | no        | no                        | Already remaps committed text onto existing runs |
| Vanilla (`packages/vanilla`) | no        | no                        | Already remaps committed text onto existing runs |

### UI fix

- [x] I reproduced the bug (or confirmed its absence) in every binding above
- [x] Every affected binding is fixed in this PR

The same neutral browser regression runs in all five Playwright projects. It verifies that focusing and blurring an existing mixed-style, bulleted text box preserves its rendered runs and list structure without adding an Undo entry.

---

## Testing

- [x] Unit tests added or updated for each binding I changed
- [x] Regression test added that fails without this change
- [x] Framework-neutral e2e spec added or updated in `e2e/`
- [x] Named Playwright projects pass locally: React, Vue, Angular, Svelte, and Vanilla

Checks run locally:

- shared commit-decision tests: 2/2 passed
- Angular inline-autofit tests: 5/5 passed
- `e2e/text-layout-parity.spec.ts` focused regression: 5/5 passed across all bindings
- shared and Angular type checks passed
- shared and Angular builds passed
- E2E neutrality, formatting, lint, and diff checks passed
- manual Angular browser flow verified unchanged blur, changed text, preserved rich/list rendering, and single-step Undo

Full-suite spot checks completed 7,349 shared tests and 3,270 Angular tests. The remaining local failures were unrelated environment/setup issues: Node 25 does not provide the expected `localStorage` implementation, and one Angular peer-range check could not resolve a hard-linked optional peer fixture. CI will run the repository checks from a clean install.

## Checks run locally

- [ ] `bun run lint`
- [ ] `bun run fmt:check`
- [ ] `bun run typecheck`
- [ ] `bun run test`

The equivalent affected-package checks were run directly because Bun is not installed in this local shell.

## Conventional Commits

- [x] My commit messages follow Conventional Commits
