### PR TITLE
fix(core): preserve fractional table font sizes

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -36,12 +36,15 @@
  * applied and that it is themed at all rather than falling back to the
  * hardcoded accent1 blue.
  */
+import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { test, expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import JSZip from 'jszip';
 
+import { savePptxViaBackstage } from './save-pptx';
 import { centreOf, openMenuOn } from './support/context-menu';
 import { resetTabSession } from './support/deck';
 
@@ -50,6 +53,13 @@ const fixturePath = resolve(
 );
 
 const LOAD_TIMEOUT_MS = 60_000;
+const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+interface DeckPayload {
+	name: string;
+	mimeType: string;
+	buffer: Buffer;
+}
 
 /** The hardcoded fallback every unresolved table style used to paint. */
 const BLUE_FALLBACK = { r: 68, g: 114, b: 196 };
@@ -177,13 +187,39 @@ function cellAt(table: TablePaint, row: number, col: number): CellPaint {
 	return found;
 }
 
-async function loadDeck(page: Page): Promise<void> {
+async function loadDeck(page: Page, deck: string | DeckPayload = fixturePath): Promise<void> {
 	await page.setViewportSize({ width: 1600, height: 1000 });
 	await resetTabSession(page);
 	await page.goto('/');
-	await page.locator('#file-input').setInputFiles(fixturePath);
+	await page.locator('#file-input').setInputFiles(deck);
 	await page.locator('[aria-label="Go to slide 5"]').first().waitFor({ timeout: LOAD_TIMEOUT_MS });
 	await page.waitForTimeout(1200);
+}
+
+/**
+ * Change PowerPoint's 12pt first run to an exact 10.5pt OOXML value in memory.
+ * The checked-in fixture stays byte-for-byte PowerPoint authored while this
+ * regression exercises the half-point value that the core parser used to
+ * round to 11pt.
+ */
+async function fractionalTableDeck(): Promise<DeckPayload> {
+	const zip = await JSZip.loadAsync(await readFile(fixturePath));
+	const slidePath = 'ppt/slides/slide4.xml';
+	const slide = zip.file(slidePath);
+	if (!slide) {
+		throw new Error(`${slidePath} is missing from the table styling fixture`);
+	}
+	const xml = await slide.async('string');
+	const authoredRun = '<a:rPr lang="en-US" sz="1200" b="0">';
+	if (!xml.includes(authoredRun)) {
+		throw new Error('the expected 12pt Revenue run is missing from slide 4');
+	}
+	zip.file(slidePath, xml.replace(authoredRun, authoredRun.replace('1200', '1050')));
+	return {
+		name: 'table-fractional-font-size.pptx',
+		mimeType: PPTX_MIME,
+		buffer: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),
+	};
 }
 
 async function gotoSlide(page: Page, slideNumber: number): Promise<void> {
@@ -343,6 +379,47 @@ test.describe('table styling', () => {
 		const editedCell = edited.cells.find((candidate) => candidate.text === 'Edited cell');
 		expect(editedCell, 'the edited cell should be rendered').toBeTruthy();
 		expect(editedCell!.fontSize).toBeCloseTo(firstRunSize!, 2);
+	});
+
+	test('preserves a fractional authored font size through edit and save', async ({ page }) => {
+		await loadDeck(page, await fractionalTableDeck());
+		await gotoSlide(page, 4);
+		const original = await measureTable(page);
+		const mixed = original.cells.find((cell) => cell.text.includes('Revenue grew 42%'));
+		expect(mixed, 'the mixed-format cell should be rendered').toBeTruthy();
+		const authoredRun = mixed!.runs.find((run) => run.text.includes('Revenue'));
+		expect(authoredRun, 'the 10.5pt run should be rendered').toBeTruthy();
+		// Browsers render points at 4/3 CSS pixels: 10.5pt is exactly 14px.
+		expect(authoredRun!.fontSize).toBeCloseTo(14, 2);
+
+		const cell = canvasCell(page, 'Revenue grew 42%');
+		const cellBox = await cell.boundingBox();
+		expect(cellBox, 'the mixed-format cell should have a layout box').not.toBeNull();
+		await page.mouse.dblclick(cellBox!.x + cellBox!.width / 2, cellBox!.y + cellBox!.height / 2);
+		const input = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('td input')
+			.first();
+		await expect(input).toBeVisible();
+		await input.fill('Fractional cell');
+		await input.press('Enter');
+		await expect(canvasCell(page, 'Fractional cell')).toBeVisible();
+
+		const edited = await measureTable(page);
+		const editedCell = edited.cells.find((candidate) => candidate.text === 'Fractional cell');
+		expect(editedCell, 'the edited cell should be rendered').toBeTruthy();
+		expect(editedCell!.fontSize).toBeCloseTo(14, 2);
+
+		const download = await savePptxViaBackstage(page);
+		const savedPath = await download.path();
+		expect(savedPath, 'the browser should retain the downloaded PPTX').not.toBeNull();
+		await loadDeck(page, savedPath!);
+		await gotoSlide(page, 4);
+		const reloaded = await measureTable(page);
+		const reloadedCell = reloaded.cells.find((candidate) => candidate.text === 'Fractional cell');
+		expect(reloadedCell, 'the saved edit should survive reloading').toBeTruthy();
+		expect(reloadedCell!.fontSize).toBeCloseTo(14, 2);
 	});
 
 	test('resolves a built-in style GUID the deck does not define', async ({ page }) => {

--- a/packages/core/src/core/core/builders/table-cell-runs.test.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.test.ts
@@ -48,7 +48,7 @@ describe('extractTableCellTextRuns', () => {
 		// "grew 42%" rendered in the plain style of "Revenue ".
 		const cell = parseCell(
 			'<a:tc><a:txBody><a:bodyPr/><a:p>' +
-				'<a:r><a:rPr lang="en-US" sz="1200"/><a:t>Revenue </a:t></a:r>' +
+				'<a:r><a:rPr lang="en-US" sz="1050"/><a:t>Revenue </a:t></a:r>' +
 				'<a:r><a:rPr lang="en-US" sz="1800" b="1" i="1" u="sng" strike="sngStrike">' +
 				'<a:solidFill><a:srgbClr val="C00000"/></a:solidFill>' +
 				'<a:latin typeface="Georgia"/></a:rPr><a:t>grew 42%</a:t></a:r>' +
@@ -56,7 +56,7 @@ describe('extractTableCellTextRuns', () => {
 		);
 		const runs = extractTableCellTextRuns(cell, context);
 		expect(runs).toHaveLength(2);
-		expect(runs?.[0]).toStrictEqual({ text: 'Revenue ', fontSize: 12 });
+		expect(runs?.[0]).toStrictEqual({ text: 'Revenue ', fontSize: 10.5 });
 		expect(runs?.[1]).toStrictEqual({
 			text: 'grew 42%',
 			bold: true,

--- a/packages/core/src/core/core/builders/table-cell-runs.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.ts
@@ -67,7 +67,7 @@ function applyRunProperties(
 	}
 	const size = parseInt(String(runProperties['@_sz'] ?? ''), 10);
 	if (Number.isFinite(size) && size > 0) {
-		run.fontSize = Math.round(size / 100);
+		run.fontSize = size / 100;
 	}
 	if (runProperties['a:solidFill']) {
 		const color = context.parseColor(runProperties['a:solidFill'] as XmlObject);

--- a/packages/core/src/core/core/builders/table-cell-text-style-helpers.test.ts
+++ b/packages/core/src/core/core/builders/table-cell-text-style-helpers.test.ts
@@ -316,12 +316,12 @@ describe('applyCellTextFormat - run properties', () => {
 		expect(style.underline).toBeUndefined();
 	});
 
-	it('applies font size from run properties (1800 => 18pt)', () => {
+	it('preserves fractional font size from run properties (1050 => 10.5pt)', () => {
 		const tableCell: XmlObject = {
 			'a:txBody': {
 				'a:p': {
 					'a:r': {
-						'a:rPr': { '@_sz': '1800' },
+						'a:rPr': { '@_sz': '1050' },
 						'a:t': 'Sized text',
 					},
 				},
@@ -329,7 +329,7 @@ describe('applyCellTextFormat - run properties', () => {
 		};
 		const style: PptxTableCellStyle = {};
 		applyCellTextFormat(tableCell, style, makeContext());
-		expect(style.fontSize).toBe(18);
+		expect(style.fontSize).toBe(10.5);
 	});
 
 	it('applies text color from run properties', () => {

--- a/packages/core/src/core/core/builders/table-cell-text-style-helpers.ts
+++ b/packages/core/src/core/core/builders/table-cell-text-style-helpers.ts
@@ -116,7 +116,7 @@ function applyRunProperties(
 		hasStyle = true;
 	}
 	if (runProperties['@_sz']) {
-		style.fontSize = Math.round(parseInt(String(runProperties['@_sz']), 10) / 100);
+		style.fontSize = parseInt(String(runProperties['@_sz']), 10) / 100;
 		hasStyle = true;
 	}
 	if (runProperties['a:solidFill']) {

--- a/packages/core/src/core/core/runtime/table-cell-save-helpers.test.ts
+++ b/packages/core/src/core/core/runtime/table-cell-save-helpers.test.ts
@@ -134,6 +134,20 @@ describe('writeCellTextFormatting', () => {
 		expect(rPr['@_b']).toBe('1');
 	});
 
+	it('rounds fractional point sizes to valid OOXML hundredths', () => {
+		const xmlCell: XmlObject = {
+			'a:txBody': {
+				'a:p': { 'a:r': { 'a:rPr': {}, 'a:t': 'Fractional size' } },
+			},
+		};
+
+		writeCellTextFormatting(xmlCell, { fontSize: 10.555 }, ensureArray);
+
+		const paragraph = ensureArray(xmlCell['a:txBody']?.['a:p'])[0];
+		const run = ensureArray(paragraph['a:r'])[0];
+		expect((run['a:rPr'] as XmlObject)['@_sz']).toBe('1056');
+	});
+
 	it('should create a:rPr if missing on runs', () => {
 		const xmlCell: XmlObject = {
 			'a:txBody': {

--- a/packages/core/src/core/core/runtime/table-cell-save-helpers.ts
+++ b/packages/core/src/core/core/runtime/table-cell-save-helpers.ts
@@ -204,7 +204,7 @@ export function writeCellTextFormatting(
 				rPr['@_u'] = style.underline ? 'sng' : 'none';
 			}
 			if (style.fontSize !== undefined) {
-				rPr['@_sz'] = String(style.fontSize * 100);
+				rPr['@_sz'] = String(Math.round(style.fontSize * 100));
 			}
 			if (style.color) {
 				rPr['a:solidFill'] = {


### PR DESCRIPTION
## Summary

- preserve exact DrawingML hundredths when parsing table-cell fallback and per-run font sizes
- emit integer hundredths when saving point-valued table font sizes
- add colocated core regressions and one framework-neutral edit, save, and reload browser test

## Why this is a bug

DrawingML stores text size as an integer number of hundredths of a point, so `sz="1050"` is exactly 10.5 pt. The table parser rounded that value to 11 pt, changing authored content as soon as a deck was loaded. The table writer could also serialize a model value such as 10.555 pt as the non-integer `1055.5`, which is not a valid DrawingML font-size value.

The ordinary-text and chart paths already preserve fractional point values and round only when converting back to OOXML. This change makes the table path follow that existing behavior.

## Cross-binding scope

This is implemented in `pptx-viewer-core`, where table text is parsed and serialized for every binding. React, Vue, Angular, Svelte, and Vanilla are all affected and all consume the corrected core behavior, so no per-binding UI changes are needed.

The browser regression runs identically against all five demos. It loads a PowerPoint-authored fixture with one run changed in memory to 10.5 pt, verifies 14 CSS px, edits the cell, saves the PPTX, reloads it, and verifies the edited cell remains 10.5 pt.

## Verification

- focused core tests: 59 passed
- core typecheck and production build passed
- focused cross-binding browser regression: 5 passed across React, Vue, Angular, Vanilla, and Svelte
- complete existing table browser suite: 50 passed across the five bindings
- format, lint, diff, and E2E-neutrality checks passed
- independent code review found no blocking issues
- independent React browser review confirmed the inspector value, computed size, edit, saved `sz="1050"`, and reopened result

A full core run completed 11,380 tests successfully but six unrelated fixture-heavy tests timed out while the five-binding browser suite ran concurrently. Those exact six tests passed on an immediate isolated rerun (56 passed).

This is my first open-source contribution series, so I would appreciate guidance if any scope or convention should be adjusted.
