### PR TITLE
fix(shared,vanilla): continue appended numbered paragraphs

### DIFF
--- a/e2e/text-layout-parity.spec.ts
+++ b/e2e/text-layout-parity.spec.ts
@@ -34,6 +34,7 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 
+import { savePptxViaBackstage } from './save-pptx';
 import { fixture, loadDeck, loadDeckAt, slideStage, thumbnail } from './support/deck';
 import { acrossFrameworks, splitReference } from './support/parity';
 import { diffTextRuns } from './support/text-run-diff';
@@ -158,6 +159,50 @@ test.describe('cross-binding text layout', () => {
 			runsOfSlide(page, origin, CJK, 2),
 		);
 		expectRunParity(results);
+	});
+
+	test('an appended numbered-list paragraph continues through save and reload', async ({
+		page,
+	}) => {
+		const appendedText = 'Browser appended item';
+		await loadDeck(page, CJK);
+		await thumbnail(page, 5).click();
+		await page.waitForTimeout(600);
+
+		const numberedList = page
+			.locator('[data-pptx-viewport] [data-element-id]')
+			.filter({ hasText: 'Lorem ipsum dolor sit amet' })
+			.first();
+		await numberedList.dblclick();
+		const editor = page.locator('[data-inline-editor]');
+		await editor.waitFor();
+
+		// Shift+Enter is the same multiline insertion gesture in all five
+		// bindings; Angular deliberately reserves plain Enter for commit.
+		await editor.press('Shift+Enter');
+		await page.keyboard.type(appendedText);
+		const stageBox = (await slideStage(page).boundingBox())!;
+		await page.mouse.click(stageBox.x + stageBox.width * 0.97, stageBox.y + stageBox.height * 0.97);
+		await expect(editor).toBeHidden();
+
+		const compactText = async (): Promise<string> =>
+			(await numberedList.innerText()).replace(/\s+/gu, '');
+		await expect.poll(compactText).toContain(`5.${appendedText.replace(/\s+/gu, '')}`);
+
+		const download = await savePptxViaBackstage(page);
+		const savedPath = await download.path();
+		expect(savedPath, 'the browser retained the saved numbered-list deck').not.toBeNull();
+		await loadDeck(page, savedPath!);
+		await thumbnail(page, 5).click();
+		await page.waitForTimeout(600);
+		const afterReload = await page
+			.locator('[data-pptx-viewport] [data-element-id]')
+			.filter({ hasText: appendedText })
+			.first()
+			.innerText()
+			.then((text) => text.replace(/\s+/gu, ''));
+
+		expect(afterReload).toContain(`5.${appendedText.replace(/\s+/gu, '')}`);
 	});
 
 	test('a hyperlink and an inline equation reach the DOM in every binding', async ({

--- a/packages/shared/src/render/inline-text-extract.test.ts
+++ b/packages/shared/src/render/inline-text-extract.test.ts
@@ -58,6 +58,57 @@ describe('readEditableText', () => {
 		).toBe('First\nSecond');
 	});
 
+	it('keeps an annotated rich-run paragraph after its placeholder is replaced', () => {
+		expect(
+			readEditableText(
+				elementFromHtml(
+					'<span data-seg-idx="0">First</span><span data-seg-idx="0" data-pptx-paragraph-start>Second</span>',
+				),
+			),
+		).toBe('First\nSecond');
+		expect(
+			readEditableText(
+				elementFromHtml(
+					'<span data-seg-idx="0">First</span><span data-seg-idx="0" data-pptx-paragraph-start><br></span>',
+				),
+			),
+		).toBe('First\n');
+	});
+
+	it('counts consecutive annotated empty paragraphs exactly once', () => {
+		expect(
+			readEditableText(
+				elementFromHtml(
+					'<span>First</span><span data-pptx-paragraph-start><br></span><span data-pptx-paragraph-start><br></span>',
+				),
+			),
+		).toBe('First\n\n');
+		expect(
+			readEditableText(
+				elementFromHtml(
+					'<div>First</div><div data-pptx-paragraph-start><span data-seg-idx="0"><br></span></div>',
+				),
+			),
+		).toBe('First\n');
+	});
+
+	it('keeps an unannotated authored soft line break', () => {
+		expect(readEditableText(elementFromHtml('<div><span data-seg-idx="0"><br></span></div>'))).toBe(
+			'\n',
+		);
+	});
+
+	it('ignores an empty-run caret placeholder but reads replacement text', () => {
+		expect(
+			readEditableText(elementFromHtml('<span>First</span><span data-pptx-empty-run><br></span>')),
+		).toBe('First');
+		expect(
+			readEditableText(
+				elementFromHtml('<span>First</span><span data-pptx-empty-run>Second</span>'),
+			),
+		).toBe('FirstSecond');
+	});
+
 	it('does not prefix a newline for the very first block', () => {
 		expect(readEditableText(elementFromHtml('<div>only</div>'))).toBe('only');
 	});

--- a/packages/shared/src/render/inline-text-extract.ts
+++ b/packages/shared/src/render/inline-text-extract.ts
@@ -12,6 +12,19 @@
  * block-element boundaries into `\n` (contenteditable normalises Enter into
  * nested blocks or `<br>` depending on the browser).
  */
+function hasOnlyCaretPlaceholder(element: HTMLElement): boolean {
+	const content = Array.from(element.childNodes).filter((child) => {
+		if (child.nodeType === 3) {
+			return (child.nodeValue ?? '').length > 0;
+		}
+		return child instanceof HTMLElement && !child.hasAttribute('data-pptx-bullet-marker');
+	});
+	if (content.length !== 1 || !(content[0] instanceof HTMLElement)) {
+		return false;
+	}
+	return content[0].tagName === 'BR' || hasOnlyCaretPlaceholder(content[0]);
+}
+
 export function readEditableText(root: Node): string {
 	let out = '';
 	const walk = (node: Node): void => {
@@ -28,6 +41,25 @@ export function readEditableText(root: Node): string {
 			// mode; excluding the annotated node prevents a semantic bullet from
 			// being committed as literal text (for example, "1.Item").
 			if (child.hasAttribute('data-pptx-bullet-marker')) {
+				continue;
+			}
+			const isAnnotatedParagraph = child.hasAttribute('data-pptx-paragraph-start');
+			if (isAnnotatedParagraph) {
+				out += '\n';
+			}
+			// Chromium leaves a BR placeholder, sometimes below a cloned run span,
+			// until the user types. The annotation already contributed exactly one
+			// paragraph break, so presentation-only markers and that BR add nothing.
+			if (isAnnotatedParagraph && hasOnlyCaretPlaceholder(child)) {
+				continue;
+			}
+			// Vanilla gives the final empty run of a list paragraph a BR solely so
+			// the caret can enter it. It is not authored text and disappears on type.
+			if (
+				child.hasAttribute('data-pptx-empty-run') &&
+				child.childNodes.length === 1 &&
+				child.firstChild?.nodeName === 'BR'
+			) {
 				continue;
 			}
 			if (child.tagName === 'BR') {

--- a/packages/shared/src/render/remap-text-bullets.ts
+++ b/packages/shared/src/render/remap-text-bullets.ts
@@ -1,0 +1,84 @@
+import type { TextSegment } from 'pptx-viewer-core';
+
+import { resolveParagraphBullet } from './bullet-list';
+import { isBulletMarkerSegment } from './bullet-toggle';
+
+/** Remove a display-only marker from editor text before remapping its content. */
+export function withoutRenderedBulletPrefix(
+	text: string,
+	originalSegments: readonly TextSegment[],
+	dedicatedMarker: TextSegment | undefined,
+): string {
+	if (!dedicatedMarker) {
+		return text;
+	}
+	const resolved = resolveParagraphBullet(dedicatedMarker);
+	if (!resolved || !text.startsWith(resolved.marker)) {
+		return text;
+	}
+
+	const withoutMarker = text.slice(resolved.marker.length);
+	const originalContent = originalSegments
+		.slice(1)
+		.map((segment) => segment.text)
+		.join('');
+	// Empty list paragraphs do not render a marker, so marker-like text typed
+	// into them is authored content and must not be stripped.
+	if (originalContent.trim().length === 0) {
+		return text;
+	}
+	const originalLeadingSpaces = originalContent.length - originalContent.trimStart().length;
+	const editedLeadingSpaces = withoutMarker.length - withoutMarker.trimStart().length;
+	if (editedLeadingSpaces > originalLeadingSpaces) {
+		return withoutMarker.slice(1);
+	}
+	return withoutMarker;
+}
+
+/**
+ * Advance an appended paragraph from the final authored auto-numbered item.
+ * Core stores the list-relative ordinal as `paragraphIndex`; copying the final
+ * item unchanged would render every paragraph added with Enter as the same
+ * number. The literal marker is refreshed only when core supplied a dedicated
+ * display-marker segment. The donor's list level is retained because core
+ * sequences each level independently when the deck is reloaded. Other bullet
+ * kinds and auto-numbers without a known runtime index remain unchanged.
+ */
+export function continueAutoNumberedParagraph(
+	segments: TextSegment[],
+	donorSegments: readonly TextSegment[],
+	offset: number,
+): TextSegment[] {
+	const donor = donorSegments[0];
+	const paragraphIndex = donor?.bulletInfo?.paragraphIndex;
+	if (
+		segments.length === 0 ||
+		!donor?.bulletInfo?.autoNumType ||
+		typeof paragraphIndex !== 'number' ||
+		!Number.isFinite(paragraphIndex)
+	) {
+		return segments;
+	}
+
+	const [first, ...rest] = segments;
+	const continued: TextSegment = {
+		...first,
+		bulletInfo: {
+			...donor.bulletInfo,
+			paragraphIndex: paragraphIndex + offset,
+		},
+	};
+	if (donor.paragraphLevel !== undefined) {
+		continued.paragraphLevel = donor.paragraphLevel;
+	}
+
+	if (isBulletMarkerSegment(donor)) {
+		const resolved = resolveParagraphBullet(continued);
+		if (resolved) {
+			const trailingWhitespace = donor.text.match(/\s+$/u)?.[0] ?? '';
+			continued.text = `${resolved.marker}${trailingWhitespace}`;
+		}
+	}
+
+	return [continued, ...rest];
+}

--- a/packages/shared/src/render/remap-text.test.ts
+++ b/packages/shared/src/render/remap-text.test.ts
@@ -194,6 +194,103 @@ describe('remapTextToSegments', () => {
 
 			expect(result.map((segment) => segment.text)).toStrictEqual(['1.', '1.Item']);
 		});
+
+		it('continues a numbered list when a new paragraph is appended', () => {
+			const original: TextSegment[] = [
+				{
+					text: '1. ',
+					style: { color: '#4472C4' },
+					bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+				},
+				seg('First item', { bold: true }),
+			];
+			const before = structuredClone(original);
+
+			const result = remapTextToSegments('First item\nSecond item', original, {});
+			const appended = result.slice(result.findIndex((segment) => segment.isParagraphBreak) + 1);
+
+			expect(appended.map((segment) => segment.text)).toStrictEqual(['2. ', 'Second item']);
+			expect(appended[0].bulletInfo).toStrictEqual({
+				autoNumType: 'arabicPeriod',
+				paragraphIndex: 1,
+			});
+			expect(appended[1].style.bold).toBeTruthy();
+			expect(original).toStrictEqual(before);
+		});
+
+		it('continues multiple appended paragraphs from a custom numbered-list start', () => {
+			const original: TextSegment[] = [
+				{
+					text: 'd)',
+					style: {},
+					bulletInfo: {
+						autoNumType: 'alphaLcParenR',
+						autoNumStartAt: 3,
+						paragraphIndex: 1,
+					},
+				},
+				seg('Fourth'),
+			];
+
+			const result = remapTextToSegments('Fourth\nFifth\nSixth', original, {});
+			const markers = result.filter((segment) => segment.bulletInfo?.autoNumType);
+
+			expect(markers.map((segment) => segment.text)).toStrictEqual(['d)', 'e)', 'f)']);
+			expect(markers.map((segment) => segment.bulletInfo?.paragraphIndex)).toStrictEqual([1, 2, 3]);
+		});
+
+		it('continues numbering when bulletInfo is carried by the content run', () => {
+			const original: TextSegment[] = [
+				{
+					text: 'First',
+					style: {},
+					bulletInfo: { autoNumType: 'romanUcPeriod', paragraphIndex: 0 },
+				},
+			];
+
+			const result = remapTextToSegments('First\nSecond', original, {});
+			const appended = result.at(-1);
+
+			expect(appended?.text).toBe('Second');
+			expect(appended?.bulletInfo).toStrictEqual({
+				autoNumType: 'romanUcPeriod',
+				paragraphIndex: 1,
+			});
+		});
+
+		it.each([
+			['a character bullet', '• ', { char: '•' }],
+			[
+				'a picture bullet',
+				'• ',
+				{ imageDataUrl: 'data:image/png;base64,AA==', imageRelId: 'rId7' },
+			],
+			['an auto-number without a runtime paragraph index', '1.', { autoNumType: 'arabicPeriod' }],
+		] as const)('does not invent a numbered sequence for %s', (_name, marker, bulletInfo) => {
+			const original: TextSegment[] = [{ text: marker, style: {}, bulletInfo }, seg('First')];
+
+			const result = remapTextToSegments(`First\nSecond`, original, {});
+			const appended = result.slice(result.findIndex((segment) => segment.isParagraphBreak) + 1);
+			const appendedBullet = appended.find((segment) => segment.bulletInfo)?.bulletInfo;
+
+			expect(appendedBullet).toStrictEqual(bulletInfo);
+			expect(appendedBullet?.paragraphIndex).toBeUndefined();
+		});
+
+		it('advances an empty appended paragraph before it receives text', () => {
+			const original: TextSegment[] = [
+				{
+					text: '1.',
+					style: {},
+					bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+				},
+				seg('First'),
+			];
+			const result = remapTextToSegments('First\n', original, {});
+			const appended = result.slice(result.findIndex((segment) => segment.isParagraphBreak) + 1);
+
+			expect(appended[0].bulletInfo?.paragraphIndex).toBe(1);
+		});
 	});
 
 	describe('paragraph metadata preservation', () => {
@@ -301,7 +398,7 @@ describe('remapTextToSegments', () => {
 			expect(paragraphs[1].paragraphProperties).toBeUndefined();
 		});
 
-		it('does not copy marker-carried paragraph metadata to an appended paragraph', () => {
+		it('continues a marker and list level without copying unrelated paragraph metadata', () => {
 			const paragraphProperties = { paragraphSpacingAfter: 9 };
 			const original: TextSegment[] = [
 				{
@@ -324,9 +421,10 @@ describe('remapTextToSegments', () => {
 
 			expect(appended?.bulletInfo).toStrictEqual({
 				autoNumType: 'arabicPeriod',
-				paragraphIndex: 0,
+				paragraphIndex: 1,
 			});
-			expect(appended?.paragraphLevel).toBeUndefined();
+			expect(appended?.text).toBe('2.');
+			expect(appended?.paragraphLevel).toBe(2);
 			expect(appended?.paragraphProperties).toBeUndefined();
 			expect(appended?.endParaRunProperties).toBeUndefined();
 		});

--- a/packages/shared/src/render/remap-text.ts
+++ b/packages/shared/src/render/remap-text.ts
@@ -5,45 +5,8 @@
  */
 import type { TextSegment, TextStyle } from 'pptx-viewer-core';
 
-import { resolveParagraphBullet } from './bullet-list';
 import { isBulletMarkerSegment } from './bullet-toggle';
-
-/**
- * Remove marker text from editor surfaces that seed it as ordinary text.
- * Depending on the binding, the gap can be CSS (`"1.Item"`) or the parsed
- * marker's trailing space (`"1. Item"`). React instead annotates its rendered
- * marker so `readEditableText` can exclude it at the DOM boundary.
- */
-function withoutRenderedBulletPrefix(
-	text: string,
-	originalSegments: readonly TextSegment[],
-	dedicatedMarker: TextSegment | undefined,
-): string {
-	if (!dedicatedMarker) {
-		return text;
-	}
-	const resolved = resolveParagraphBullet(dedicatedMarker);
-	if (!resolved || !text.startsWith(resolved.marker)) {
-		return text;
-	}
-
-	const withoutMarker = text.slice(resolved.marker.length);
-	const originalContent = originalSegments
-		.slice(1)
-		.map((segment) => segment.text)
-		.join('');
-	// Empty list paragraphs do not render a marker, so marker-like text typed
-	// into them is authored content and must not be stripped.
-	if (originalContent.trim().length === 0) {
-		return text;
-	}
-	const originalLeadingSpaces = originalContent.length - originalContent.trimStart().length;
-	const editedLeadingSpaces = withoutMarker.length - withoutMarker.trimStart().length;
-	if (editedLeadingSpaces > originalLeadingSpaces) {
-		return withoutMarker.slice(1);
-	}
-	return withoutMarker;
-}
+import { continueAutoNumberedParagraph, withoutRenderedBulletPrefix } from './remap-text-bullets';
 
 /**
  * Whether an original segment is ATOMIC: its rendered text is not what is
@@ -301,10 +264,17 @@ export function remapTextToSegments(
 
 		const originalParagraph = originalParagraphs[pi];
 		const origPara = originalParagraph?.segments ?? lastOrigPara ?? [];
-		const paraSegments = restoreParagraphMetadata(
+		let paraSegments = restoreParagraphMetadata(
 			originalParagraph?.segments[0] ?? originalParagraph?.terminator,
 			remapParagraph(newParagraphTexts[pi], origPara),
 		);
+		if (!originalParagraph) {
+			paraSegments = continueAutoNumberedParagraph(
+				paraSegments,
+				lastOrigPara ?? [],
+				pi - originalParagraphs.length + 1,
+			);
+		}
 		output.push(...paraSegments);
 	}
 

--- a/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
@@ -8,7 +8,7 @@
 import type { PptxElement } from 'pptx-viewer-core';
 import { describe, expect, it, vi } from 'vitest';
 
-import { openInlineEditor } from './inline-text-editor';
+import { openInlineEditor, readEditableText } from './inline-text-editor';
 
 function textElement(): PptxElement {
 	return {
@@ -137,6 +137,252 @@ describe('openInlineEditor caret placement', () => {
 			overlayRoot.remove();
 		},
 	);
+});
+
+describe('openInlineEditor input handling', () => {
+	it('marks generated list markers as display-only editor content', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const onCommit = vi.fn();
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: {
+				...textElement(),
+				text: 'Item',
+				textSegments: [
+					{
+						text: '1. ',
+						style: {},
+						bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+					},
+					{ text: 'Item', style: {} },
+				],
+			} as PptxElement,
+			onCommit,
+			onClose: () => {},
+		});
+
+		const marker = session.el.querySelector<HTMLElement>('[data-seg-idx="0"]');
+		expect(marker?.hasAttribute('data-pptx-bullet-marker')).toBeTruthy();
+		expect(marker?.contentEditable).toBe('false');
+		expect(readEditableText(session.el)).toBe('Item');
+
+		session.commit();
+		expect(onCommit).not.toHaveBeenCalled();
+		overlayRoot.remove();
+	});
+
+	it('gives a final empty list run a caret placeholder without committing it', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const onCommit = vi.fn();
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: {
+				...textElement(),
+				text: '1. ',
+				textSegments: [
+					{
+						text: '1. ',
+						style: {},
+						bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+					},
+					{ text: '', style: {} },
+				],
+			} as PptxElement,
+			onCommit,
+			onClose: () => {},
+		});
+
+		expect(session.el.querySelector('[data-pptx-empty-run]')?.firstElementChild?.tagName).toBe(
+			'BR',
+		);
+		expect(readEditableText(session.el)).toBe('');
+		session.commit();
+		expect(onCommit).not.toHaveBeenCalled();
+
+		overlayRoot.remove();
+	});
+
+	it('does not add a caret placeholder to an ordinary empty formatting run', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: {
+				...textElement(),
+				textSegments: [
+					{ text: 'Hello', style: {} },
+					{ text: '', style: { bold: true } },
+					{ text: ' world', style: {} },
+				],
+			} as PptxElement,
+			onCommit: () => {},
+			onClose: () => {},
+		});
+
+		expect(session.el.querySelector('[data-pptx-empty-run]')).toBeNull();
+
+		session.cancel();
+		overlayRoot.remove();
+	});
+
+	it('marks the rich run or paragraph block that Chromium creates for plain Enter', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const onInput = vi.fn();
+		const onCommit = vi.fn();
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: textElement(),
+			onInput,
+			onCommit,
+			onClose: () => {},
+		});
+
+		const inserted = document.createElement('span');
+		inserted.dataset.segIdx = '0';
+		inserted.appendChild(document.createElement('br'));
+		session.el.appendChild(inserted);
+		const range = document.createRange();
+		range.setStart(inserted, 0);
+		range.collapse(true);
+		const selection = window.getSelection()!;
+		selection.removeAllRanges();
+		selection.addRange(range);
+
+		session.el.dispatchEvent(
+			new InputEvent('input', { bubbles: true, inputType: 'insertParagraph' }),
+		);
+
+		expect(inserted.hasAttribute('data-pptx-paragraph-start')).toBeTruthy();
+		expect(readEditableText(session.el)).toBe('TARGET\n');
+		expect(onInput).toHaveBeenLastCalledWith('TARGET\n');
+		inserted.textContent = 'NEXT';
+		expect(readEditableText(session.el)).toBe('TARGET\nNEXT');
+
+		const insertedBlock = document.createElement('div');
+		const nestedRun = document.createElement('span');
+		nestedRun.dataset.segIdx = '0';
+		nestedRun.appendChild(document.createElement('br'));
+		insertedBlock.appendChild(nestedRun);
+		session.el.appendChild(insertedBlock);
+		range.setStart(nestedRun, 0);
+		range.collapse(true);
+		selection.removeAllRanges();
+		selection.addRange(range);
+		session.el.dispatchEvent(
+			new InputEvent('input', { bubbles: true, inputType: 'insertParagraph' }),
+		);
+
+		expect(insertedBlock.hasAttribute('data-pptx-paragraph-start')).toBeTruthy();
+		expect(nestedRun.hasAttribute('data-pptx-paragraph-start')).toBeFalsy();
+		expect(readEditableText(session.el)).toBe('TARGET\nNEXT\n');
+		expect(onInput).toHaveBeenLastCalledWith('TARGET\nNEXT\n');
+		session.commit();
+		expect(onCommit).toHaveBeenCalledWith('TARGET\nNEXT\n');
+
+		overlayRoot.remove();
+	});
+
+	it('marks the leading placeholder when plain Enter splits the start of a rich run', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const onInput = vi.fn();
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: textElement(),
+			onInput,
+			onCommit: () => {},
+			onClose: () => {},
+		});
+
+		const originalRun = session.el.querySelector<HTMLElement>('[data-seg-idx="0"]')!;
+		const leading = document.createElement('span');
+		leading.dataset.segIdx = '0';
+		leading.appendChild(document.createElement('br'));
+		session.el.insertBefore(leading, originalRun);
+		const range = document.createRange();
+		range.setStart(originalRun.firstChild!, 0);
+		range.collapse(true);
+		const selection = window.getSelection()!;
+		selection.removeAllRanges();
+		selection.addRange(range);
+
+		session.el.dispatchEvent(
+			new InputEvent('input', { bubbles: true, inputType: 'insertParagraph' }),
+		);
+
+		expect(leading.hasAttribute('data-pptx-paragraph-start')).toBeTruthy();
+		expect(originalRun.hasAttribute('data-pptx-paragraph-start')).toBeFalsy();
+		expect(readEditableText(session.el)).toBe('\nTARGET');
+		expect(onInput).toHaveBeenLastCalledWith('\nTARGET');
+
+		session.cancel();
+		overlayRoot.remove();
+	});
+
+	it('ignores a display-only marker when locating a leading list placeholder', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: textElement(),
+			onCommit: () => {},
+			onClose: () => {},
+		});
+
+		const originalRun = session.el.querySelector<HTMLElement>('[data-seg-idx="0"]')!;
+		originalRun.dataset.segIdx = '1';
+		const originalBlock = document.createElement('div');
+		session.el.insertBefore(originalBlock, originalRun);
+		originalBlock.appendChild(originalRun);
+		const leadingBlock = document.createElement('div');
+		const marker = document.createElement('span');
+		marker.dataset.segIdx = '0';
+		marker.dataset.pptxBulletMarker = '';
+		marker.textContent = '• ';
+		const leadingRun = document.createElement('span');
+		leadingRun.dataset.segIdx = '1';
+		leadingRun.appendChild(document.createElement('br'));
+		leadingBlock.append(marker, leadingRun);
+		session.el.insertBefore(leadingBlock, originalBlock);
+		const range = document.createRange();
+		range.setStart(originalRun.firstChild!, 0);
+		range.collapse(true);
+		const selection = window.getSelection()!;
+		selection.removeAllRanges();
+		selection.addRange(range);
+
+		session.el.dispatchEvent(
+			new InputEvent('input', { bubbles: true, inputType: 'insertParagraph' }),
+		);
+
+		expect(leadingBlock.hasAttribute('data-pptx-paragraph-start')).toBeTruthy();
+		expect(originalBlock.hasAttribute('data-pptx-paragraph-start')).toBeFalsy();
+		expect(readEditableText(session.el)).toBe('\nTARGET');
+
+		session.cancel();
+		overlayRoot.remove();
+	});
 });
 
 describe('openInlineEditor commit ordering', () => {

--- a/packages/vanilla/src/viewer/editor/inline-text-editor.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-editor.ts
@@ -3,6 +3,7 @@ import { hasTextProperties } from 'pptx-viewer-core';
 import {
 	canInteractWithElement,
 	getInlineEditorSelection,
+	isBulletMarkerSegment,
 	placeCaretAtEnd,
 	readEditableText,
 	remapTextToSegments,
@@ -11,6 +12,7 @@ import {
 import type { InlineTextSelection } from 'pptx-viewer-shared';
 
 import { createEl, getTextBlockStyle } from '../render';
+import { markInsertedParagraph } from './inline-text-paragraph-marker';
 import type { OverlayBox } from './selection-overlay';
 
 /**
@@ -168,15 +170,37 @@ export function openInlineEditor(options: OpenInlineEditorOptions): InlineEditor
 	surface.setAttribute('role', 'textbox');
 	surface.setAttribute('aria-multiline', 'true');
 	if (withText?.textSegments?.length) {
-		withText.textSegments.forEach((segment, index) => {
+		const segments = withText.textSegments;
+		segments.forEach((segment, index) => {
 			const span = doc.createElement('span');
 			span.dataset.segIdx = String(index);
-			span.textContent = segment.text;
+			if (isBulletMarkerSegment(segment)) {
+				span.dataset.pptxBulletMarker = '';
+				span.contentEditable = 'false';
+			}
+			const precedingMarker = index > 0 && isBulletMarkerSegment(segments[index - 1]);
+			const carriesList = segment.bulletInfo && !segment.bulletInfo.none;
+			if (
+				segment.text.length === 0 &&
+				index === segments.length - 1 &&
+				(precedingMarker || carriesList)
+			) {
+				// An empty inline span after a non-editable list marker has no caret
+				// position. A display-only BR lets that pending list item receive text.
+				span.dataset.pptxEmptyRun = '';
+				span.appendChild(doc.createElement('br'));
+			} else {
+				span.textContent = segment.text;
+			}
 			surface.appendChild(span);
 		});
 	} else {
 		surface.textContent = initialText;
 	}
+	// Compare commits against the same authored-text projection used on close.
+	// `element.text` can include core-generated bullet markers, while the editor
+	// correctly excludes their display-only spans.
+	const initialEditableText = readEditableText(surface);
 
 	let closed = false;
 	const close = (commitText: string | null): void => {
@@ -189,14 +213,22 @@ export function openInlineEditor(options: OpenInlineEditorOptions): InlineEditor
 		// still-`[data-inline-editor]`-attributed node from inside that
 		// callback (`EditorOperations.commitInlineText`), and a detached node
 		// reports `offsetWidth: 0`, which would break the measurement.
-		if (commitText !== null && commitText !== initialText) {
+		if (commitText !== null && commitText !== initialEditableText) {
 			options.onCommit(commitText);
 		}
 		surface.remove();
 		options.onClose();
 	};
 
-	surface.addEventListener('input', () => options.onInput?.(readEditableText(surface)));
+	surface.addEventListener('input', (event) => {
+		// Chrome can represent Enter between rich-run spans as a cloned sibling
+		// span. Its placeholder BR disappears as soon as the user types, leaving
+		// no delimiter for commit, so annotate the browser-created span itself.
+		if ((event as InputEvent).inputType === 'insertParagraph') {
+			markInsertedParagraph(doc, surface);
+		}
+		options.onInput?.(readEditableText(surface));
+	});
 	surface.addEventListener('blur', () => close(readEditableText(surface)));
 	surface.addEventListener('keydown', (event) => {
 		// Keep every keystroke local so viewer navigation/editor shortcuts

--- a/packages/vanilla/src/viewer/editor/inline-text-paragraph-marker.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-paragraph-marker.ts
@@ -1,0 +1,43 @@
+function isCaretPlaceholder(element: HTMLElement): boolean {
+	const content = Array.from(element.childNodes).filter((child) => {
+		if (child.nodeType === 3) {
+			return (child.nodeValue ?? '').length > 0;
+		}
+		return child instanceof HTMLElement && !child.hasAttribute('data-pptx-bullet-marker');
+	});
+	if (content.length !== 1 || !(content[0] instanceof HTMLElement)) {
+		return false;
+	}
+	return content[0].tagName === 'BR' || isCaretPlaceholder(content[0]);
+}
+
+function firstEditableRunIndex(element: HTMLElement): string | undefined {
+	const run =
+		element.matches('[data-seg-idx]') && !element.hasAttribute('data-pptx-bullet-marker')
+			? element
+			: element.querySelector<HTMLElement>('[data-seg-idx]:not([data-pptx-bullet-marker])');
+	return run?.dataset.segIdx;
+}
+
+/** Mark Chromium's inserted rich-run paragraph boundary. */
+export function markInsertedParagraph(doc: Document, surface: HTMLElement): void {
+	const selection = doc.getSelection();
+	const anchor = selection?.anchorNode;
+	const anchorElement =
+		anchor?.nodeType === Node.ELEMENT_NODE ? (anchor as HTMLElement) : anchor?.parentElement;
+	const insertedRun = anchorElement?.closest<HTMLElement>('[data-seg-idx]');
+	if (!insertedRun || !surface.contains(insertedRun)) {
+		return;
+	}
+	const block = insertedRun.closest<HTMLElement>('div, p');
+	const caretParagraph =
+		block && block !== surface && surface.contains(block) ? block : insertedRun;
+	const previous = caretParagraph.previousElementSibling;
+	const paragraph =
+		previous instanceof HTMLElement &&
+		firstEditableRunIndex(previous) === insertedRun.dataset.segIdx &&
+		isCaretPlaceholder(previous)
+			? previous
+			: caretParagraph;
+	paragraph.dataset.pptxParagraphStart = '';
+}


### PR DESCRIPTION
## What does this change?

When inline editing appends paragraphs to an existing auto-numbered list, continue the runtime list ordinal instead of repeating the final original number. The change also preserves Chromium's plain-Enter paragraph boundary in the Vanilla rich-run editor so that the shared continuation logic receives the appended paragraph.

The continuation is deliberately narrow: it applies only to auto-numbered paragraphs with a finite runtime `paragraphIndex`, retains the donor list level, and regenerates only dedicated generated markers. Character bullets, picture bullets, auto-numbering without a runtime index, paragraph spacing, indentation, and end-paragraph run properties retain their existing behavior.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

---

## Cross-binding parity

### Which bindings did you check, and what did you find?

| Binding                      | Affected? | Fixed / implemented here? | Notes |
| ---------------------------- | --------- | ------------------------- | ----- |
| React (`packages/react`)     | yes       | yes                       | Appended item continues through save and reload |
| Vue (`packages/vue`)         | yes       | yes                       | Appended item continues through save and reload |
| Angular (`packages/angular`) | yes       | yes                       | Shift+Enter inserts the paragraph; Enter remains the binding's commit gesture |
| Svelte (`packages/svelte`)   | yes       | yes                       | Appended item continues through save and reload |
| Vanilla (`packages/vanilla`) | yes       | yes                       | Also preserves Chromium's cloned rich-run paragraph boundary and pending empty-item caret target |

### New UI feature

- [x] The framework-agnostic logic lives in `pptx-viewer-shared`, not duplicated
      per binding
- [ ] Implemented in **all five** bindings
- [ ] User-visible copy is routed through `t()` / `translate` with keys added to
      `translations-en.ts` **and** `packages/locales/src/{de,es,fr}/`

This is a UI bug fix, not a new UI feature, and it adds no user-visible copy.

### UI fix

- [x] I reproduced the bug (or confirmed its absence) in every binding above
- [x] Every affected binding is fixed in this PR

## Testing

- [x] Unit tests added or updated for each binding I changed
- [x] Regression test added that fails without this change
- [x] Framework-neutral e2e spec added or updated in `e2e/`
- [x] Named projects run locally: React, Vue, Angular, Svelte, and Vanilla

The framework-neutral save/download/reload regression passed in all five Playwright projects. Focused shared and Vanilla tests passed 66/66. Additional real Chromium checks covered plain Enter at the start, middle, and end of rich text; consecutive empty paragraphs; numbered and character-bullet pending items; an authored soft line break; and a no-op edit remaining clean.

## Checks run locally

- [ ] `bun run lint`
- [ ] `bun run fmt:check`
- [ ] `bun run typecheck`
- [ ] `bun run test`

Equivalent direct checks were run with the repository binaries: formatting and lint on every touched file, shared and Vanilla typechecks, focused Vitest suites, `git diff --check`, and the E2E framework-neutrality check. The affected package builds also pass.

## Conventional Commits

- [x] My commit messages follow
      [Conventional Commits](https://www.conventionalcommits.org)

## Screenshots / recordings

No static screenshot is included because the regression is behavioral. The E2E test exercises editing, commit, save, download, reload, and the rendered next ordinal in every binding.
