### PR TITLE
fix(react,angular): skip unchanged autofit commits

### DIFF
--- a/e2e/text-layout-parity.spec.ts
+++ b/e2e/text-layout-parity.spec.ts
@@ -53,6 +53,8 @@ const SAMPLE = fixture('sample-deck.pptx');
 const CJK = fixture('Japanese_10_Slides_1_8_MB_bbd4090b55.pptx');
 /** Real-world deck with authored blank paragraphs and hanging bullets. */
 const BLANK_PARAGRAPHS = fixture('solution-explorer.pptx');
+/** PowerPoint-authored title whose body uses a:spAutoFit. */
+const SHAPE_AUTOFIT = fixture('animation-builds-color.pptx');
 
 /** Load `deck`, show slide `slideNumber`, and measure every run on it. */
 async function runsOfSlide(
@@ -124,6 +126,38 @@ test.describe('cross-binding text layout', () => {
 		expect(after, 'found the rich-text element after editing').toBeDefined();
 		expect(diffTextRuns([before!], [after!]).join('\n')).toBe('');
 		await expect(undo).toBeDisabled();
+	});
+
+	test('an unchanged spAutoFit edit preserves the authored height and clean history', async ({
+		page,
+	}) => {
+		await loadDeck(page, SHAPE_AUTOFIT);
+		await slideStage(page).waitFor();
+		await page.waitForTimeout(400);
+		const undo = page.getByRole('button', { name: /^undo/iu }).first();
+		await expect(undo).toBeDisabled();
+		await expect(page.getByText('Unsaved changes', { exact: true })).toHaveCount(0);
+
+		const target = page
+			.locator('[data-pptx-viewport] [data-element-id]')
+			.filter({ hasText: 'Chart Build Slide' })
+			.first();
+		await target.waitFor();
+		const before = await target.boundingBox();
+		expect(before, 'found the authored spAutoFit title before editing').not.toBeNull();
+
+		await target.dblclick();
+		const editor = page.locator('[data-inline-editor]');
+		await editor.waitFor();
+		const stageBox = (await slideStage(page).boundingBox())!;
+		await page.mouse.click(stageBox.x + stageBox.width * 0.95, stageBox.y + stageBox.height * 0.95);
+		await expect(editor).toBeHidden();
+
+		const after = await target.boundingBox();
+		expect(after, 'found the authored spAutoFit title after editing').not.toBeNull();
+		expect(after!.height).toBeCloseTo(before!.height, 1);
+		await expect(undo).toBeDisabled();
+		await expect(page.getByText('Unsaved changes', { exact: true })).toHaveCount(0);
 	});
 
 	test('autofit, wrap="none", default fonts and run splitting agree run for run', async ({

--- a/packages/angular/src/viewer/inline-edit-autofit-commit.test.ts
+++ b/packages/angular/src/viewer/inline-edit-autofit-commit.test.ts
@@ -55,35 +55,49 @@ describe('resolveCommitTextAutoFitHeight', () => {
 	it('grows the shape to the measured content height for spAutoFit', () => {
 		stubScrollHeight(250);
 		const editor = document.createElement('textarea');
-		const result = resolveCommitTextAutoFitHeight([makeTextElement()], 'tx_1', editor);
+		const result = resolveCommitTextAutoFitHeight([makeTextElement()], 'tx_1', 'Changed', editor);
 		expect(result).toBe(250);
+	});
+
+	it('does not resize an unchanged spAutoFit shape', () => {
+		stubScrollHeight(42);
+		const editor = document.createElement('textarea');
+		const result = resolveCommitTextAutoFitHeight(
+			[makeTextElement({ height: 162 })],
+			'tx_1',
+			'Hello',
+			editor,
+		);
+		expect(result).toBeUndefined();
 	});
 
 	it('never resizes for normAutofit (font-shrink mode)', () => {
 		stubScrollHeight(250);
 		const editor = document.createElement('textarea');
 		const el = makeTextElement({ textStyle: { autoFitMode: 'normal' } });
-		expect(resolveCommitTextAutoFitHeight([el], 'tx_1', editor)).toBeUndefined();
+		expect(resolveCommitTextAutoFitHeight([el], 'tx_1', 'Changed', editor)).toBeUndefined();
 	});
 
 	it('never resizes a shape with no autofit at all', () => {
 		stubScrollHeight(250);
 		const editor = document.createElement('textarea');
 		const el = makeTextElement({ textStyle: {} });
-		expect(resolveCommitTextAutoFitHeight([el], 'tx_1', editor)).toBeUndefined();
+		expect(resolveCommitTextAutoFitHeight([el], 'tx_1', 'Changed', editor)).toBeUndefined();
 	});
 
 	it('returns undefined when the element cannot be found (e.g. deleted mid-edit)', () => {
 		stubScrollHeight(250);
 		const editor = document.createElement('textarea');
-		expect(resolveCommitTextAutoFitHeight([makeTextElement()], 'missing', editor)).toBeUndefined();
+		expect(
+			resolveCommitTextAutoFitHeight([makeTextElement()], 'missing', 'Changed', editor),
+		).toBeUndefined();
 	});
 
 	it('returns undefined for an element with no text properties (e.g. a table)', () => {
 		stubScrollHeight(250);
 		const editor = document.createElement('textarea');
 		const el = { id: 'tbl_1', type: 'table', x: 0, y: 0, width: 100, height: 40 } as PptxElement;
-		expect(resolveCommitTextAutoFitHeight([el], 'tbl_1', editor)).toBeUndefined();
+		expect(resolveCommitTextAutoFitHeight([el], 'tbl_1', 'Changed', editor)).toBeUndefined();
 	});
 });
 
@@ -101,16 +115,23 @@ describe('resolveCommitTextNormAutofitShrink', () => {
 		stubScrollHeight(400);
 		const editor = document.createElement('textarea');
 		const el = makeTextElement({ textStyle: { autoFitMode: 'normal' } });
-		expect(resolveCommitTextNormAutofitShrink([el], 'tx_1', editor)).toStrictEqual({
+		expect(resolveCommitTextNormAutofitShrink([el], 'tx_1', 'Changed', editor)).toStrictEqual({
 			fontScale: 0.25,
 			lnSpcReduction: 0.2,
 		});
 	});
 
+	it('does not recompute an unchanged normAutofit shape', () => {
+		stubScrollHeight(400);
+		const editor = document.createElement('textarea');
+		const el = makeTextElement({ textStyle: { autoFitMode: 'normal' } });
+		expect(resolveCommitTextNormAutofitShrink([el], 'tx_1', 'Hello', editor)).toBe('unchanged');
+	});
+
 	it('never shrinks for spAutoFit (shape-resize mode)', () => {
 		stubScrollHeight(400);
 		const editor = document.createElement('textarea');
-		expect(resolveCommitTextNormAutofitShrink([makeTextElement()], 'tx_1', editor)).toBe(
+		expect(resolveCommitTextNormAutofitShrink([makeTextElement()], 'tx_1', 'Changed', editor)).toBe(
 			'unchanged',
 		);
 	});
@@ -118,8 +139,8 @@ describe('resolveCommitTextNormAutofitShrink', () => {
 	it('returns unchanged when the element cannot be found (e.g. deleted mid-edit)', () => {
 		stubScrollHeight(400);
 		const editor = document.createElement('textarea');
-		expect(resolveCommitTextNormAutofitShrink([makeTextElement()], 'missing', editor)).toBe(
-			'unchanged',
-		);
+		expect(
+			resolveCommitTextNormAutofitShrink([makeTextElement()], 'missing', 'Changed', editor),
+		).toBe('unchanged');
 	});
 });

--- a/packages/angular/src/viewer/inline-edit-autofit-commit.ts
+++ b/packages/angular/src/viewer/inline-edit-autofit-commit.ts
@@ -3,6 +3,7 @@ import { hasTextProperties } from 'pptx-viewer-core';
 
 import type { NormAutofitShrinkResult } from '../internal/shared';
 import {
+	buildInlineTextCommitPatch,
 	resolveInlineEditAutoFitHeight,
 	resolveInlineEditNormAutofitShrink,
 } from '../internal/shared';
@@ -22,10 +23,11 @@ import {
 export function resolveCommitTextAutoFitHeight(
 	elements: readonly PptxElement[],
 	id: string,
+	text: string,
 	editor: HTMLTextAreaElement,
 ): number | undefined {
 	const el = elements.find((e) => e.id === id);
-	if (!el || !hasTextProperties(el)) {
+	if (!el || !hasTextProperties(el) || !buildInlineTextCommitPatch(el, text)) {
 		return undefined;
 	}
 	return resolveInlineEditAutoFitHeight(el.textStyle, el.height, editor);
@@ -41,10 +43,11 @@ export function resolveCommitTextAutoFitHeight(
 export function resolveCommitTextNormAutofitShrink(
 	elements: readonly PptxElement[],
 	id: string,
+	text: string,
 	editor: HTMLTextAreaElement,
 ): NormAutofitShrinkResult {
 	const el = elements.find((e) => e.id === id);
-	if (!el || !hasTextProperties(el)) {
+	if (!el || !hasTextProperties(el) || !buildInlineTextCommitPatch(el, text)) {
 		return 'unchanged';
 	}
 	return resolveInlineEditNormAutofitShrink(el.textStyle, el.height, editor);

--- a/packages/angular/src/viewer/slide-canvas.component.ts
+++ b/packages/angular/src/viewer/slide-canvas.component.ts
@@ -985,17 +985,17 @@ export class SlideCanvasComponent implements SlideContext {
 			return;
 		}
 		const editor = event.target as HTMLTextAreaElement;
+		const text = this.viewerOpts ? this.viewerOpts.autoCorrect(editor.value) : editor.value;
 		// `a:spAutoFit` ("Resize shape to fit text"): grow/shrink the shape to
-		// the text's natural content height, the way PowerPoint does. `editor`
-		// is the live, still-mounted textarea (this handler runs off its own
-		// `blur`), so no separate DOM lookup is needed here.
-		const height = resolveCommitTextAutoFitHeight(this.allElements(), id, editor);
+		// the text's natural content height after a real edit. `editor` is the
+		// live, still-mounted textarea (this handler runs off its own `blur`), so
+		// no separate DOM lookup is needed here.
+		const height = resolveCommitTextAutoFitHeight(this.allElements(), id, text, editor);
 		// `a:normAutofit` ("Shrink text on overflow"): recompute the font
 		// scale/line-spacing reduction so the (possibly now longer or shorter)
 		// text still fits the shape. Mutually exclusive with the `spAutoFit`
 		// resize above (both read `autoFitMode`, only one mode is ever set).
-		const shrink = resolveCommitTextNormAutofitShrink(this.allElements(), id, editor);
-		const text = this.viewerOpts ? this.viewerOpts.autoCorrect(editor.value) : editor.value;
+		const shrink = resolveCommitTextNormAutofitShrink(this.allElements(), id, text, editor);
 		this.textCommit.emit({
 			id,
 			text,

--- a/packages/react/src/viewer/hooks/useCanvasInteractions.autofit.test.tsx
+++ b/packages/react/src/viewer/hooks/useCanvasInteractions.autofit.test.tsx
@@ -100,14 +100,18 @@ function Harness({
 	element,
 	inlineEditingText,
 	updateElementById,
+	markDirty,
+	transformCommittedText,
 }: {
 	element: PptxElement;
 	inlineEditingText: string;
 	updateElementById: (elementId: string, updates: Partial<PptxElement>) => void;
+	markDirty?: () => void;
+	transformCommittedText?: (text: string) => string;
 }) {
 	const elementLookup = new Map([[element.id, element]]);
 	const ops = { updateElementById } as unknown as ElementOperations;
-	const history = { markDirty: () => {} } as unknown as EditorHistoryResult;
+	const history = { markDirty: markDirty ?? (() => {}) } as unknown as EditorHistoryResult;
 	const input: UseCanvasInteractionsInput = {
 		mode: 'edit',
 		canEdit: true,
@@ -136,6 +140,7 @@ function Harness({
 		inlineEditingText,
 		ops,
 		history,
+		transformCommittedText,
 		presentationHandleAction: () => {},
 		setEditingEquationOmml: () => {},
 		setIsEquationDialogOpen: () => {},
@@ -156,6 +161,8 @@ function mount(props: {
 	element: PptxElement;
 	inlineEditingText: string;
 	updateElementById: (elementId: string, updates: Partial<PptxElement>) => void;
+	markDirty?: () => void;
+	transformCommittedText?: (text: string) => string;
 }): void {
 	act(() => {
 		root.render(<Harness {...props} />);
@@ -188,6 +195,45 @@ describe('useCanvasInteractions - spAutoFit editor resize', () => {
 		const [elementId, updates] = updateElementById.mock.calls[0];
 		expect(elementId).toBe('tx_1');
 		expect(updates.height).toBe(250);
+	});
+
+	it('does not resize or dirty an unchanged spAutoFit shape on blur', () => {
+		stubScrollHeight(42);
+		const updateElementById = vi.fn<(elementId: string, updates: Partial<PptxElement>) => void>();
+		const markDirty = vi.fn<() => void>();
+		mount({
+			element: makeTextElement({ height: 162 }),
+			inlineEditingText: 'Hello',
+			updateElementById,
+			markDirty,
+		});
+
+		act(() => {
+			getInlineEditor().dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+		});
+
+		expect(updateElementById).not.toHaveBeenCalled();
+		expect(markDirty).not.toHaveBeenCalled();
+	});
+
+	it('resizes when autocorrect changes otherwise unchanged text', () => {
+		stubScrollHeight(55);
+		const updateElementById = vi.fn<(elementId: string, updates: Partial<PptxElement>) => void>();
+		mount({
+			element: makeTextElement(),
+			inlineEditingText: 'Hello',
+			updateElementById,
+			transformCommittedText: () => '“Hello”',
+		});
+
+		act(() => {
+			getInlineEditor().dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+		});
+
+		expect(updateElementById).toHaveBeenCalledWith(
+			'tx_1',
+			expect.objectContaining({ text: '“Hello”', height: 55 }),
+		);
 	});
 
 	it('does not touch height for normAutofit (font-shrink mode)', () => {

--- a/packages/react/src/viewer/hooks/useCanvasInteractions.ts
+++ b/packages/react/src/viewer/hooks/useCanvasInteractions.ts
@@ -2,6 +2,7 @@ import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, TextStyle } from 'pptx-viewer-core';
 import {
 	beginShapeAdjustment,
+	buildInlineTextCommitPatch,
 	canInteractWithElement,
 	filterInteractableIds,
 	resolveInlineEditAutoFitHeight,
@@ -20,7 +21,6 @@ import type {
 	ElementContextMenuState,
 } from '../types';
 import type { ViewerMode } from '../types-core';
-import { remapTextToSegments } from '../utils/remap-text';
 import type { CanvasInteractionHandlers } from './canvas-interaction-types';
 import type { EditorHistoryResult } from './useEditorHistory';
 import type { ElementOperations } from './useElementOperations';
@@ -143,7 +143,12 @@ export function useCanvasInteractions(
 			const committedText = transformCommittedText
 				? transformCommittedText(inlineEditingText)
 				: inlineEditingText;
-			const newSegments = remapTextToSegments(committedText, el.textSegments, el.textStyle);
+			const textPatch = buildInlineTextCommitPatch(el, committedText);
+			if (!textPatch) {
+				setInlineEditingElementId(null);
+				setInlineEditingText('');
+				return;
+			}
 			// `a:spAutoFit` ("Resize shape to fit text"): grow/shrink the shape to
 			// the text's natural content height, the way PowerPoint does. The
 			// editor's DOM node is still mounted here (the state update below is
@@ -159,8 +164,7 @@ export function useCanvasInteractions(
 			// `autoFitMode`, only one of the two modes is ever set).
 			const shrink = resolveInlineEditNormAutofitShrink(el.textStyle, el.height, editorEl);
 			ops.updateElementById(editId, {
-				text: committedText,
-				textSegments: newSegments,
+				...textPatch,
 				...(newHeight !== undefined ? { height: newHeight } : {}),
 				...(shrink !== 'unchanged'
 					? {


### PR DESCRIPTION
## Summary

- skip React and Angular autofit commit work when post-autocorrect text is unchanged
- preserve spAutoFit and normAutofit recomputation for real text changes
- keep unchanged editor closes out of dirty history

## Why

React currently runs measurement, element update, and dirty marking for every valid inline-editor close. Angular computes autofit metadata before its existing shared no-op gate, so measured metadata turns an unchanged close into a real update.

The change applies the existing unchanged-text invariant before autofit work. Vue already returns on post-autocorrect text equality, while Svelte and Vanilla only call their commit path when editor text changed, so they need no source change.

## Verification

- current main baseline, same five-binding browser test: React reported Unsaved changes; Angular shrank the authored shape from 35.7375 px to 31.2703 px; Vue, Svelte, and Vanilla passed
- patched five-binding no-op browser test: 5/5 passed
- existing five-binding inline-edit persistence test: 5/5 passed
- React focused tests: 8/8
- Angular focused tests: 10/10
- React full suite: 6,983/6,983
- Angular full suite: 3,552/3,552
- React and Angular TypeScript checks passed
- monorepo build, formatting, lint, diff checks, and E2E neutrality passed
- independent code and real-browser reviews passed

The browser review also confirmed that real edits still persist and produce dirty state. A separate pre-existing React Undo issue was reproduced on unmodified main and is intentionally outside this PR.