### PR TITLE
fix(vanilla): keep rich text runs inline while editing

### DIFF
--- a/e2e/text-layout-parity.spec.ts
+++ b/e2e/text-layout-parity.spec.ts
@@ -116,6 +116,10 @@ test.describe('cross-binding text layout', () => {
 		await target.dblclick();
 		const editor = page.locator('[data-inline-editor]');
 		await editor.waitFor();
+		const editingText = await editor.evaluate((node) =>
+			node instanceof HTMLTextAreaElement ? node.value : (node as HTMLElement).innerText,
+		);
+		expect(editingText).toContain('Alpha Beta');
 		const stageBox = (await slideStage(page).boundingBox())!;
 		await page.mouse.click(stageBox.x + stageBox.width * 0.95, stageBox.y + stageBox.height * 0.95);
 		await expect(editor).toBeHidden();

--- a/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
@@ -43,14 +43,10 @@ describe('openInlineEditor caret placement', () => {
 		expect(sel!.rangeCount).toBe(1);
 		const range = sel!.getRangeAt(0);
 		expect(range.collapsed).toBeTruthy();
-		// End position: after the last child (segment span) of the surface, or at
-		// the end of its trailing text node.
-		const endsAtEnd =
-			(range.endContainer === session.el && range.endOffset === session.el.childNodes.length) ||
-			(range.endContainer.nodeType === Node.TEXT_NODE &&
-				range.endContainer.textContent === 'TARGET' &&
-				range.endOffset === 'TARGET'.length);
-		expect(endsAtEnd).toBeTruthy();
+		const beforeCaret = document.createRange();
+		beforeCaret.selectNodeContents(session.el);
+		beforeCaret.setEnd(range.endContainer, range.endOffset);
+		expect(beforeCaret.toString()).toBe('TARGET');
 
 		session.cancel();
 		overlayRoot.remove();
@@ -118,9 +114,10 @@ describe('openInlineEditor caret placement', () => {
 				onSelectionChange,
 				onClose: () => {},
 			});
+			const segmentSpans = session.el.querySelectorAll('[data-seg-idx]');
 			const range = document.createRange();
-			range.setStart(session.el.childNodes[startChild].firstChild!, startOffset);
-			range.setEnd(session.el.childNodes[endChild].firstChild!, endOffset);
+			range.setStart(segmentSpans[startChild].firstChild!, startOffset);
+			range.setEnd(segmentSpans[endChild].firstChild!, endOffset);
 			const selection = window.getSelection()!;
 			selection.removeAllRanges();
 			selection.addRange(range);
@@ -137,6 +134,40 @@ describe('openInlineEditor caret placement', () => {
 			overlayRoot.remove();
 		},
 	);
+
+	it('keeps adjacent rich-text runs in one flex item', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: {
+				...textElement(),
+				text: 'Alpha Beta',
+				textSegments: [
+					{ text: 'Alpha ', style: { bold: true } },
+					{ text: 'Beta', style: { italic: true } },
+				],
+			} as PptxElement,
+			onCommit: () => {},
+			onClose: () => {},
+		});
+
+		expect(session.el.style.flexDirection).toBe('column');
+		expect(session.el.children).toHaveLength(1);
+		const flow = session.el.querySelector('[data-pptx-text-flow]');
+		expect(flow?.parentElement).toBe(session.el);
+		expect(flow?.tagName).toBe('DIV');
+		expect(
+			Array.from(flow?.querySelectorAll('[data-seg-idx]') ?? []).map((span) => span.textContent),
+		).toStrictEqual(['Alpha ', 'Beta']);
+		expect(readEditableText(session.el)).toBe('Alpha Beta');
+
+		session.cancel();
+		overlayRoot.remove();
+	});
 });
 
 describe('openInlineEditor input handling', () => {
@@ -255,7 +286,8 @@ describe('openInlineEditor input handling', () => {
 		const inserted = document.createElement('span');
 		inserted.dataset.segIdx = '0';
 		inserted.appendChild(document.createElement('br'));
-		session.el.appendChild(inserted);
+		const textFlow = session.el.querySelector<HTMLElement>('[data-pptx-text-flow]')!;
+		textFlow.appendChild(inserted);
 		const range = document.createRange();
 		range.setStart(inserted, 0);
 		range.collapse(true);
@@ -278,7 +310,7 @@ describe('openInlineEditor input handling', () => {
 		nestedRun.dataset.segIdx = '0';
 		nestedRun.appendChild(document.createElement('br'));
 		insertedBlock.appendChild(nestedRun);
-		session.el.appendChild(insertedBlock);
+		textFlow.appendChild(insertedBlock);
 		range.setStart(nestedRun, 0);
 		range.collapse(true);
 		selection.removeAllRanges();
@@ -313,10 +345,11 @@ describe('openInlineEditor input handling', () => {
 		});
 
 		const originalRun = session.el.querySelector<HTMLElement>('[data-seg-idx="0"]')!;
+		const textFlow = originalRun.parentElement!;
 		const leading = document.createElement('span');
 		leading.dataset.segIdx = '0';
 		leading.appendChild(document.createElement('br'));
-		session.el.insertBefore(leading, originalRun);
+		textFlow.insertBefore(leading, originalRun);
 		const range = document.createRange();
 		range.setStart(originalRun.firstChild!, 0);
 		range.collapse(true);
@@ -351,9 +384,10 @@ describe('openInlineEditor input handling', () => {
 		});
 
 		const originalRun = session.el.querySelector<HTMLElement>('[data-seg-idx="0"]')!;
+		const textFlow = originalRun.parentElement!;
 		originalRun.dataset.segIdx = '1';
 		const originalBlock = document.createElement('div');
-		session.el.insertBefore(originalBlock, originalRun);
+		textFlow.insertBefore(originalBlock, originalRun);
 		originalBlock.appendChild(originalRun);
 		const leadingBlock = document.createElement('div');
 		const marker = document.createElement('span');
@@ -364,7 +398,7 @@ describe('openInlineEditor input handling', () => {
 		leadingRun.dataset.segIdx = '1';
 		leadingRun.appendChild(document.createElement('br'));
 		leadingBlock.append(marker, leadingRun);
-		session.el.insertBefore(leadingBlock, originalBlock);
+		textFlow.insertBefore(leadingBlock, originalBlock);
 		const range = document.createRange();
 		range.setStart(originalRun.firstChild!, 0);
 		range.collapse(true);

--- a/packages/vanilla/src/viewer/editor/inline-text-editor.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-editor.ts
@@ -193,7 +193,14 @@ export function openInlineEditor(options: OpenInlineEditorOptions): InlineEditor
 	surface.dataset.inlineEditor = '';
 	surface.setAttribute('role', 'textbox');
 	surface.setAttribute('aria-multiline', 'true');
+	let textContainer = surface;
 	if (withText?.textSegments?.length) {
+		// The text-block style makes the surface a flex column so vertical
+		// alignment applies to paragraphs. Keep rich-text runs inside one flex
+		// item; direct flex children are blockified onto separate rows.
+		const textFlow = doc.createElement('div');
+		textFlow.dataset.pptxTextFlow = '';
+		textContainer = textFlow;
 		const segments = withText.textSegments;
 		segments.forEach((segment, index) => {
 			const span = doc.createElement('span');
@@ -216,8 +223,9 @@ export function openInlineEditor(options: OpenInlineEditorOptions): InlineEditor
 			} else {
 				span.textContent = segment.text;
 			}
-			surface.appendChild(span);
+			textFlow.appendChild(span);
 		});
+		surface.appendChild(textFlow);
 	} else {
 		surface.textContent = initialText;
 	}
@@ -273,7 +281,7 @@ export function openInlineEditor(options: OpenInlineEditorOptions): InlineEditor
 	surface.focus();
 	// Caret at the END of the seeded text so typing appends (the contract the
 	// other bindings follow; focus alone leaves the caret at the start).
-	placeCaretAtEnd(surface);
+	placeCaretAtEnd(textContainer);
 
 	return {
 		el: surface,

--- a/packages/vanilla/src/viewer/editor/inline-text-paragraph-marker.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-paragraph-marker.ts
@@ -30,8 +30,9 @@ export function markInsertedParagraph(doc: Document, surface: HTMLElement): void
 		return;
 	}
 	const block = insertedRun.closest<HTMLElement>('div, p');
+	const isTextFlow = block?.hasAttribute('data-pptx-text-flow');
 	const caretParagraph =
-		block && block !== surface && surface.contains(block) ? block : insertedRun;
+		block && block !== surface && !isTextFlow && surface.contains(block) ? block : insertedRun;
 	const previous = caretParagraph.previousElementSibling;
 	const paragraph =
 		previous instanceof HTMLElement &&


### PR DESCRIPTION
## What does this change?

Keeps adjacent styled text runs on the same visual line when a user enters inline editing in the Vanilla viewer.

The editor intentionally applies the authored text-block flex layout so vertical alignment still matches the slide. Its rich-run spans were direct children of that flex column, however, so the browser promoted each run to a separate flex item and displayed adjacent runs on separate rows. This change groups the seeded runs in one structural flow container while leaving the authored layout on the outer editor unchanged.

Caret placement, text extraction, browser-created paragraph detection, bullets, empty list items, no-op commits, and real text edits retain their existing behavior.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Docs / tooling / CI only

---

## Cross-binding parity

| Binding | Affected? | Fixed here? | Notes |
| --- | --- | --- | --- |
| React | no | no | Parsed rich-text paragraphs already keep adjacent runs inline |
| Vue | no | no | Uses one contiguous plain-text edit surface |
| Angular | no | no | Uses one contiguous textarea value |
| Svelte | no | no | Uses one contiguous plain-text edit surface |
| Vanilla | yes | yes | Direct rich-run children were blockified as separate flex items |

### UI fix

- [x] I reproduced the bug or confirmed its absence in every binding above
- [x] Every affected binding is fixed in this PR

The same framework-neutral regression runs in all five Playwright projects. Current main fails only in Vanilla because the live editor contains a line break between `Alpha ` and `Beta`; the patched branch passes in all five.

## Testing

- Vanilla focused editor tests: 12/12 passed
- Vanilla full test suite: 1,780/1,780 passed
- Framework-neutral inline-edit regression: 5/5 passed across React, Vue, Angular, Vanilla, and Svelte
- Existing real inline-edit regression: 5/5 passed across all bindings
- Vanilla typecheck and full monorepo build passed
- E2E neutrality, formatting, lint, and `git diff --check` passed
- Independent code review found no blocker
- Independent Chromium review verified same-line rich runs, no-op blur, a real rich-text edit, Enter after an existing bullet, a second generated bullet, dirty/Undo state, and no console errors

## Conventional Commits

- [x] My commit message follows Conventional Commits
