### PR TITLE
fix(core): preserve fractional table row heights

### DIFF
--- a/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
@@ -15,6 +15,116 @@ import type { TablePptxElement } from '../../core/types/elements';
  * `SAVE_ELEMENT_SKIPPED` warning. The saved slide had an empty `p:spTree`.
  */
 describe('sDK-created table survives save round-trip', () => {
+	it.each([
+		'no edit',
+		'other shape',
+		'cell text',
+		'row height',
+		'add row',
+		'delete row',
+		'add column',
+		'delete column',
+	])('preserves row-height precision through load/save after %s', async (edit) => {
+		const emuPerPx = 9525;
+		const expectedHeights = [825500, 370840, 914400];
+		const { handler: creator, data, createSlide } = await PresentationBuilder.create();
+		data.slides.push(
+			createSlide('Blank')
+				.addText('Title', { x: 20, y: 10, width: 300, height: 40 })
+				.addTable(
+					{
+						rows: expectedHeights.map((height, index) => ({
+							height: height / emuPerPx,
+							cells: [{ text: `Row ${index}` }, { text: 'Value' }],
+						})),
+					},
+					{ x: 20, y: 80, width: 400, height: 240 },
+				)
+				.build(),
+		);
+		const fixture = await creator.save(data.slides);
+		const handler = new PptxHandler();
+		const loaded = await handler.load(fixture.buffer as ArrayBuffer);
+		const title = loaded.slides[0].elements.find(
+			(element) => element.type === 'text' && element.text === 'Title',
+		)!;
+		const table = loaded.slides[0].elements.find((element) => element.type === 'table')!;
+		const tableData = table.tableData!;
+
+		switch (edit) {
+			case 'other shape':
+				title.x += 10;
+				break;
+			case 'cell text':
+				tableData.rows[0].cells[0].text = 'Edited cell';
+				break;
+			case 'row height':
+				tableData.rows[0].height = 42.25;
+				expectedHeights[0] = Math.round(42.25 * emuPerPx);
+				break;
+			case 'add row':
+				tableData.rows.push({ height: 31.5, cells: [{ text: 'New row' }, { text: 'Value' }] });
+				expectedHeights.push(Math.round(31.5 * emuPerPx));
+				break;
+			case 'delete row':
+				tableData.rows.splice(1, 1);
+				expectedHeights.splice(1, 1);
+				break;
+			case 'add column':
+				tableData.columnWidths = [1 / 3, 1 / 3, 1 / 3];
+				for (const row of tableData.rows) {
+					row.cells.push({ text: 'New column' });
+				}
+				break;
+			case 'delete column':
+				tableData.columnWidths = [1];
+				for (const row of tableData.rows) {
+					row.cells.pop();
+				}
+				break;
+		}
+
+		const saved = await handler.save(loaded.slides);
+		const zip = await JSZip.loadAsync(saved);
+		const xml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+		expect(
+			[...xml.matchAll(/<a:tr\b[^>]*\bh="(\d+)"/g)].map((match) => Number(match[1])),
+		).toStrictEqual(expectedHeights);
+		if (edit === 'cell text') {
+			expect(xml).toContain('Edited cell');
+		}
+		if (edit === 'add row') {
+			expect(xml).toContain('New row');
+		}
+		if (edit === 'add column') {
+			expect(xml).toContain('New column');
+		}
+
+		const reloader = new PptxHandler();
+		const reloaded = await reloader.load(saved.buffer as ArrayBuffer);
+		const reloadedTable = reloaded.slides[0].elements.find((element) => element.type === 'table')!;
+		expect(
+			reloadedTable.tableData!.rows.map((row) => Math.round(row.height! * emuPerPx)),
+		).toStrictEqual(expectedHeights);
+		if (edit === 'other shape') {
+			expect(
+				reloaded.slides[0].elements.find(
+					(element) => element.type === 'text' && element.text === 'Title',
+				)!.x,
+			).toBe(title.x);
+		}
+		if (edit === 'row height') {
+			// A dirty re-save must preserve the explicitly resized row too.
+			reloadedTable.x += 1;
+			const savedAgain = await reloader.save(reloaded.slides);
+			const secondZip = await JSZip.loadAsync(savedAgain);
+			const secondXml = await secondZip.file('ppt/slides/slide1.xml')!.async('string');
+			expect(
+				[...secondXml.matchAll(/<a:tr\b[^>]*\bh="(\d+)"/g)].map((match) => Number(match[1])),
+			).toStrictEqual(expectedHeights);
+		}
+	});
+
 	it('addTable then save → reload preserves rows, columns, and cell text', async () => {
 		const { handler, data, createSlide } = await PresentationBuilder.create();
 		data.slides.push(

--- a/packages/core/src/core/core/builders/PptxTableDataParser.ts
+++ b/packages/core/src/core/core/builders/PptxTableDataParser.ts
@@ -78,7 +78,7 @@ export class PptxTableDataParser implements IPptxTableDataParser {
 			const xmlRows = this.context.ensureArray(tableNode['a:tr']) as XmlObject[];
 			const rows: PptxTableRow[] = xmlRows.map((rowNode) => {
 				const rowHeightEmu = parseInt(String(rowNode?.['@_h'] || '0'), 10) || 0;
-				const rowHeight = Math.round(rowHeightEmu / this.context.emuPerPx);
+				const rowHeight = rowHeightEmu / this.context.emuPerPx;
 				const xmlCells = this.context.ensureArray(rowNode['a:tc']) as XmlObject[];
 
 				return {

--- a/packages/core/src/core/core/builders/table-data-parser.test.ts
+++ b/packages/core/src/core/core/builders/table-data-parser.test.ts
@@ -125,7 +125,7 @@ describe('pptxTableDataParser - grid column widths', () => {
 // ---------------------------------------------------------------------------
 
 describe('pptxTableDataParser - row heights', () => {
-	it('converts row height from EMU to rounded pixels', () => {
+	it('preserves fractional pixels when converting row heights from EMU', () => {
 		const graphicData = makeTableXml({
 			gridCols: ['9144000'],
 			rows: [
@@ -136,8 +136,19 @@ describe('pptxTableDataParser - row heights', () => {
 		const parser = new PptxTableDataParser(makeContext());
 		const result = parser.parseTableData(graphicData);
 
-		expect(result!.rows[0].height).toBe(Math.round(370840 / EMU_PER_PX));
-		expect(result!.rows[1].height).toBe(Math.round(914400 / EMU_PER_PX));
+		expect(result!.rows[0].height).toBe(370840 / EMU_PER_PX);
+		expect(result!.rows[1].height).toBe(914400 / EMU_PER_PX);
+	});
+
+	it.each([0, 1, 4762, 4763, 825500, 9144001])('round-trips a row height of %i EMU', (height) => {
+		const parser = new PptxTableDataParser(makeContext());
+		const result = parser.parseTableData(
+			makeTableXml({
+				gridCols: ['9144000'],
+				rows: [{ height: String(height), cells: [makeCell('A')] }],
+			}),
+		);
+		expect(Math.round(result!.rows[0].height! * EMU_PER_PX)).toBe(height);
 	});
 
 	it('defaults row height to 0 when @_h is missing', () => {

--- a/packages/core/src/core/core/builders/table-parser-spec.test.ts
+++ b/packages/core/src/core/core/builders/table-parser-spec.test.ts
@@ -108,8 +108,8 @@ describe('pptxTableDataParser — table structure', () => {
 
 		expect(result).toBeDefined();
 		expect(result!.rows).toHaveLength(1);
-		// 370840 / 9525 ≈ 38.93 → Math.round = 39
-		expect(result!.rows[0].height).toBe(Math.round(370840 / EMU_PER_PX));
+		// Preserve fractional pixels so save can recover the original EMU.
+		expect(result!.rows[0].height).toBe(370840 / EMU_PER_PX);
 	});
 
 	it('extracts cell text from a:txBody > a:p > a:r > a:t', () => {


### PR DESCRIPTION
## What does this change?

Preserve fractional table row heights when loading PPTX files. The production change removes parse-time pixel rounding; save still rounds at the integer-EMU output boundary.

For example, an authored height of `825500` EMU is `86.6667px`. It currently loads as `87px`, then becomes `828675` EMU when the table is serialized after a cell edit or an unrelated shape edit on the same slide. This is a small but unintended change to authored geometry, not a change to resize snapping or display preferences.

## Type of change

- [x] Bug fix (non-breaking)

## Why this approach?

The rounded-pixel parser and its assertions date to the initial implementation (`3edaf123`). This change follows the later preservation work in `6fb27675` and exact-EMU conversion work in `175dbbdc`: retain authored precision until serialization. Whole-slide passthrough protects an entirely untouched slide, but not an untouched table on an edited slide.

`PptxTableRow.height` already represents numeric pixels, and the renderers accept fractional heights. Removing the rounding fixes both in-place table serialization and structural rebuilds without adding a table snapshot/cache or changing explicit resize and row-insertion behavior.

## Cross-binding parity

This is a core parsing fix inherited by all five bindings; no binding code changes are needed.

Independent real-Chromium review used the existing `e2e/fixtures/table-styling.pptx` deck:

- Baseline React: edit slide 4 cell `R2C1`, File -> Save, then reload. All four row heights on that slide changed from `825500` to `828675` EMU; unedited slides retained their original heights.
- Patched React, Vue, Svelte, and Vanilla: the same visible edit/save/reload flow preserved the edited text and all 20 authored row heights exactly. Dirty/Undo state worked, with no browser console errors.
- Patched React row insertion: Insert Row Below survived save/reload; the new default 40px row was `381000` EMU while the existing rows stayed `825500` EMU.
- Angular browser validation was blocked before loading: current-main build fails on a missing `morph-extra-layers.component` and an unresolved `pptx-viewer-shared` import. It was not counted as a browser pass.

## Testing

- [x] Updated existing parser tests and added round-trip cases to the existing table SDK save test file; no new test file.
- [x] Regression tests fail without the parser change.
- [x] Covered no edit, unrelated shape edits, cell edits, explicit fractional row resize, row/column insertion and deletion, reload, and a second dirty save after resize.
- [x] Kept missing-height behavior and covered zero, subpixel/boundary, exact-grid, and off-grid heights.
- [x] Independent code review and independent browser review completed.
- [x] Focused core tests: 70 passed across six files.
- [x] Core TypeScript check and changed-file lint/format checks passed.

Full core suite: 13,970 passed, with 220 pre-existing failures across `smartart-gallery-ground-truth.test.ts` (218) and `native-animation-media-duration-fixture.test.ts` (2). The pre-fix run with these regression tests had the same 220 failures plus 14 row-height failures. Comparing failed test names shows all 14 row-height failures resolved and no new failures. The complete suite is therefore not claimed as green.

## Conventional Commits

- [x] Commit follows Conventional Commits (`fix(core)`).
