### PR TITLE
fix(react,vue): honor explicit slide insertion indexes

### DIFF
--- a/packages/react/src/viewer/hooks/editor-dirty-wiring.test.tsx
+++ b/packages/react/src/viewer/hooks/editor-dirty-wiring.test.tsx
@@ -54,9 +54,9 @@ const { PptxHandler } = await import('pptx-viewer-core');
 const { PowerPointViewer } = await import('../../index');
 type ViewerHandle = import('../../index').PowerPointViewerHandle;
 
-/** A real one-slide package, so the viewer mounts its editor chrome. */
-async function sampleDeck(): Promise<Uint8Array> {
-	const { handler, data } = await PptxHandler.create({ initialSlideCount: 1 });
+/** A real package, so the viewer mounts its editor chrome. */
+async function sampleDeck(initialSlideCount = 1): Promise<Uint8Array> {
+	const { handler, data } = await PptxHandler.create({ initialSlideCount });
 	try {
 		return await handler.save(data.slides);
 	} finally {
@@ -126,6 +126,74 @@ async function flushUntilLoaded(ref: React.RefObject<ViewerHandle | null>): Prom
 }
 
 describe('an ordinary edit marks the document dirty', () => {
+	it.each([
+		{ afterIndex: -1, active: 2, inserted: 0 },
+		{ afterIndex: 0, active: 2, inserted: 1 },
+		{ afterIndex: 1, active: 0, inserted: 2 },
+		{ afterIndex: 2, active: 0, inserted: 3 },
+		{ afterIndex: 99, active: 0, inserted: 3 },
+		{ afterIndex: undefined, active: 0, inserted: 1 },
+		{ afterIndex: 'sidebar click' as const, active: 0, inserted: 1 },
+	])(
+		'addSlide($afterIndex) inserts at $inserted with slide $active active',
+		async ({ afterIndex, active, inserted }) => {
+			const content = await sampleDeck(3);
+			const ref = createRef<ViewerHandle>();
+			await act(async () => {
+				root.render(
+					<PowerPointViewer ref={ref} content={content} filePath='slide-order.pptx' canEdit />,
+				);
+			});
+			await flushUntilLoaded(ref);
+			await act(async () => {
+				handleOf(ref).goTo(active);
+				if (afterIndex === 'sidebar click') {
+					handleOf(ref).setMode('edit');
+				}
+			});
+			const original = handleOf(ref)
+				.getSlides()
+				.map((slide) => slide.id);
+			await act(async () => {
+				if (afterIndex === 'sidebar click') {
+					const button = [...container.querySelectorAll('aside button')].find(
+						(element) => element.textContent?.trim() === 'Add Slide',
+					) as HTMLButtonElement;
+					expect(button).toBeDefined();
+					button.click();
+				} else {
+					handleOf(ref).addSlide(afterIndex);
+				}
+			});
+			const slides = handleOf(ref).getSlides();
+			expect(slides).toHaveLength(4);
+			expect(original).not.toContain(slides[inserted].id);
+			expect(
+				slides.filter((_, index) => index !== inserted).map((slide) => slide.id),
+			).toStrictEqual(original);
+			expect(handleOf(ref).getActiveSlideIndex()).toBe(inserted);
+			expect(handleOf(ref).isDirty()).toBeTruthy();
+			expect(handleOf(ref).canUndo()).toBeTruthy();
+			const addedIds = slides.map((slide) => slide.id);
+			await act(async () => {
+				handleOf(ref).undo();
+			});
+			expect(
+				handleOf(ref)
+					.getSlides()
+					.map((slide) => slide.id),
+			).toStrictEqual(original);
+			await act(async () => {
+				handleOf(ref).redo();
+			});
+			expect(
+				handleOf(ref)
+					.getSlides()
+					.map((slide) => slide.id),
+			).toStrictEqual(addedIds);
+		},
+	);
+
 	it('raises the dirty flag useAutosave gates on, and reports it to the host', async () => {
 		const content = await sampleDeck();
 		const ref = createRef<ViewerHandle>();

--- a/packages/react/src/viewer/hooks/useSlideManagement.ts
+++ b/packages/react/src/viewer/hooks/useSlideManagement.ts
@@ -32,6 +32,7 @@ export interface UseSlideManagementInput {
 
 export interface SlideManagementHandlers {
 	handleAddSlide: () => void;
+	handleAddSlideAfter: (afterIndex: number) => void;
 	handleMoveSlide: (fromIndex: number, toIndex: number) => void;
 	handleSlideContextMenu: (e: React.MouseEvent, index: number) => void;
 	handleDeleteSlides: (indexes: number[]) => void;
@@ -69,16 +70,18 @@ export function useSlideManagement(input: UseSlideManagementInput): SlideManagem
 		theme,
 	} = input;
 
-	const handleAddSlide = () => {
+	const handleAddSlideAfter = (afterIndex: number) => {
+		const insertAt = Math.max(0, Math.min(afterIndex + 1, slides.length));
 		const newSlide = createBlankSlide(slides.length + 1);
 		ops.updateSlides((prev) => {
 			const next = [...prev];
-			next.splice(activeSlideIndex + 1, 0, newSlide);
+			next.splice(insertAt, 0, newSlide);
 			return next;
 		});
-		setActiveSlideIndex(activeSlideIndex + 1);
+		setActiveSlideIndex(insertAt);
 		history.markDirty();
 	};
+	const handleAddSlide = () => handleAddSlideAfter(activeSlideIndex);
 
 	const handleMoveSlide = (fromIndex: number, toIndex: number) => {
 		if (fromIndex === toIndex) {
@@ -224,6 +227,7 @@ export function useSlideManagement(input: UseSlideManagementInput): SlideManagem
 
 	return {
 		handleAddSlide,
+		handleAddSlideAfter,
 		handleMoveSlide,
 		handleSlideContextMenu,
 		handleDeleteSlides,

--- a/packages/react/src/viewer/hooks/useViewerIntegration.ts
+++ b/packages/react/src/viewer/hooks/useViewerIntegration.ts
@@ -382,8 +382,12 @@ export function useViewerIntegration(input: UseViewerIntegrationInput): ViewerIn
 				return slides[activeSlideIndex];
 			},
 			// -- Slide manipulation --
-			addSlide(_afterIndex?: number) {
-				editorOps.slideOps.handleAddSlide();
+			addSlide(afterIndex?: number) {
+				if (afterIndex === undefined) {
+					editorOps.slideOps.handleAddSlide();
+				} else {
+					editorOps.slideOps.handleAddSlideAfter(afterIndex);
+				}
 			},
 			deleteSlides(indexes: number[]) {
 				editorOps.slideOps.handleDeleteSlides(indexes);

--- a/packages/vue/src/viewer/PowerPointViewer.edit.test.ts
+++ b/packages/vue/src/viewer/PowerPointViewer.edit.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import ComparePanel from './components/ComparePanel.vue';
 import VersionHistoryPanel from './components/VersionHistoryPanel.vue';
 import PowerPointViewer from './PowerPointViewer.vue';
+import type { PowerPointViewerExpose } from './types';
 
 /**
  * Smoke test for the editing wiring. With no `content`, `useLoadContent` settles
@@ -12,6 +13,51 @@ import PowerPointViewer from './PowerPointViewer.vue';
  * content only appears in edit/master mode, so it gates on `canEdit`.
  */
 describe('powerPointViewer editing wiring', () => {
+	it.each([
+		{ afterIndex: -1, active: 2, inserted: 0 },
+		{ afterIndex: 0, active: 2, inserted: 1 },
+		{ afterIndex: 1, active: 0, inserted: 2 },
+		{ afterIndex: 2, active: 0, inserted: 3 },
+		{ afterIndex: 99, active: 0, inserted: 3 },
+		{ afterIndex: undefined, active: 0, inserted: 1 },
+	])(
+		'addSlide($afterIndex) inserts at $inserted with slide $active active',
+		async ({ afterIndex, active, inserted }) => {
+			const wrapper = mount(PowerPointViewer, { props: { canEdit: true } });
+			try {
+				await flushPromises();
+				const viewer = wrapper.vm as unknown as PowerPointViewerExpose;
+				for (let index = 0; index < 3; index++) {
+					viewer.addSlide();
+					await flushPromises();
+				}
+				viewer.goTo(active);
+				await flushPromises();
+				const original = viewer.getSlides().map((slide) => slide.id);
+				viewer.addSlide(afterIndex);
+				await flushPromises();
+				const slides = viewer.getSlides();
+				expect(slides).toHaveLength(4);
+				expect(original).not.toContain(slides[inserted].id);
+				expect(
+					slides.filter((_, index) => index !== inserted).map((slide) => slide.id),
+				).toStrictEqual(original);
+				expect(viewer.getActiveSlideIndex()).toBe(inserted);
+				expect(viewer.isDirty()).toBeTruthy();
+				expect(viewer.canUndo()).toBeTruthy();
+				const addedIds = slides.map((slide) => slide.id);
+				viewer.undo();
+				await flushPromises();
+				expect(viewer.getSlides().map((slide) => slide.id)).toStrictEqual(original);
+				viewer.redo();
+				await flushPromises();
+				expect(viewer.getSlides().map((slide) => slide.id)).toStrictEqual(addedIds);
+			} finally {
+				wrapper.unmount();
+			}
+		},
+	);
+
 	it('hides the ribbon tab content when not editable', async () => {
 		const wrapper = mount(PowerPointViewer, { props: { canEdit: false } });
 		await flushPromises();

--- a/packages/vue/src/viewer/composables/useSlideOperations.ts
+++ b/packages/vue/src/viewer/composables/useSlideOperations.ts
@@ -29,8 +29,8 @@ export interface UseSlideOperationsInput {
 }
 
 export interface UseSlideOperationsResult {
-	/** Insert a blank slide directly after the active slide. */
-	addSlide: () => void;
+	/** Insert after the given index, or after the active slide when omitted. */
+	addSlide: (afterIndex?: number) => void;
 	/** Remove the slide at `index` (no-op when only one slide remains). */
 	deleteSlide: (index: number) => void;
 	/** Deep-clone the slide at `index` and insert the copy right after it. */
@@ -42,10 +42,10 @@ export interface UseSlideOperationsResult {
 export function useSlideOperations(input: UseSlideOperationsInput): UseSlideOperationsResult {
 	const { slides, activeSlideIndex, pushHistory } = input;
 
-	const addSlide = (): void => {
+	const addSlide = (afterIndex = activeSlideIndex.value): void => {
 		pushHistory();
 		const next = [...slides.value];
-		const insertAt = Math.max(0, Math.min(activeSlideIndex.value + 1, next.length));
+		const insertAt = Math.max(0, Math.min(afterIndex + 1, next.length));
 		next.splice(insertAt, 0, createBlankSlide(next.length + 1));
 		slides.value = next;
 		activeSlideIndex.value = insertAt;

--- a/packages/vue/src/viewer/composables/useViewerApi.ts
+++ b/packages/vue/src/viewer/composables/useViewerApi.ts
@@ -41,7 +41,7 @@ export interface UseViewerApiOptions {
 		canRedo: ComputedRef<boolean> | Ref<boolean>;
 	};
 	slideOps: {
-		addSlide: () => void;
+		addSlide: (afterIndex?: number) => void;
 		deleteSlide: (index: number) => void;
 		duplicateSlide: (index: number) => void;
 		moveSlide: (from: number, to: number) => void;
@@ -109,7 +109,7 @@ export function useViewerApi(options: UseViewerApiOptions): PowerPointViewerExpo
 		getSlide: (index: number) => slides.value[index],
 		getActiveSlide: () => activeSlide.value,
 		// -- Slide manipulation --
-		addSlide: () => slideOps.addSlide(),
+		addSlide: (afterIndex?: number) => slideOps.addSlide(afterIndex),
 		deleteSlides: (indexes: number[]) => {
 			// Descending, so each removal cannot shift the index of one still pending.
 			for (const i of [...indexes].sort((a, b) => b - a)) {


### PR DESCRIPTION
## What does this change?

Fixes React and Vue ignoring the explicit `afterIndex` argument to the public `addSlide(afterIndex)` API. For example, with the last slide selected, `addSlide(0)` currently appends instead of inserting after the first slide.

React's imperative adapter discarded the argument, and Vue's adapter did not forward it. This wires the argument into the existing slide operations and clamps the insertion position, matching the other bindings. React keeps a separate zero-argument UI callback so a sidebar click event cannot be interpreted as an index.

The omitted-argument behavior and normal New Slide action remain unchanged: React and Vue still insert after the active slide. Their binding-specific documentation describes this behavior, although the shared API documentation describes appending. This PR deliberately does not resolve that separate default-behavior discrepancy.

I traced the adapter wiring back to the progressive imperative API change, `877339d0`. This is a correction to the existing API, not a new insertion policy or shared abstraction.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

| Binding | Affected? | Fixed here? | Actual browser check |
| --- | --- | --- | --- |
| React | Yes | Yes | Explicit indexes were ignored before; insertion, undo/redo, save/reload, and New Slide now pass. |
| Vue | Yes | Yes | Same reproduction and patched checks as React. |
| Angular | No | Not needed | With the last slide active, `addSlide(0)` correctly inserts after the first slide. |
| Svelte | No | Not needed | Same explicit-index insertion check passes. |
| Vanilla | No | Not needed | Same explicit-index insertion check passes. |

- [x] Reproduced the bug or confirmed its absence in every binding above.
- [x] Every affected binding is fixed in this PR.

All browser checks used real Chromium with a generated five-slide fixture. The unaffected bindings also marked insertion dirty and undoable. Angular retains its pre-existing numeric active index; this PR does not change other bindings' focus policies.

## Testing

- [x] Regression tests added to existing React and Vue viewer test files.
- [x] Explicit-index cases fail before the production change and pass afterward.
- [x] Tests cover prepend, first/middle/last insertion, oversized indexes, omitted index, original slide order, active slide, dirty state, and undo/redo.
- [x] A native React sidebar button click verifies that the UI callback remains safe.

Independent code review and an independent real-Chromium browser review were completed. The affected-binding browser checks cover insertion order, focus, dirty state, undo/redo, normal New Slide behavior, and save/reload persistence. The browser reproduction used a temporary consumer of the public viewer API; no harness files are included in this PR.

No framework-neutral e2e spec was added because this fixes imperative API wiring rather than adding a UI feature. The persistent regression coverage mounts each affected viewer and calls its public handle.

## Checks run locally

- React full package suite: 443 files, 7,036 tests passed.
- Vue full package suite: 335 files, 2,880 tests passed.
- Both suites rerun after rebasing onto `6bc1e4c2`, using Node 22 to match CI.
- React `tsc --noEmit` and Vue `vue-tsc --noEmit`: passed after rebase.
- Changed-file `oxfmt --check`, `oxlint --deny-warnings`, and `git diff --check`: passed.
- Independent Chromium checks: React and Vue baseline/patched scenarios; explicit-index spot checks in Angular, Svelte, and Vanilla. No browser console or uncaught page errors.

These are scoped package checks, not a claim that the full monorepo test or e2e suite was run.

## Conventional Commits

- [x] Commit message follows Conventional Commits.
