### PR TITLE
fix(core): preserve empty soft line breaks on load

### DIFF
--- a/packages/core/src/__tests__/integration/inline-field-position-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/inline-field-position-roundtrip.test.ts
@@ -58,6 +58,82 @@ function fieldSegments(segments: TextSegment[] | undefined): Array<[string, stri
 }
 
 describe('inline field position round-trip', () => {
+	it.each(['text', 'table'] as const)(
+		'loads soft line breaks in %s content through the runtime parser',
+		async (kind) => {
+			const cases = [
+				{ content: '<a:br/>', expected: ['<br>'] },
+				{ content: '<a:br/><a:r><a:t>After</a:t></a:r>', expected: ['<br>', 'After'] },
+				{
+					content: '<a:r><a:t>Before</a:t></a:r><a:br/><a:r><a:t>After</a:t></a:r>',
+					expected: ['Before', '<br>', 'After'],
+				},
+				{ content: '<a:r><a:t>Before</a:t></a:r><a:br/>', expected: ['Before', '<br>'] },
+				{
+					content: '<a:r><a:t>Before</a:t></a:r><a:br/><a:br/><a:r><a:t>After</a:t></a:r>',
+					expected: ['Before', '<br>', '<br>', 'After'],
+				},
+				{
+					content:
+						'<a:r><a:t>Before</a:t></a:r><a:br><a:rPr lang="en-US"/></a:br><a:r><a:t>After</a:t></a:r>',
+					expected: ['Before', '<br>', 'After'],
+				},
+				{
+					content: '<a:r><a:t>Before</a:t></a:r><a:r><a:t>After</a:t></a:r>',
+					expected: ['Before', 'After'],
+				},
+			];
+			for (const { content, expected } of cases) {
+				const {
+					handler: creator,
+					data,
+					createSlide,
+				} = await PptxHandler.createBlank({
+					initialSlideCount: 0,
+				});
+				const slide = createSlide('Blank');
+				const bounds = { x: 60, y: 60, width: 500, height: 160 };
+				if (kind === 'table') {
+					slide.addTable({ rows: [{ cells: [{ text: MARKER }] }] }, bounds);
+				} else {
+					slide.addText(MARKER, bounds);
+				}
+				data.slides.push(slide.build());
+				const reader = new PptxHandler();
+				try {
+					const zip = await JSZip.loadAsync(await creator.save(data.slides));
+					const path = 'ppt/slides/slide1.xml';
+					const xml = await zip.file(path)!.async('string');
+					const markerRun = new RegExp(
+						`<a:r>(?:(?!</a:r>).)*${MARKER}(?:(?!</a:r>).)*</a:r>`,
+						'su',
+					);
+					expect(xml).toMatch(markerRun);
+					zip.file(path, xml.replace(markerRun, content));
+					const bytes = await zip.generateAsync({ type: 'uint8array' });
+					const loaded = await reader.load(bytes.buffer as ArrayBuffer);
+					const element = loaded.slides[0].elements.find((candidate) =>
+						kind === 'table'
+							? candidate.type === 'table'
+							: candidate.type === 'text' || candidate.type === 'shape',
+					)!;
+					const runs =
+						element.type === 'table'
+							? element.tableData!.rows[0].cells[0].textRuns
+							: element.textSegments;
+					expect(
+						runs
+							?.filter((run) => !run.isParagraphBreak)
+							.map((run) => (run.isLineBreak ? '<br>' : run.text)),
+					).toStrictEqual(expected);
+				} finally {
+					creator.dispose();
+					reader.dispose();
+				}
+			}
+		},
+	);
+
 	it('loads and saves an inline a:fld at its authored position', async () => {
 		const bytes = await buildDeckWithInlineFields();
 		const handler = new PptxHandler();

--- a/packages/core/src/core/core/builders/table-cell-runs.test.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.test.ts
@@ -38,6 +38,13 @@ function parseCell(xml: string): XmlObject {
 }
 
 describe('extractTableCellTextRuns', () => {
+	it('preserves a paragraph containing only a soft break', () => {
+		const cell = parseCell('<a:tc><a:txBody><a:bodyPr/><a:p><a:br/></a:p></a:txBody></a:tc>');
+		expect(extractTableCellTextRuns(cell, context)).toStrictEqual([
+			{ text: '', isLineBreak: true },
+		]);
+	});
+
 	it('returns undefined for a cell with no runs', () => {
 		const cell = parseCell('<a:tc><a:txBody><a:bodyPr/><a:p/></a:txBody></a:tc>');
 		expect(extractTableCellTextRuns(cell, context)).toBeUndefined();

--- a/packages/core/src/core/core/builders/table-cell-runs.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.ts
@@ -100,26 +100,25 @@ export function extractTableCellTextRuns(
 	}
 
 	const runs: PptxTableCellTextRun[] = [];
-	let textRunCount = 0;
+	let contentRunCount = 0;
 	paragraphs.forEach((paragraph, paragraphIndex) => {
 		if (paragraphIndex > 0) {
 			runs.push({ text: '', isParagraphBreak: true });
 		}
-		const { entries } = paragraphContentEntries(paragraph, CELL_CONTENT_TAGS, (value) =>
-			context.ensureArray(value),
-		);
+		const { entries } = paragraphContentEntries(paragraph, CELL_CONTENT_TAGS);
 		for (const [tag, item] of entries) {
 			if (tag === 'a:br') {
 				runs.push({ text: '', isLineBreak: true });
+				contentRunCount++;
 				continue;
 			}
 			const node = item as XmlObject | undefined;
 			const run: PptxTableCellTextRun = { text: String(node?.['a:t'] ?? '') };
 			applyRunProperties(run, node?.['a:rPr'] as XmlObject | undefined, context);
 			runs.push(run);
-			textRunCount++;
+			contentRunCount++;
 		}
 	});
 
-	return textRunCount > 0 ? runs : undefined;
+	return contentRunCount > 0 ? runs : undefined;
 }

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.ts
@@ -292,9 +292,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 		// its paragraph. `paragraphContentEntries` replays the order recovered
 		// from the raw XML at parse time, and reports `authored: false` when
 		// there was nothing to recover (already grouped, or SDK-built).
-		const { entries, authored } = paragraphContentEntries(p, PARAGRAPH_CONTENT_TAGS, (value) =>
-			this.ensureArray(value),
-		);
+		const { entries, authored } = paragraphContentEntries(p, PARAGRAPH_CONTENT_TAGS);
 		const runCount = this.ensureArray(p['a:r']).length;
 		const breakCount = this.ensureArray(p['a:br']).length;
 		// Legacy repair, kept for the grouped case only: with the true order

--- a/packages/core/src/core/core/runtime/paragraph-sibling-order.test.ts
+++ b/packages/core/src/core/core/runtime/paragraph-sibling-order.test.ts
@@ -24,13 +24,6 @@ const CONTENT_TAGS: ReadonlySet<string> = new Set([
 	'a:br',
 ]);
 
-function ensureArray(value: unknown): unknown[] {
-	if (value === undefined || value === null) {
-		return [];
-	}
-	return Array.isArray(value) ? value : [value];
-}
-
 /** Parse a slide fragment through the runtime parser (annotators included). */
 function parseParagraph(paragraphXml: string): XmlObject {
 	const parsed = factory.createParser().parse(`<p:sp><p:txBody>${paragraphXml}</p:txBody></p:sp>`);
@@ -40,7 +33,7 @@ function parseParagraph(paragraphXml: string): XmlObject {
 /** The `[tag, text]` sequence a paragraph's content children resolve to. */
 function contentSequence(txBody: XmlObject): Array<[string, string]> {
 	const paragraph = txBody['a:p'] as XmlObject;
-	const { entries } = paragraphContentEntries(paragraph, CONTENT_TAGS, ensureArray);
+	const { entries } = paragraphContentEntries(paragraph, CONTENT_TAGS);
 	return entries.map(([tag, item]) => [tag, String((item as XmlObject)?.['a:t'] ?? '')]);
 }
 
@@ -71,7 +64,7 @@ describe('paragraph sibling order', () => {
 	it('reports a grouped paragraph as unauthored so callers keep their fallback', () => {
 		const txBody = parseParagraph(`<a:p>${RUN('a')}${RUN('b')}${FLD('slidenum', '#')}</a:p>`);
 		const paragraph = txBody['a:p'] as XmlObject;
-		const { entries, authored } = paragraphContentEntries(paragraph, CONTENT_TAGS, ensureArray);
+		const { entries, authored } = paragraphContentEntries(paragraph, CONTENT_TAGS);
 		// Grouped by tag already: key iteration is correct, nothing recorded.
 		expect(authored).toBeFalsy();
 		expect(entries.map(([tag]) => tag)).toStrictEqual(['a:r', 'a:r', 'a:fld']);
@@ -84,7 +77,7 @@ describe('paragraph sibling order', () => {
 		);
 		const paragraphs = txBody['a:p'] as unknown as XmlObject[];
 		const sequence = (paragraph: XmlObject): string[] =>
-			paragraphContentEntries(paragraph, CONTENT_TAGS, ensureArray).entries.map(([tag]) => tag);
+			paragraphContentEntries(paragraph, CONTENT_TAGS).entries.map(([tag]) => tag);
 		// The first is grouped (field then run) and needs no correction; the
 		// second is interleaved and must not inherit the first one's order.
 		expect(sequence(paragraphs[0]!)).toStrictEqual(['a:fld', 'a:r']);
@@ -98,7 +91,7 @@ describe('paragraph sibling order', () => {
 			'a:r': [{ 'a:t': 'a' }, { 'a:t': 'b' }],
 			'a:fld': { 'a:t': '#' },
 		};
-		const { entries, authored } = paragraphContentEntries(paragraph, CONTENT_TAGS, ensureArray);
+		const { entries, authored } = paragraphContentEntries(paragraph, CONTENT_TAGS);
 		expect(authored).toBeFalsy();
 		expect(entries).toHaveLength(3);
 	});

--- a/packages/core/src/core/core/runtime/paragraph-sibling-order.ts
+++ b/packages/core/src/core/core/runtime/paragraph-sibling-order.ts
@@ -183,13 +183,14 @@ export interface ParagraphContentEntries {
 export function paragraphContentEntries(
 	paragraph: XmlObject,
 	contentTags: ReadonlySet<string>,
-	ensureArray: (value: unknown) => unknown[],
 ): ParagraphContentEntries {
+	// An empty <a:br/> is parsed as '', but it is still a line break.
+	// Preserve present XML children rather than normalizing them as objects.
 	const order = childOrder.get(paragraph);
 	if (!order) {
 		const entries = Object.keys(paragraph).flatMap((key) =>
 			contentTags.has(key)
-				? ensureArray(paragraph[key]).map((item) => [key, item] as [string, unknown])
+				? ensureItems(paragraph[key]).map((item) => [key, item] as [string, unknown])
 				: [],
 		);
 		return { entries, authored: false };
@@ -203,7 +204,7 @@ export function paragraphContentEntries(
 		if (!contentTags.has(tag)) {
 			continue;
 		}
-		const item = ensureArray(paragraph[tag])[index];
+		const item = ensureItems(paragraph[tag])[index];
 		if (item !== undefined) {
 			entries.push([tag, item]);
 		}


### PR DESCRIPTION
## What does this change?

Preserves a single empty `<a:br/>` when loading text shapes and table cells. An authored `Before<a:br/>After` currently renders as `BeforeAfter` rather than two lines. Styled breaks and multiple breaks already work.

The runtime normalizer treats the parser's empty-string representation as absent. `paragraphContentEntries` now uses its existing XML-specific `ensureItems` helper in both the authored-order and fallback paths, and its two callers no longer inject an object-oriented normalizer. The global runtime normalizer and the separate legacy grouped-break repair are unchanged.

Table parsing also counts a soft break as content, preserving a cell whose paragraph contains only a break. Wholly empty paragraphs retain the existing fallback behavior.

This follows the authored-order work in `beb2067f` and the table-run parsing in `2011c664`; it does not change their ordering or save policies. The prior unit helper preserved empty strings, which is why the production wiring gap was not caught. Regression coverage now goes through the real `PptxHandler.load` path.

An empty break is valid DrawingML; [Microsoft's Open XML documentation](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.break?view=openxml-3.0.1) uses `<a:br/>` between two text runs as its example.

## Type of change

- [x] Bug fix (non-breaking)

## Scope and parity

The fix is in core parsing, consumed by all five bindings. No binding-specific rendering or product default changes are needed.

Independent real-Chromium checks reproduced the baseline loss in React text shapes and tables, with styled and multiple-break controls. After the fix, all five bindings (React, Angular, Vue, Svelte, and Vanilla) render the singleton break in both shapes and tables. Angular was checked after rebuilding core and refreshing its optimized dependency. React additionally covers a break-only cell and no-op save/reload. No browser console or uncaught page errors were observed.

This PR fixes loading/rendering. A separate dirty-slide table serialization issue can reorder retained raw runs and fields; it is not addressed or claimed fixed here.

## Testing

- [x] Regression tests added to an existing integration test file.
- [x] Both real text-shape and table-cell loading regressions fail before the fix.
- [x] Checks lone, leading, middle, and trailing empty singleton breaks; multiple breaks, a styled break, and no-break positive controls.
- [x] Existing authored field-order and paragraph-content tests remain covered.

- Full core suite on Node 22: 830 test files passed, one skipped; 14,148 tests passed, 231 skipped by the existing suite configuration.
- Focused paragraph, table-run, and real-load tests: 60 passed.
- Core TypeScript check, changed-file formatting/lint checks, and `git diff --check`: passed.

These are core package checks, not a claim that the full monorepo or Playwright suite was run.

Independent code and real-browser reviews were performed. Temporary browser harnesses and generated fixtures are not included in the commit.

## Conventional Commits

- [x] Commit message follows Conventional Commits.
