### PR TITLE
fix(core): preserve table inline content order on save

### DIFF
--- a/packages/core/src/__tests__/integration/inline-field-position-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/inline-field-position-roundtrip.test.ts
@@ -2,7 +2,7 @@ import JSZip from 'jszip';
 import { describe, expect, it } from 'vitest';
 
 import { PptxHandler } from '../../core/PptxHandler';
-import type { TextSegment } from '../../core/types';
+import type { PptxData, PptxElement, TablePptxElement, TextSegment } from '../../core/types';
 
 /**
  * Integration: an OOXML field authored INSIDE a sentence must load, and save,
@@ -19,6 +19,10 @@ import type { TextSegment } from '../../core/types';
  */
 
 const MARKER = 'FIELDMARKER';
+const TABLE_MARKER = 'TABLEFIELDMARKER';
+const SLIDE_TABLE_NAME = 'Inline order table';
+const MASTER_TABLE_NAME = 'Master inline order table';
+const LAYOUT_TABLE_NAME = 'Layout inline order table';
 const RPR = '<a:rPr lang="en-US" sz="2000" dirty="0"/>';
 
 /** `"Slide " #slidenum " - " #slidetitle`: literal / field / literal / field. */
@@ -28,11 +32,167 @@ const FIELD_RUNS =
 	`<a:r>${RPR}<a:t> - </a:t></a:r>` +
 	`<a:fld id="{AAAA0000-0000-4000-A000-000000000002}" type="slidetitle">${RPR}<a:t>Title</a:t></a:fld>`;
 
+const TABLE_FIELD_RUNS =
+	`<a:r>${RPR}<a:t>Page </a:t></a:r>` +
+	`<a:fld id="{BBBB0000-0000-4000-A000-000000000001}" type="slidenum">${RPR}<a:t>1</a:t></a:fld>` +
+	`<a:r>${RPR}<a:t> of 10</a:t></a:r>`;
+
+const STYLED_BREAK_RUNS =
+	`<a:r>${RPR}<a:t>Before</a:t></a:r>` +
+	`<a:br>${RPR}</a:br>` +
+	`<a:r>${RPR}<a:t>After</a:t></a:r>`;
+
+const IDENTICAL_TEXT_FIELD_RUNS =
+	`<a:r>${RPR}<a:t>Same</a:t></a:r>` +
+	`<a:fld id="{CCCC0000-0000-4000-A000-000000000001}" type="slidenum">${RPR}<a:t>Same</a:t></a:fld>` +
+	`<a:r>${RPR}<a:t>Same</a:t></a:r>`;
+
 /** Replace the whole marker run with the interleaved field runs. */
 function spliceFields(slideXml: string): string {
 	const markerRun = new RegExp(`<a:r>(?:(?!</a:r>).)*${MARKER}(?:(?!</a:r>).)*</a:r>`, 'su');
 	expect(markerRun.test(slideXml)).toBeTruthy();
 	return slideXml.replace(markerRun, FIELD_RUNS);
+}
+
+function spliceMarkerRun(xml: string, marker: string, replacement: string): string {
+	const markerRun = new RegExp(`<a:r>(?:(?!</a:r>).)*${marker}(?:(?!</a:r>).)*</a:r>`, 'su');
+	expect(markerRun.test(xml)).toBeTruthy();
+	return xml.replace(markerRun, replacement);
+}
+
+function firstGraphicFrame(xml: string): string {
+	const start = xml.indexOf('<p:graphicFrame');
+	const end = xml.indexOf('</p:graphicFrame>', start);
+	expect(start).toBeGreaterThan(-1);
+	expect(end).toBeGreaterThan(start);
+	return xml.slice(start, end + '</p:graphicFrame>'.length);
+}
+
+function withFrameIdentity(frame: string, id: string, name: string): string {
+	return frame.replace(/<p:cNvPr\b[^>]*>/u, (tag) =>
+		tag.replace(/\bid="[^"]*"/u, `id="${id}"`).replace(/\bname="[^"]*"/u, `name="${name}"`),
+	);
+}
+
+function appendToShapeTree(partXml: string, frame: string): string {
+	expect(partXml).toContain('</p:spTree>');
+	return partXml.replace('</p:spTree>', `${frame}</p:spTree>`);
+}
+
+interface TableDeck {
+	bytes: Uint8Array;
+	masterPath?: string;
+	layoutPath?: string;
+}
+
+async function buildTableDeck(
+	content = TABLE_FIELD_RUNS,
+	copyToTemplates = false,
+): Promise<TableDeck> {
+	const { handler, data, createSlide } = await PptxHandler.createBlank({ initialSlideCount: 0 });
+	try {
+		data.slides.push(
+			createSlide('Blank')
+				.addTable(
+					{ rows: [{ cells: [{ text: TABLE_MARKER }] }] },
+					{ x: 60, y: 220, width: 600, height: 100 },
+				)
+				.build(),
+		);
+		if (copyToTemplates) {
+			data.slides[0]!.notes = 'Speaker notes';
+		}
+		const zip = await JSZip.loadAsync(
+			await handler.save(
+				data.slides,
+				copyToTemplates
+					? {
+							handoutMaster: { path: 'ppt/handoutMasters/handoutMaster1.xml' },
+						}
+					: undefined,
+			),
+		);
+		const slidePath = 'ppt/slides/slide1.xml';
+		let slideXml = spliceMarkerRun(
+			await zip.file(slidePath)!.async('string'),
+			TABLE_MARKER,
+			content,
+		);
+		const originalFrame = firstGraphicFrame(slideXml);
+		const slideFrame = withFrameIdentity(originalFrame, '8001', SLIDE_TABLE_NAME);
+		slideXml = slideXml.replace(originalFrame, slideFrame);
+		zip.file(slidePath, slideXml);
+
+		if (!copyToTemplates) {
+			return { bytes: await zip.generateAsync({ type: 'uint8array' }) };
+		}
+
+		const paths = Object.keys(zip.files);
+		const masterPath = paths.find((path) => /^ppt\/slideMasters\/slideMaster\d+\.xml$/u.test(path));
+		const layoutPath = paths.find((path) => /^ppt\/slideLayouts\/slideLayout\d+\.xml$/u.test(path));
+		expect(masterPath).toBeDefined();
+		expect(layoutPath).toBeDefined();
+		const masterFrame = withFrameIdentity(slideFrame, '8002', MASTER_TABLE_NAME);
+		const layoutFrame = withFrameIdentity(slideFrame, '8003', LAYOUT_TABLE_NAME);
+		zip.file(
+			masterPath!,
+			appendToShapeTree(await zip.file(masterPath!)!.async('string'), masterFrame),
+		);
+		zip.file(
+			layoutPath!,
+			appendToShapeTree(await zip.file(layoutPath!)!.async('string'), layoutFrame),
+		);
+		for (const [path, name] of [
+			['ppt/notesMasters/notesMaster1.xml', 'Notes table'],
+			['ppt/handoutMasters/handoutMaster1.xml', 'Handout table'],
+		]) {
+			zip.file(
+				path,
+				appendToShapeTree(
+					await zip.file(path)!.async('string'),
+					withFrameIdentity(slideFrame, '8004', name),
+				),
+			);
+		}
+		return {
+			bytes: await zip.generateAsync({ type: 'uint8array' }),
+			masterPath,
+			layoutPath,
+		};
+	} finally {
+		handler.dispose();
+	}
+}
+
+function arrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function tableByName(elements: PptxElement[] | undefined, name: string): TablePptxElement {
+	const table = elements?.find((element) => element.type === 'table' && element.name === name);
+	expect(table?.type).toBe('table');
+	return table as TablePptxElement;
+}
+
+function tableParagraphTags(partXml: string, tableName: string): string[] {
+	const nameAt = partXml.indexOf(`name="${tableName}"`);
+	const frameStart = partXml.lastIndexOf('<p:graphicFrame', nameAt);
+	const frameEnd = partXml.indexOf('</p:graphicFrame>', nameAt);
+	expect(nameAt).toBeGreaterThan(-1);
+	expect(frameStart).toBeGreaterThan(-1);
+	expect(frameEnd).toBeGreaterThan(nameAt);
+	const frame = partXml.slice(frameStart, frameEnd);
+	const paragraphStart = frame.search(/<a:p(?=[\s>])/u);
+	const paragraphEnd = frame.indexOf('</a:p>', paragraphStart);
+	expect(paragraphStart).toBeGreaterThan(-1);
+	expect(paragraphEnd).toBeGreaterThan(paragraphStart);
+	const paragraph = frame.slice(paragraphStart, paragraphEnd);
+	return [...paragraph.matchAll(/<(a:(?:r|br|fld))(?=[\s/>])/gu)].map((match) => match[1]!);
+}
+
+async function loadTableDeck(deck: TableDeck): Promise<{ handler: PptxHandler; data: PptxData }> {
+	const handler = new PptxHandler();
+	return { handler, data: await handler.load(arrayBuffer(deck.bytes)) };
 }
 
 /** Build a one-slide deck whose only text shape holds the interleaved runs. */
@@ -88,5 +248,206 @@ describe('inline field position round-trip', () => {
 		expect(at(' - ')).toBeLessThan(at('type="slidetitle"'));
 		// The internal ordering markers are never allowed into the file.
 		expect(xml).not.toContain('#pptx-order-');
+	});
+
+	it('keeps an untouched table ordered through the no-op save fast path', async () => {
+		const deck = await buildTableDeck();
+		const { handler, data } = await loadTableDeck(deck);
+		try {
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r', 'a:fld', 'a:r']);
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it('keeps literal / field / literal order when only the table is moved', async () => {
+		const { handler, data } = await loadTableDeck(await buildTableDeck());
+		try {
+			tableByName(data.slides[0]!.elements, SLIDE_TABLE_NAME).x += 10;
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r', 'a:fld', 'a:r']);
+			expect(xml).not.toContain('#pptx-order-');
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it('keeps a styled soft break between its surrounding runs on a dirty slide', async () => {
+		const { handler, data } = await loadTableDeck(await buildTableDeck(STYLED_BREAK_RUNS));
+		try {
+			tableByName(data.slides[0]!.elements, SLIDE_TABLE_NAME).x += 10;
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r', 'a:br', 'a:r']);
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it('keeps field order when only the cell fill is edited', async () => {
+		const { handler, data } = await loadTableDeck(await buildTableDeck());
+		try {
+			const cell = tableByName(data.slides[0]!.elements, SLIDE_TABLE_NAME).tableData!.rows[0]!
+				.cells[0]!;
+			cell.style = { ...cell.style, fillMode: 'solid', backgroundColor: '#AABBCC' };
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r', 'a:fld', 'a:r']);
+			expect(xml).toContain('<a:srgbClr val="AABBCC"');
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it('stays ordered across two dirty saves through the same handler', async () => {
+		const { handler, data } = await loadTableDeck(await buildTableDeck());
+		try {
+			const table = tableByName(data.slides[0]!.elements, SLIDE_TABLE_NAME);
+			table.x += 10;
+			await handler.save(data.slides);
+			table.x += 10;
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r', 'a:fld', 'a:r']);
+			expect(xml).not.toContain('#pptx-order-');
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it('recovers table order after a non-structural rawXml clone', async () => {
+		const { handler, data } = await loadTableDeck(await buildTableDeck());
+		try {
+			const table = tableByName(data.slides[0]!.elements, SLIDE_TABLE_NAME);
+			table.rawXml = structuredClone(table.rawXml);
+			table.y += 10;
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r', 'a:fld', 'a:r']);
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it('uses run kind, not text matching, when literal and field text are identical', async () => {
+		const { handler, data } = await loadTableDeck(await buildTableDeck(IDENTICAL_TEXT_FIELD_RUNS));
+		try {
+			tableByName(data.slides[0]!.elements, SLIDE_TABLE_NAME).x += 10;
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r', 'a:fld', 'a:r']);
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it('still replaces a field with one plain run after a genuine cell text edit', async () => {
+		const { handler, data } = await loadTableDeck(await buildTableDeck());
+		try {
+			const table = tableByName(data.slides[0]!.elements, SLIDE_TABLE_NAME);
+			const cell = table.tableData!.rows[0]!.cells[0]!;
+			cell.text = 'Plain replacement';
+			table.x += 10;
+			const saved = await JSZip.loadAsync(await handler.save(data.slides));
+			const xml = await saved.file('ppt/slides/slide1.xml')!.async('string');
+			expect(tableParagraphTags(xml, SLIDE_TABLE_NAME)).toStrictEqual(['a:r']);
+			expect(xml).toContain('Plain replacement');
+			expect(xml).not.toContain('type="slidenum"');
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it.each([
+		['the template data is passed back unchanged', false],
+		['only master and layout backgrounds are edited', true],
+	] as const)('keeps untouched table order when %s', async (_scenario, editBackgrounds) => {
+		const deck = await buildTableDeck(TABLE_FIELD_RUNS, true);
+		const { handler, data } = await loadTableDeck(deck);
+		try {
+			const master = data.slideMasters!.find((entry) => entry.path === deck.masterPath)!;
+			const layout = data
+				.slideMasters!.flatMap((entry) => entry.layouts ?? [])
+				.find((entry) => entry.path === deck.layoutPath)!;
+			if (editBackgrounds) {
+				master.backgroundColor = '#AABBCC';
+				layout.backgroundColor = '#DDEEFF';
+			}
+			const saved = await JSZip.loadAsync(
+				await handler.save(data.slides, { slideMasters: data.slideMasters }),
+			);
+			expect({
+				master: tableParagraphTags(
+					await saved.file(deck.masterPath!)!.async('string'),
+					MASTER_TABLE_NAME,
+				),
+				layout: tableParagraphTags(
+					await saved.file(deck.layoutPath!)!.async('string'),
+					LAYOUT_TABLE_NAME,
+				),
+			}).toStrictEqual({
+				master: ['a:r', 'a:fld', 'a:r'],
+				layout: ['a:r', 'a:fld', 'a:r'],
+			});
+		} finally {
+			handler.dispose();
+		}
+	});
+
+	it.each([
+		['notesMaster', 'ppt/notesMasters/notesMaster1.xml', 'Notes table'],
+		['handoutMaster', 'ppt/handoutMasters/handoutMaster1.xml', 'Handout table'],
+	] as const)(
+		'keeps an untouched table ordered for a partial %s background edit',
+		async (kind, path, name) => {
+			const { handler, data } = await loadTableDeck(await buildTableDeck(TABLE_FIELD_RUNS, true));
+			try {
+				const saved = await JSZip.loadAsync(
+					await handler.save(data.slides, {
+						[kind]: { path, backgroundColor: '#AABBCC' },
+					}),
+				);
+				const xml = await saved.file(path)!.async('string');
+				expect(tableParagraphTags(xml, name)).toStrictEqual(['a:r', 'a:fld', 'a:r']);
+				expect(xml).toContain('AABBCC');
+			} finally {
+				handler.dispose();
+			}
+		},
+	);
+
+	it('keeps table field order when edited master and layout parts are saved', async () => {
+		const deck = await buildTableDeck(TABLE_FIELD_RUNS, true);
+		const { handler, data } = await loadTableDeck(deck);
+		try {
+			const master = data.slideMasters!.find((entry) => entry.path === deck.masterPath)!;
+			const layout = data
+				.slideMasters!.flatMap((entry) => entry.layouts ?? [])
+				.find((entry) => entry.path === deck.layoutPath)!;
+			tableByName(master.elements, MASTER_TABLE_NAME).x += 10;
+			tableByName(layout.elements, LAYOUT_TABLE_NAME).x += 10;
+			const saved = await JSZip.loadAsync(
+				await handler.save(data.slides, { slideMasters: data.slideMasters }),
+			);
+			const sequences = {
+				master: tableParagraphTags(
+					await saved.file(deck.masterPath!)!.async('string'),
+					MASTER_TABLE_NAME,
+				),
+				layout: tableParagraphTags(
+					await saved.file(deck.layoutPath!)!.async('string'),
+					LAYOUT_TABLE_NAME,
+				),
+			};
+			expect(sequences).toStrictEqual({
+				master: ['a:r', 'a:fld', 'a:r'],
+				layout: ['a:r', 'a:fld', 'a:r'],
+			});
+		} finally {
+			handler.dispose();
+		}
 	});
 });

--- a/packages/core/src/core/core/builders/table-cell-runs.test.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.test.ts
@@ -106,6 +106,21 @@ describe('extractTableCellTextRuns', () => {
 		]);
 	});
 
+	it('distinguishes an inline field from a literal with the same text', () => {
+		const cell = parseCell(
+			'<a:tc><a:txBody><a:p>' +
+				'<a:r><a:t>1</a:t></a:r>' +
+				'<a:fld id="page" type="slidenum"><a:t>1</a:t></a:fld>' +
+				'<a:r><a:t>1</a:t></a:r>' +
+				'</a:p></a:txBody></a:tc>',
+		);
+		expect(extractTableCellTextRuns(cell, context)).toStrictEqual([
+			{ text: '1' },
+			{ text: '1', isField: true },
+			{ text: '1' },
+		]);
+	});
+
 	it('leaves the flat cell text untouched, so the #68 save guard still fires', () => {
 		// The writer decides a cell was EDITED by comparing the flattened text it
 		// re-derives from the source `a:txBody` against `cell.text`; an unedited

--- a/packages/core/src/core/core/builders/table-cell-runs.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.ts
@@ -115,6 +115,9 @@ export function extractTableCellTextRuns(
 			}
 			const node = item as XmlObject | undefined;
 			const run: PptxTableCellTextRun = { text: String(node?.['a:t'] ?? '') };
+			if (tag === 'a:fld') {
+				run.isField = true;
+			}
 			applyRunProperties(run, node?.['a:rPr'] as XmlObject | undefined, context);
 			runs.push(run);
 			textRunCount++;

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveDataSerialization.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveDataSerialization.ts
@@ -97,6 +97,7 @@ import {
 	serializeCellMergeAttributes,
 	serializeTablePropertyFlags,
 } from './save-table-merge-helpers';
+import { recordTableParagraphOrder } from './table-paragraph-save-order';
 import { rebuildTableXmlFromData } from './table-structural-ops';
 import { writeTablePropertiesOwnFillAndEffects } from './table-tblpr-save';
 
@@ -212,6 +213,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 					// don't yet have typed equivalents on the cell-style
 					// shape but must be preserved across save cycles.
 					serializeCellExtraAttributes(xmlCell, cell.extraAttributes);
+					recordTableParagraphOrder(xmlCell, cell.textRuns);
 				}
 			}
 		} catch (e) {

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveDocumentParts.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveDocumentParts.ts
@@ -43,6 +43,7 @@ import {
 	resolveSmartArtSaveLayout,
 } from './smartart-save-geometry';
 import { mergeSmartArtPointXml, mergeSmartArtConnectionXml } from './smartart-xml-builders';
+import { withOrderedTableParagraphs } from './table-paragraph-save-order';
 
 export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 	/** Pending SmartArt data updates to process during save. */
@@ -405,7 +406,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 
 			root['p:cSld'] = cSld;
 			data['p:notesMaster'] = root;
-			this.zip.file(notesMaster.path, this.builder.build(data));
+			this.zip.file(notesMaster.path, this.builder.build(withOrderedTableParagraphs(data)));
 		} catch (e) {
 			console.warn('Failed to save notes master changes:', e);
 		}
@@ -446,7 +447,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 
 			root['p:cSld'] = cSld;
 			data['p:handoutMaster'] = root;
-			this.zip.file(handoutMaster.path, this.builder.build(data));
+			this.zip.file(handoutMaster.path, this.builder.build(withOrderedTableParagraphs(data)));
 		} catch (e) {
 			console.warn('Failed to save handout master changes:', e);
 		}

--- a/packages/core/src/core/core/runtime/slide-save-xml-order.ts
+++ b/packages/core/src/core/core/runtime/slide-save-xml-order.ts
@@ -34,6 +34,7 @@ import type { XmlObject } from '../../types';
 import { SHAPE_TREE_ELEMENT_TAGS } from '../../utils';
 import { assignOrderedXmlChildren, setOwnXmlProperty } from './ordered-xml-children';
 import type { SlideShapeCollectors } from './PptxHandlerRuntimeSaveElementWriter';
+import { withOrderedTableParagraphs } from './table-paragraph-save-order';
 
 const ALTERNATE_CONTENT_TAG = 'mc:AlternateContent';
 const UNRANKED = Number.MAX_SAFE_INTEGER;
@@ -267,5 +268,5 @@ export function buildOrderedSlideXml(options: {
 		}
 	}
 	nextSlide = orderSlideRootChildren(nextSlide, getLocalName);
-	return { ...xmlObj, 'p:sld': nextSlide };
+	return withOrderedTableParagraphs({ ...xmlObj, 'p:sld': nextSlide });
 }

--- a/packages/core/src/core/core/runtime/table-paragraph-save-order.test.ts
+++ b/packages/core/src/core/core/runtime/table-paragraph-save-order.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PptxTableCellTextRun, XmlObject } from '../../types';
+import { PptxRuntimeDependencyFactory } from '../factories/PptxRuntimeDependencyFactory';
+import {
+	recordTableParagraphOrder,
+	withOrderedTableParagraphs,
+} from './table-paragraph-save-order';
+
+const runs: PptxTableCellTextRun[] = [
+	{ text: 'Page ' },
+	{ text: '1', isField: true },
+	{ text: '', isLineBreak: true },
+	{ text: 'of 10' },
+];
+
+function fixture() {
+	const paragraph: XmlObject = {
+		'a:r': [{ 'a:t': 'Page ' }, { 'a:t': 'of 10' }],
+		'a:fld': { '@_id': 'page', '@_type': 'slidenum', 'a:t': '1' },
+		'a:br': '',
+		'a:endParaRPr': { '@_lang': 'en-US' },
+		// Styling may add pPr after the content. Save must use schema order.
+		'a:pPr': { '@_algn': 'ctr' },
+	};
+	const cell: XmlObject = { 'a:txBody': { 'a:p': paragraph } };
+	return { paragraph, cell };
+}
+
+describe('table paragraph save order', () => {
+	it('uses the actual cached parse for untouched tables, without changing other paragraphs', () => {
+		const factory = new PptxRuntimeDependencyFactory();
+		const xml =
+			'<a:p><a:r><a:t>Page </a:t></a:r><a:fld type="slidenum"><a:t>1</a:t></a:fld><a:r><a:t> of 10</a:t></a:r></a:p>';
+		const parsed = factory
+			.createParser()
+			.parse(
+				`<part><shape>${xml}</shape><a:tbl><a:tr><a:tc><a:txBody>${xml}</a:txBody></a:tc></a:tr></a:tbl></part>`,
+			) as XmlObject;
+		const before = structuredClone(parsed);
+		const ordered = withOrderedTableParagraphs(parsed);
+		expect(parsed).toStrictEqual(before);
+		expect((ordered.part as XmlObject).shape).toBe((parsed.part as XmlObject).shape);
+		const saved = factory.createBuilder().build(ordered);
+		const table = saved.slice(saved.indexOf('<a:tbl'));
+		expect(table.indexOf('Page ')).toBeLessThan(table.indexOf('slidenum'));
+		expect(table.indexOf('slidenum')).toBeLessThan(table.indexOf(' of 10'));
+	});
+
+	it('does not apply stale cached source order after raw content changes', () => {
+		const factory = new PptxRuntimeDependencyFactory();
+		const parsed = factory
+			.createParser()
+			.parse(
+				'<a:tbl><a:p><a:r><a:t>A</a:t></a:r><a:br/><a:r><a:t>B</a:t></a:r></a:p></a:tbl>',
+			) as XmlObject;
+		const paragraph = (parsed['a:tbl'] as XmlObject)['a:p'] as XmlObject;
+		paragraph['a:r'] = [{ 'a:t': 'A' }, { 'a:t': 'B' }, { 'a:t': 'C' }];
+		expect(withOrderedTableParagraphs(parsed)).toBe(parsed);
+	});
+
+	it('orders existing nodes only on a serialization copy and leaves cached XML readable', () => {
+		const { paragraph, cell } = fixture();
+		const untouched = { 'a:p': { 'a:r': { 'a:t': 'Plain' } } };
+		const part = { tables: [cell], untouched };
+		const before = structuredClone(part);
+		recordTableParagraphOrder(cell, runs);
+		const ordered = withOrderedTableParagraphs(part);
+		expect(part).toStrictEqual(before);
+		expect(ordered).not.toBe(part);
+		expect(ordered.untouched).toBe(untouched);
+		const result = (ordered.tables[0]['a:txBody'] as XmlObject)['a:p'] as XmlObject;
+		expect(Object.keys(result)).toStrictEqual([
+			'a:pPr',
+			'a:r',
+			'a:fld',
+			'a:br',
+			'a:r#pptx-order-3',
+			'a:endParaRPr',
+		]);
+		expect(result['a:fld']).toBe(paragraph['a:fld']);
+		expect(result['a:br']).toBe('');
+		expect(result['a:r']).toBe((paragraph['a:r'] as XmlObject[])[0]);
+		const xml = new PptxRuntimeDependencyFactory().createBuilder().build(ordered);
+		expect(xml).not.toContain('#pptx-order-');
+		expect(xml.indexOf('Page ')).toBeLessThan(xml.indexOf('slidenum'));
+		expect(xml.indexOf('slidenum')).toBeLessThan(xml.indexOf('<a:br'));
+		expect(xml.indexOf('<a:br')).toBeLessThan(xml.indexOf('of 10'));
+		expect(withOrderedTableParagraphs(part)).toStrictEqual(ordered);
+	});
+
+	it.each([
+		[
+			'missing run',
+			(p: XmlObject) => {
+				p['a:r'] = [{ 'a:t': 'Page ' }];
+			},
+		],
+		[
+			'changed text',
+			(p: XmlObject) => {
+				(p['a:fld'] as XmlObject)['a:t'] = '2';
+			},
+		],
+		[
+			'extra field',
+			(p: XmlObject) => {
+				p['a:fld'] = [p['a:fld'], { 'a:t': '1' }];
+			},
+		],
+		[
+			'inline math',
+			(p: XmlObject) => {
+				p['m:oMath'] = {};
+			},
+		],
+		[
+			'alternate content',
+			(p: XmlObject) => {
+				p['mc:AlternateContent'] = {};
+			},
+		],
+		[
+			'unexpected text',
+			(p: XmlObject) => {
+				p['#text'] = 'unmodelled';
+			},
+		],
+	] as const)('does not guess an order for %s', (_label, mutate) => {
+		const { paragraph, cell } = fixture();
+		mutate(paragraph);
+		recordTableParagraphOrder(cell, runs);
+		expect(withOrderedTableParagraphs(cell)).toBe(cell);
+	});
+
+	it('does not reuse a previous registration when runs are invalidated by an edit', () => {
+		const { cell } = fixture();
+		recordTableParagraphOrder(cell, runs);
+		expect(withOrderedTableParagraphs(cell)).not.toBe(cell);
+		recordTableParagraphOrder(cell, undefined);
+		expect(withOrderedTableParagraphs(cell)).toBe(cell);
+	});
+
+	it('requires the same paragraph count and does not shift content across empty paragraphs', () => {
+		const { paragraph, cell } = fixture();
+		(cell['a:txBody'] as XmlObject)['a:p'] = [{}, paragraph, {}];
+		recordTableParagraphOrder(cell, runs);
+		expect(withOrderedTableParagraphs(cell)).toBe(cell);
+		recordTableParagraphOrder(cell, [
+			{ text: '', isParagraphBreak: true },
+			...runs,
+			{ text: '', isParagraphBreak: true },
+		]);
+		const ordered = withOrderedTableParagraphs(cell);
+		expect(ordered).not.toBe(cell);
+		const paragraphs = (ordered['a:txBody'] as XmlObject)['a:p'] as XmlObject[];
+		expect(paragraphs).toHaveLength(3);
+		expect(paragraphs[0]).toStrictEqual({});
+		expect(paragraphs[2]).toStrictEqual({});
+	});
+
+	it('keeps grouped content and unsupported or absent run metadata untouched', () => {
+		const { cell } = fixture();
+		recordTableParagraphOrder(cell, [runs[0], runs[3], runs[1], runs[2]]);
+		expect(withOrderedTableParagraphs(cell)).toBe(cell);
+		recordTableParagraphOrder(
+			cell,
+			runs.map(({ text, isLineBreak }) => ({ text, isLineBreak })),
+		);
+		expect(withOrderedTableParagraphs(cell)).toBe(cell);
+		expect(withOrderedTableParagraphs({})).toStrictEqual({});
+	});
+});

--- a/packages/core/src/core/core/runtime/table-paragraph-save-order.ts
+++ b/packages/core/src/core/core/runtime/table-paragraph-save-order.ts
@@ -1,0 +1,165 @@
+import type { PptxTableCellTextRun, XmlObject } from '../../types';
+import { assignOrderedXmlChildren, setOwnXmlProperty } from './ordered-xml-children';
+import { paragraphContentEntries } from './paragraph-sibling-order';
+import { ensureItems, isGroupedByTag, isXmlObject } from './xml-child-scan';
+
+const CONTENT_TAGS = new Set(['a:r', 'a:br', 'a:fld']);
+const paragraphOrders = new WeakMap<XmlObject, readonly string[]>();
+
+function runTag(run: PptxTableCellTextRun): string {
+	return run.isLineBreak ? 'a:br' : run.isField ? 'a:fld' : 'a:r';
+}
+
+/** Do not infer positions for content the table run model cannot represent. */
+function supportsOrder(paragraph: XmlObject, tags: readonly string[]): boolean {
+	for (const [key, value] of Object.entries(paragraph)) {
+		if (key.startsWith('@_') || key === 'a:pPr' || key === 'a:endParaRPr') {
+			continue;
+		}
+		if (key === '#text' && String(value).trim() === '') {
+			continue;
+		}
+		if (!CONTENT_TAGS.has(key)) {
+			return false;
+		}
+	}
+	return [...CONTENT_TAGS].every(
+		(tag) =>
+			tags.filter((candidate) => candidate === tag).length === ensureItems(paragraph[tag]).length,
+	);
+}
+
+function matchesParagraph(paragraph: XmlObject, runs: readonly PptxTableCellTextRun[]): boolean {
+	if (!supportsOrder(paragraph, runs.map(runTag))) {
+		return false;
+	}
+	const consumed = new Map<string, number>();
+	for (const run of runs) {
+		const tag = runTag(run);
+		const index = consumed.get(tag) ?? 0;
+		const node = ensureItems(paragraph[tag])[index];
+		if (node === undefined) {
+			return false;
+		}
+		if (tag !== 'a:br' && (!isXmlObject(node) || String(node['a:t'] ?? '') !== run.text)) {
+			return false;
+		}
+		consumed.set(tag, index + 1);
+	}
+	return true;
+}
+
+/**
+ * #68 keeps an unedited cell's rich XML, but the parser grouped its children
+ * by tag. The ordered run model supplies the missing sequence, including when
+ * rawXml was cloned and no longer carries the load-time WeakMap annotation.
+ * Register only exact matches after text/style updates; never rebuild content
+ * from this display model or apply stale runs to a genuinely edited cell.
+ */
+export function recordTableParagraphOrder(
+	xmlCell: XmlObject,
+	textRuns: readonly PptxTableCellTextRun[] | undefined,
+): void {
+	const txBody = xmlCell['a:txBody'];
+	const paragraphs = isXmlObject(txBody) ? ensureItems(txBody['a:p']) : [];
+	for (const paragraph of paragraphs) {
+		if (isXmlObject(paragraph)) {
+			paragraphOrders.delete(paragraph);
+		}
+	}
+	if (!textRuns) {
+		return;
+	}
+	const runsByParagraph: PptxTableCellTextRun[][] = [[]];
+	for (const run of textRuns) {
+		if (run.isParagraphBreak) {
+			runsByParagraph.push([]);
+		} else {
+			runsByParagraph.at(-1)!.push(run);
+		}
+	}
+	if (runsByParagraph.length !== paragraphs.length) {
+		return;
+	}
+	paragraphs.forEach((paragraph, index) => {
+		const runs = runsByParagraph[index];
+		const tags = runs.map(runTag);
+		if (isXmlObject(paragraph) && !isGroupedByTag(tags) && matchesParagraph(paragraph, runs)) {
+			paragraphOrders.set(paragraph, tags);
+		}
+	});
+}
+
+function orderedParagraph(paragraph: XmlObject, tags: readonly string[]): XmlObject {
+	const result: XmlObject = {};
+	for (const [key, value] of Object.entries(paragraph)) {
+		if (!CONTENT_TAGS.has(key) && key !== 'a:pPr' && key !== 'a:endParaRPr') {
+			setOwnXmlProperty(result, key, value);
+		}
+	}
+	if (paragraph['a:pPr'] !== undefined) {
+		result['a:pPr'] = paragraph['a:pPr'];
+	}
+	const consumed = new Map<string, number>();
+	assignOrderedXmlChildren(
+		result,
+		tags.map((tag) => {
+			const index = consumed.get(tag) ?? 0;
+			consumed.set(tag, index + 1);
+			return { tag, node: ensureItems(paragraph[tag])[index] };
+		}),
+	);
+	if (paragraph['a:endParaRPr'] !== undefined) {
+		result['a:endParaRPr'] = paragraph['a:endParaRPr'];
+	}
+	return result;
+}
+
+/**
+ * Copy only paragraphs with a recorded order and their ancestor spine at the
+ * slide/template serialization boundary. Marker keys must never reach cached
+ * rawXml: tag-keyed readers and the next save still need every plain a:r.
+ */
+export function withOrderedTableParagraphs<T>(value: T, insideTable = false): T {
+	if (Array.isArray(value)) {
+		let result: unknown[] = value;
+		value.forEach((item, index) => {
+			const next = withOrderedTableParagraphs(item, insideTable);
+			if (next !== item) {
+				if (result === value) {
+					result = [...value];
+				}
+				result[index] = next;
+			}
+		});
+		return result as T;
+	}
+	if (!isXmlObject(value)) {
+		return value;
+	}
+	let result: XmlObject = value;
+	for (const [key, item] of Object.entries(value)) {
+		if (key.startsWith('@_') || key === '#text') {
+			continue;
+		}
+		const next = withOrderedTableParagraphs(item, insideTable || key === 'a:tbl');
+		if (next !== item) {
+			if (result === value) {
+				result = { ...value };
+			}
+			setOwnXmlProperty(result, key, next);
+		}
+	}
+	let tags = paragraphOrders.get(value);
+	if (!tags && insideTable) {
+		// Untouched template tables may be flushed from a separately parsed
+		// cached part without visiting the element writer. That actual parsed
+		// paragraph already carries its source order, unlike a rawXml clone.
+		const { entries, authored } = paragraphContentEntries(value, CONTENT_TAGS, ensureItems);
+		const sourceTags = entries.map(([tag]) => tag);
+		if (authored && supportsOrder(value, sourceTags)) {
+			tags = sourceTags;
+		}
+	}
+	return (tags ? orderedParagraph(result, tags) : result) as T;
+}

--- a/packages/core/src/core/core/runtime/template-sp-tree-order.ts
+++ b/packages/core/src/core/core/runtime/template-sp-tree-order.ts
@@ -44,6 +44,7 @@ import { setOwnXmlProperty } from './ordered-xml-children';
 import { orderShapeTreeChildren } from './slide-save-xml-order';
 import { scanSpTreeDocumentOrder } from './sp-tree-document-order-scan';
 import type { SpTreeChildPlan } from './sp-tree-document-order-scan';
+import { withOrderedTableParagraphs } from './table-paragraph-save-order';
 
 const ALTERNATE_CONTENT_TAG = 'mc:AlternateContent';
 
@@ -208,10 +209,10 @@ export function orderedTemplatePartXml(options: {
 		? orderShapeTreeChildren(rewrapped, (node) => rebuilt.get(node), getLocalName)
 		: orderContainer(rewrapped, sourceXml ? scanSpTreeDocumentOrder(sourceXml) : [], getLocalName);
 	if (ordered === spTree) {
-		return xmlObj;
+		return withOrderedTableParagraphs(xmlObj);
 	}
 	const nextRoot: XmlObject = { ...root, 'p:cSld': { ...commonSlideData, 'p:spTree': ordered } };
 	const nextPart: XmlObject = { ...xmlObj };
 	setOwnXmlProperty(nextPart, rootTag, nextRoot);
-	return nextPart;
+	return withOrderedTableParagraphs(nextPart);
 }

--- a/packages/core/src/core/types/table.ts
+++ b/packages/core/src/core/types/table.ts
@@ -255,6 +255,8 @@ export interface PptxTableCellTextRun {
 	isParagraphBreak?: boolean;
 	/** This entry is a soft line break (`a:br`) rather than carrying text. */
 	isLineBreak?: boolean;
+	/** This entry carries an `a:fld` value rather than a literal `a:r`. */
+	isField?: true;
 	bold?: boolean;
 	italic?: boolean;
 	underline?: boolean;


### PR DESCRIPTION
## What does this change?

Preserve the position of inline fields and soft breaks in unchanged table cells when saving.

## Type of change

- [x] Bug fix (non-breaking)

### User-visible bug

Open a table containing `Page ` + a slide-number field + ` of 10`, nudge the table, save, and reopen. The cell changes from `Page 1 of 10` to `Page of 101`. A no-op slide save can hide this because it bypasses serialization. Styled line breaks can move to the end of the cell for the same reason.

### Why this change

The earlier #68 fix correctly retains an unchanged cell's rich XML, and the later table-run parser restores authored order for display. However, the retained XML still groups children by tag when the dirty part is serialized. The shape paragraph save path already handles this distinction; the table path was missing it.

- Keep the existing flat-text comparison and genuine text-edit behavior unchanged.
- Add the missing field discriminator to the existing ordered table-run model, so cloned raw XML can recover its sequence without guessing from text.
- Reuse the existing ordered-child serialization convention on temporary copies only. Cached raw XML keeps its ordinary tag keys.
- Preserve the actual existing field and break nodes, including their properties. Reject stale/mismatched run metadata and unsupported paragraph content.
- Cover slide, slide-master, layout, notes-master, and handout-master save routes, including untouched cached tables and partial background-only updates.

This does not change row/column insertion, list behavior, or how plain cell edits replace rich content.

## Testing

- Existing inline-field integration file extended for table movement, fill-only editing, styled breaks, identical field/literal text, raw XML cloning, repeated dirty saves, real text replacement, and template-part routes.
- Before the fix, six dirty-save regressions failed while the no-op and plain-edit controls passed. Additional cached-template and partial notes/handout regressions also failed before their save routes were covered.
- Pure helper tests cover copy-on-write behavior, marker stripping, stale metadata, unsupported children, paragraph boundaries, and source-order recovery. The helper has a colocated unit test; package-level round trips stay in the existing integration file.
- 46 focused tests passed. After rebasing onto current main, the full core suite passed: 834 test files passed, 1 skipped; 14,195 tests passed, 231 skipped. Core TypeScript checking and changed-file formatting/lint checks passed. I did not run the full monorepo suite or claim a full `bun run e2e` pass.
- Independent code review passed.
- Independent real Chromium review reproduced the React keyboard-nudge/save/reopen failure, then verified the fix, styled-break preservation, plain-cell editing, and no-op controls. Public `getContent()` also preserved untouched master/layout tables. Saved output was opened and checked in React, Vue, Angular, Svelte, and Vanilla with no browser errors. Background-edit template routes were tested in core integration tests, not through the browser master-view UI.

## Cross-binding parity

This is core serialization, not framework-specific UI behavior. All five bindings use the same save implementation and inherit the fix; no binding-specific production changes are needed.

## Conventional Commits

- [x] Commit follows Conventional Commits (`fix(core)`).
