### PR TITLE
fix: preserve rich table cells during row and column edits

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -45,7 +45,7 @@ import type { Locator, Page } from '@playwright/test';
 import JSZip from 'jszip';
 
 import { savePptxViaBackstage } from './save-pptx';
-import { centreOf, openMenuOn } from './support/context-menu';
+import { centreOf, chooseCommand, openMenuOn, selectTableCell } from './support/context-menu';
 import { resetTabSession } from './support/deck';
 
 const fixturePath = resolve(
@@ -220,6 +220,58 @@ async function fractionalTableDeck(): Promise<DeckPayload> {
 		mimeType: PPTX_MIME,
 		buffer: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),
 	};
+}
+
+interface RawTableRun {
+	text: string;
+	xml: string;
+}
+
+interface RawTableCell {
+	text: string;
+	runs: RawTableRun[];
+}
+
+/** Read slide 4's authored table cells from a saved browser download. */
+async function savedSlideFourTable(page: Page): Promise<RawTableCell[][]> {
+	const download = await savePptxViaBackstage(page);
+	const savedPath = await download.path();
+	expect(savedPath, 'the browser should retain the downloaded PPTX').not.toBeNull();
+	const zip = await JSZip.loadAsync(await readFile(savedPath!));
+	const slide = zip.file('ppt/slides/slide4.xml');
+	expect(slide, 'the saved package should contain slide 4').not.toBeNull();
+	const xml = await slide!.async('string');
+	const table = xml.match(/<a:tbl>.*?<\/a:tbl>/su)?.[0];
+	expect(table, 'slide 4 should retain its table XML').toBeTruthy();
+	return [...table!.matchAll(/<a:tr\b.*?<\/a:tr>/gsu)].map((row) =>
+		[...row[0].matchAll(/<a:tc>.*?<\/a:tc>/gsu)].map((cell) => ({
+			text: [...cell[0].matchAll(/<a:t>(.*?)<\/a:t>/gsu)].map((match) => match[1]).join(''),
+			runs: [...cell[0].matchAll(/<a:r>(.*?)<\/a:r>/gsu)].map((run) => ({
+				text: [...run[1].matchAll(/<a:t>(.*?)<\/a:t>/gsu)].map((match) => match[1]).join(''),
+				xml: run[0],
+			})),
+		})),
+	);
+}
+
+/** Drive one table-cell context-menu command through the neutral UI contract. */
+async function chooseTableCommand(page: Page, cell: Locator, label: string): Promise<void> {
+	await selectTableCell(page, cell);
+	const menu = await openMenuOn(page, cell);
+	expect(menu.labels).toContain(label.toLowerCase());
+	await chooseCommand(page, label);
+}
+
+function expectMixedRevenueRuns(cell: RawTableCell): void {
+	expect(cell.text).toBe('Revenue grew 42%');
+	expect(cell.runs.map((run) => run.text)).toEqual(['Revenue ', 'grew 42%']);
+	expect(cell.runs[0]?.xml).toContain('sz="1200"');
+	expect(cell.runs[0]?.xml).toContain('b="0"');
+	expect(cell.runs[0]?.xml).toContain('typeface="Arial"');
+	expect(cell.runs[1]?.xml).toContain('sz="2400"');
+	expect(cell.runs[1]?.xml).toContain('b="1"');
+	expect(cell.runs[1]?.xml).toContain('val="C00000"');
+	expect(cell.runs[1]?.xml).toContain('typeface="Georgia"');
 }
 
 async function gotoSlide(page: Page, slideNumber: number): Promise<void> {
@@ -420,6 +472,36 @@ test.describe('table styling', () => {
 		const reloadedCell = reloaded.cells.find((candidate) => candidate.text === 'Fractional cell');
 		expect(reloadedCell, 'the saved edit should survive reloading').toBeTruthy();
 		expect(reloadedCell!.fontSize).toBeCloseTo(14, 2);
+	});
+
+	test('keeps rich cell runs aligned after inserting a middle row', async ({ page }) => {
+		await gotoSlide(page, 4);
+		await chooseTableCommand(page, canvasCell(page, 'R1C1'), 'Insert Row Below');
+
+		const live = await measureTable(page);
+		const liveMixed = cellAt(live, 2, 1);
+		expect(liveMixed.text).toBe('Revenue grew 42%');
+		expect(liveMixed.runs.map((run) => run.text)).toEqual(['Revenue ', 'grew 42%']);
+
+		const rows = await savedSlideFourTable(page);
+		expect(rows).toHaveLength(5);
+		expect(rows[1]?.map((cell) => cell.text)).toEqual(['', '', '', '']);
+		expectMixedRevenueRuns(rows[2]![1]!);
+	});
+
+	test('keeps rich cell runs aligned after deleting the first column', async ({ page }) => {
+		await gotoSlide(page, 4);
+		await chooseTableCommand(page, canvasCell(page, 'R1C1'), 'Delete Column');
+
+		const live = await measureTable(page);
+		const liveMixed = cellAt(live, 1, 0);
+		expect(liveMixed.text).toBe('Revenue grew 42%');
+		expect(liveMixed.runs.map((run) => run.text)).toEqual(['Revenue ', 'grew 42%']);
+
+		const rows = await savedSlideFourTable(page);
+		expect(rows).toHaveLength(4);
+		expect(rows.every((row) => row.length === 3)).toBe(true);
+		expectMixedRevenueRuns(rows[1]![0]!);
 	});
 
 	test('resolves a built-in style GUID the deck does not define', async ({ page }) => {

--- a/packages/angular/src/viewer/editor-context-menu-dispatch.test.ts
+++ b/packages/angular/src/viewer/editor-context-menu-dispatch.test.ts
@@ -14,14 +14,15 @@
  * @module angular-viewer/editor-context-menu-dispatch.test
  */
 
-import type { TablePptxElement } from 'pptx-viewer-core';
-import { describe, expect, it } from 'vitest';
+import type { TablePptxElement, XmlObject } from 'pptx-viewer-core';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { ContextMenuCommandId } from '../internal/shared';
 import { buildContextMenuEntries } from '../internal/shared';
 import { isMergedTableCell, tableMenuContext } from './editor-context-menu-context';
 import type { ContextMenuActions, TableCommandOp } from './editor-context-menu-dispatch';
 import { runContextMenuCommand, tableCommandOp } from './editor-context-menu-dispatch';
+import { EditorContextMenuComponent } from './editor-context-menu.component';
 import type { TableCellSelection } from './table-selection.service';
 
 // ---------------------------------------------------------------------------
@@ -79,6 +80,37 @@ function makeTable(): TablePptxElement {
 
 function selectionAt(rowIndex: number, columnIndex: number): TableCellSelection {
 	return { elementId: 'tbl-1', rowIndex, columnIndex };
+}
+
+function withRawXml(element: TablePptxElement): TablePptxElement {
+	return {
+		...element,
+		rawXml: {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': {
+							'a:gridCol': element.tableData!.columnWidths.map(() => ({ '@_w': '1000' })),
+						},
+						'a:tr': element.tableData!.rows.map((row) => ({
+							'@_h': '370840',
+							'a:tc': row.cells.map((cell) => ({
+								'a:txBody': { 'a:p': { 'a:r': { 'a:t': cell.text ?? '' } } },
+								'a:tcPr': {},
+							})),
+						})),
+					},
+				},
+			},
+		},
+	};
+}
+
+function rawRows(element: TablePptxElement): XmlObject[] {
+	const graphic = element.rawXml?.['a:graphic'] as XmlObject;
+	const graphicData = graphic['a:graphicData'] as XmlObject;
+	const table = graphicData['a:tbl'] as XmlObject;
+	return table['a:tr'] as XmlObject[];
 }
 
 /** The non-table commands, paired with the action each must reach. */
@@ -193,6 +225,56 @@ describe('tableCommandOp', () => {
 		const table = makeTable();
 		expect(op?.(table, selectionAt(0, 0))).toBe(table);
 	});
+
+	it('commits the rebuilt raw XML from a structural context-menu operation', () => {
+		const element = withRawXml(makeTable());
+		const updateElement = vi.fn();
+		const harness = {
+			tableCtx: () => ({ element, sel: selectionAt(0, 0) }),
+			slideIndex: () => 4,
+			editor: { updateElement },
+		};
+		const applyTable = (
+			EditorContextMenuComponent.prototype as unknown as {
+				applyTable(op: TableCommandOp): void;
+			}
+		).applyTable;
+		const op = tableCommandOp('table-insert-row-below');
+
+		applyTable.call(harness, op!);
+
+		expect(updateElement).toHaveBeenCalledOnce();
+		const [, , patch] = updateElement.mock.calls[0] as [number, string, TablePptxElement];
+		expect(patch.tableData?.rows).toHaveLength(4);
+		expect(rawRows(patch)).toHaveLength(4);
+		expect(patch.rawXml).not.toBe(element.rawXml);
+		expect(rawRows(element)).toHaveLength(3);
+	});
+
+	it.each(['table-delete-row', 'table-delete-col'] as const)(
+		'does not commit %s when the table has only one cell',
+		(id) => {
+			const element = withRawXml({
+				...makeTable(),
+				tableData: { columnWidths: [1], rows: [{ cells: [{ text: 'only' }] }] },
+			});
+			const updateElement = vi.fn();
+			const harness = {
+				tableCtx: () => ({ element, sel: selectionAt(0, 0) }),
+				slideIndex: () => 4,
+				editor: { updateElement },
+			};
+			const applyTable = (
+				EditorContextMenuComponent.prototype as unknown as {
+					applyTable(op: TableCommandOp): void;
+				}
+			).applyTable;
+
+			applyTable.call(harness, tableCommandOp(id)!);
+
+			expect(updateElement).not.toHaveBeenCalled();
+		},
+	);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/angular/src/viewer/editor-context-menu.component.ts
+++ b/packages/angular/src/viewer/editor-context-menu.component.ts
@@ -245,10 +245,14 @@ export class EditorContextMenuComponent {
 			return;
 		}
 		const updated = op(ctx.element, ctx.sel);
-		if (updated.tableData) {
-			this.editor.updateElement(this.slideIndex(), ctx.element.id, {
+		if (updated !== ctx.element && updated.tableData) {
+			const patch: Partial<TablePptxElement> = {
 				tableData: updated.tableData,
-			});
+			};
+			if (updated.rawXml !== ctx.element.rawXml) {
+				patch.rawXml = updated.rawXml;
+			}
+			this.editor.updateElement(this.slideIndex(), ctx.element.id, patch);
 		}
 	}
 }

--- a/packages/angular/src/viewer/table-data-helpers.test.ts
+++ b/packages/angular/src/viewer/table-data-helpers.test.ts
@@ -9,7 +9,7 @@
  * @module angular-viewer/table-data-helpers.test
  */
 
-import type { PptxTableCell, TablePptxElement } from 'pptx-viewer-core';
+import type { PptxTableCell, TablePptxElement, XmlObject } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -50,6 +50,10 @@ function makeTable(rows: string[][], widths?: number[]): TablePptxElement {
 /** Convenience: read a cell from a table element. */
 function cellAt(el: TablePptxElement, r: number, c: number): PptxTableCell | undefined {
 	return el.tableData?.rows[r]?.cells[c];
+}
+
+function rawRows(el: TablePptxElement): XmlObject[] {
+	return el.rawXml!['a:graphic']['a:graphicData']['a:tbl']['a:tr'] as XmlObject[];
 }
 
 // ---------------------------------------------------------------------------
@@ -120,6 +124,55 @@ describe('insertRow', () => {
 		// The anchor's rowSpan grows to 3 rather than the merge being destroyed.
 		expect(cellAt(result, 0, 0)?.rowSpan).toBe(3);
 		expect(cellAt(result, 1, 0)?.vMerge).toBeTruthy();
+	});
+
+	it('keeps a shifted rich raw cell aligned with its tableData row', () => {
+		const el = makeTable([
+			['A', 'B'],
+			['Rich text', 'D'],
+		]);
+		el.rawXml = {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': { 'a:gridCol': [{ '@_w': '1000' }, { '@_w': '1000' }] },
+						'a:tr': [
+							{
+								'@_h': '370840',
+								'a:tc': [
+									{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'A' } } }, 'a:tcPr': {} },
+									{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'B' } } }, 'a:tcPr': {} },
+								],
+							},
+							{
+								'@_h': '370840',
+								'a:tc': [
+									{
+										'a:txBody': {
+											'a:p': {
+												'a:r': [
+													{ 'a:rPr': { '@_b': '1' }, 'a:t': 'Rich ' },
+													{ 'a:rPr': { '@_i': '1' }, 'a:t': 'text' },
+												],
+											},
+										},
+										'a:tcPr': { 'x:opaque': { '@_marker': 'survivor' } },
+									},
+									{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'D' } } }, 'a:tcPr': {} },
+								],
+							},
+						],
+					},
+				},
+			},
+		};
+		const richCell = structuredClone(rawRows(el)[1]['a:tc'][0]);
+
+		const result = insertRow(el, 0, 'below');
+
+		expect(cellAt(result, 2, 0)?.text).toBe('Rich text');
+		expect(rawRows(result)[2]['a:tc'][0]).toStrictEqual(richCell);
+		expect(rawRows(el)).toHaveLength(2);
 	});
 });
 

--- a/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
@@ -2,6 +2,8 @@ import JSZip from 'jszip';
 import { describe, it, expect } from 'vitest';
 
 import { PresentationBuilder } from '../../core/builders/sdk/PresentationBuilder';
+import { rebuildTableStructureInRawXml } from '../../core/core/runtime/table-cell-rawxml-ops';
+import type { TableStructureEdit } from '../../core/core/runtime/table-cell-rawxml-ops';
 import { PptxHandler } from '../../core/PptxHandler';
 import type { TablePptxElement } from '../../core/types/elements';
 
@@ -15,6 +17,99 @@ import type { TablePptxElement } from '../../core/types/elements';
  * `SAVE_ELEMENT_SKIPPED` warning. The saved slide had an empty `p:spTree`.
  */
 describe('sDK-created table survives save round-trip', () => {
+	it.each(
+		(['row', 'column'] as const).flatMap((axis) =>
+			(['insert', 'delete'] as const).flatMap((action) =>
+				[0, 1, action === 'insert' ? 3 : 2].map((index) => ({ axis, action, index })),
+			),
+		),
+	)(
+		'preserves rich surviving cells after $axis $action at $index',
+		async (edit: TableStructureEdit) => {
+			const { handler: creator, data, createSlide } = await PresentationBuilder.create();
+			data.slides.push(
+				createSlide('Blank')
+					.addTable(
+						{
+							rows: Array.from({ length: 3 }, () => ({
+								height: 40,
+								cells: Array.from({ length: 3 }, () => ({ text: 'Rich text' })),
+							})),
+						},
+						{ x: 20, y: 80, width: 400, height: 240 },
+					)
+					.build(),
+			);
+			const initial = await creator.save(data.slides);
+			const handler = new PptxHandler();
+			const loaded = await handler.load(initial.buffer as ArrayBuffer);
+			const table = loaded.slides[0].elements.find((element) => element.type === 'table')!;
+			const rows = table.rawXml!['a:graphic']['a:graphicData']['a:tbl']['a:tr'];
+			for (const row of rows) {
+				for (const cell of row['a:tc']) {
+					cell['a:txBody']['a:p'] = {
+						'a:r': [
+							{ 'a:rPr': { '@_b': '1' }, 'a:t': 'Rich ' },
+							{ 'a:rPr': { '@_i': '1' }, 'a:t': 'text' },
+						],
+					};
+				}
+			}
+			table.x += 1;
+			const richFixture = await handler.save(loaded.slides);
+			const editor = new PptxHandler();
+			const edited = await editor.load(richFixture.buffer as ArrayBuffer);
+			const source = edited.slides[0].elements.find((element) => element.type === 'table')!;
+			const expectedRuns = source.tableData!.rows[0].cells[0].textRuns;
+			expect(expectedRuns).toStrictEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ text: 'Rich ', bold: true }),
+					expect.objectContaining({ text: 'text', italic: true }),
+				]),
+			);
+			const next = structuredClone(source.tableData!);
+			if (edit.axis === 'row') {
+				if (edit.action === 'insert') {
+					next.rows.splice(edit.index, 0, {
+						height: 40,
+						cells: Array.from({ length: 3 }, () => ({ text: '' })),
+					});
+				} else {
+					next.rows.splice(edit.index, 1);
+				}
+			} else {
+				for (const row of next.rows) {
+					if (edit.action === 'insert') {
+						row.cells.splice(edit.index, 0, { text: '' });
+					} else {
+						row.cells.splice(edit.index, 1);
+					}
+				}
+				next.columnWidths = Array.from({ length: edit.action === 'insert' ? 4 : 2 }, () =>
+					edit.action === 'insert' ? 0.25 : 0.5,
+				);
+			}
+			const rawXml = rebuildTableStructureInRawXml(source, next, edit);
+			Object.assign(source, { tableData: next, rawXml });
+			const saved = await editor.save(edited.slides);
+			const reloaded = await new PptxHandler().load(saved.buffer as ArrayBuffer);
+			const result = reloaded.slides[0].elements.find(
+				(element) => element.type === 'table',
+			)!.tableData!;
+			expect(result.rows).toHaveLength(next.rows.length);
+			expect(result.columnWidths).toHaveLength(next.columnWidths.length);
+			for (const [r, row] of result.rows.entries()) {
+				for (const [c, cell] of row.cells.entries()) {
+					const inserted = edit.action === 'insert' && (edit.axis === 'row' ? r : c) === edit.index;
+					expect(cell.text).toBe(inserted ? '' : 'Rich text');
+					if (!inserted) {
+						expect(cell.textRuns).toStrictEqual(expectedRuns);
+					}
+				}
+			}
+		},
+	);
+
 	it.each([
 		'no edit',
 		'other shape',

--- a/packages/core/src/core/core/index.ts
+++ b/packages/core/src/core/core/index.ts
@@ -26,6 +26,7 @@ export { DEFAULT_MAX_UNCOMPRESSED_BYTES, MAX_ZIP_ENTRY_COUNT, ZipBombError } fro
 // Framework-agnostic table XML builders and raw-XML mutation operations,
 // consumed by the viewer bindings (insert tables, edit cell text/style,
 // sync rawXml on merge/structure changes).
+export type { TableStructureEdit } from './runtime/table-structural-ops';
 export {
 	createTableCellXml,
 	createTableGraphicFrameRawXml,

--- a/packages/core/src/core/core/runtime/table-cell-rawxml-ops.test.ts
+++ b/packages/core/src/core/core/runtime/table-cell-rawxml-ops.test.ts
@@ -9,8 +9,12 @@
 import { XMLBuilder, XMLParser } from 'fast-xml-parser';
 import { describe, expect, it } from 'vitest';
 
-import type { PptxElement, XmlObject } from '../../types';
-import { updateCellTextInRawXml, updateCellTextStyleInRawXml } from './table-cell-rawxml-ops';
+import type { PptxElement, PptxTableData, TablePptxElement, XmlObject } from '../../types';
+import {
+	rebuildTableStructureInRawXml,
+	updateCellTextInRawXml,
+	updateCellTextStyleInRawXml,
+} from './table-cell-rawxml-ops';
 import { ensureArray } from './table-structural-helpers';
 
 const parser = new XMLParser({
@@ -49,6 +53,245 @@ function cellOf(rawXml: XmlObject): XmlObject {
 function paragraphsOf(rawXml: XmlObject): XmlObject[] {
 	const txBody = cellOf(rawXml)['a:txBody'] as XmlObject;
 	return ensureArray(txBody['a:p'] as XmlObject | XmlObject[] | undefined);
+}
+
+function rawTableOf(rawXml: XmlObject): XmlObject {
+	const graphic = rawXml['a:graphic'] as XmlObject;
+	const data = graphic['a:graphicData'] as XmlObject;
+	return data['a:tbl'] as XmlObject;
+}
+
+function rawRowsOf(rawXml: XmlObject): XmlObject[] {
+	return ensureArray(rawTableOf(rawXml)['a:tr'] as XmlObject | XmlObject[] | undefined);
+}
+
+function rawGridColumnsOf(rawXml: XmlObject): XmlObject[] {
+	const grid = rawTableOf(rawXml)['a:tblGrid'] as XmlObject;
+	return ensureArray(grid['a:gridCol'] as XmlObject | XmlObject[] | undefined);
+}
+
+function rawCellsOf(row: XmlObject): XmlObject[] {
+	return ensureArray(row['a:tc'] as XmlObject | XmlObject[] | undefined);
+}
+
+function richStructureCellXml(id: string, text = id): XmlObject {
+	return {
+		'@_id': id,
+		'a:txBody': {
+			'a:bodyPr': { '@_anchor': 'ctr' },
+			'a:p': {
+				'a:r': [
+					{ 'a:rPr': { '@_b': '1', '@_lang': 'en-US' }, 'a:t': text.slice(0, 1) },
+					{ 'a:rPr': { '@_i': '1', '@_lang': 'en-US' }, 'a:t': text.slice(1) },
+				],
+			},
+		},
+		'a:tcPr': {
+			'@_marL': '91440',
+			'a:extLst': { 'a:ext': { '@_uri': `urn:${id}`, 'x:opaque': { '@_id': id } } },
+		},
+	};
+}
+
+function structureTableElement(): TablePptxElement {
+	const rows = Array.from({ length: 3 }, (_, row) => ({
+		height: (row + 1) * 10,
+		cells: Array.from({ length: 3 }, (_cell, column) => ({
+			text: `r${row}c${column}`,
+		})),
+	}));
+	return {
+		id: 'structure-table',
+		type: 'table',
+		x: 0,
+		y: 0,
+		width: 300,
+		height: 60,
+		tableData: {
+			columnWidths: [0.2, 0.3, 0.5],
+			rows,
+		},
+		rawXml: {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': {
+							'a:gridCol': [
+								{ '@_w': '200', '@_id': 'g0', 'x:opaque': { '@_id': 'grid-0' } },
+								{ '@_w': '300', '@_id': 'g1', 'x:opaque': { '@_id': 'grid-1' } },
+								{ '@_w': '500', '@_id': 'g2', 'x:opaque': { '@_id': 'grid-2' } },
+							],
+						},
+						'a:tr': rows.map((row, rowIndex) => ({
+							'@_h': String(row.height! * 9525),
+							'@_id': `r${rowIndex}`,
+							'x:opaque': { '@_id': `row-${rowIndex}` },
+							'a:tc': row.cells.map((_, columnIndex) =>
+								richStructureCellXml(`r${rowIndex}c${columnIndex}`),
+							),
+						})),
+					},
+				},
+			},
+		},
+	} as TablePptxElement;
+}
+
+function insertDataRow(data: PptxTableData, index: number): PptxTableData {
+	const rows = [...data.rows];
+	rows.splice(index, 0, {
+		height: 40,
+		cells: data.columnWidths.map(() => ({ text: '', style: {} })),
+	});
+	return { ...data, rows };
+}
+
+function deleteDataRow(data: PptxTableData, index: number): PptxTableData {
+	return { ...data, rows: data.rows.filter((_, rowIndex) => rowIndex !== index) };
+}
+
+function insertDataColumn(data: PptxTableData, index: number): PptxTableData {
+	const columnWidths = [...data.columnWidths];
+	const sourceIndex = index < columnWidths.length ? index : columnWidths.length - 1;
+	const halfWidth = (columnWidths[sourceIndex] ?? 0) / 2;
+	columnWidths[sourceIndex] = halfWidth;
+	columnWidths.splice(index, 0, halfWidth);
+	return {
+		...data,
+		columnWidths,
+		rows: data.rows.map((row) => {
+			const cells = [...row.cells];
+			cells.splice(index, 0, { text: '', style: {} });
+			return { ...row, cells };
+		}),
+	};
+}
+
+function deleteDataColumn(data: PptxTableData, index: number): PptxTableData {
+	const remainingWidths = data.columnWidths.filter((_, columnIndex) => columnIndex !== index);
+	const total = remainingWidths.reduce((sum, width) => sum + width, 0);
+	return {
+		...data,
+		columnWidths: remainingWidths.map((width) => width / total),
+		rows: data.rows.map((row) => ({
+			...row,
+			cells: row.cells.filter((_, columnIndex) => columnIndex !== index),
+		})),
+	};
+}
+
+function rebuild(
+	element: TablePptxElement,
+	next: PptxTableData,
+	edit: Parameters<typeof rebuildTableStructureInRawXml>[2],
+): XmlObject {
+	const rawXml = rebuildTableStructureInRawXml(element, next, edit);
+	expect(rawXml).toBeDefined();
+	return rawXml!;
+}
+
+type MergeAxis = 'row' | 'column';
+
+function mergedTableElement(
+	axis: MergeAxis,
+	anchorText = 'Anchor',
+	targetText = 'Target',
+): TablePptxElement {
+	const anchor = {
+		text: anchorText,
+		textRuns: [{ text: anchorText, bold: true }],
+		style: { fontFamily: 'Anchor Font' },
+		...(axis === 'row' ? { rowSpan: 2 } : { gridSpan: 2 }),
+	};
+	const target = {
+		text: targetText,
+		textRuns: [{ text: targetText, italic: true }],
+		style: { fontFamily: 'Target Font' },
+		...(axis === 'row' ? { vMerge: true } : { hMerge: true }),
+	};
+	const anchorXml = richStructureCellXml('anchor', anchorText);
+	const targetXml = richStructureCellXml('target', targetText);
+	anchorXml[axis === 'row' ? '@_rowSpan' : '@_gridSpan'] = '2';
+	targetXml[axis === 'row' ? '@_vMerge' : '@_hMerge'] = '1';
+
+	const tableData: PptxTableData =
+		axis === 'row'
+			? {
+					columnWidths: [1],
+					rows: [
+						{ height: 10, cells: [anchor] },
+						{ height: 20, cells: [target] },
+					],
+				}
+			: {
+					columnWidths: [0.5, 0.5],
+					rows: [{ height: 10, cells: [anchor, target] }],
+				};
+	const rawRows: XmlObject[] =
+		axis === 'row'
+			? [
+					{ '@_h': '95250', '@_id': 'anchor-row', 'a:tc': anchorXml },
+					{ '@_h': '190500', '@_id': 'target-row', 'a:tc': targetXml },
+				]
+			: [{ '@_h': '95250', '@_id': 'merge-row', 'a:tc': [anchorXml, targetXml] }];
+
+	return {
+		id: `merged-${axis}`,
+		type: 'table',
+		x: 0,
+		y: 0,
+		width: 100,
+		height: 40,
+		tableData,
+		rawXml: {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': {
+							'a:gridCol': Array.from({ length: axis === 'row' ? 1 : 2 }, (_, index) => ({
+								'@_w': axis === 'row' ? '1000' : '500',
+								'@_id': `g${index}`,
+							})),
+						},
+						'a:tr': rawRows.length === 1 ? rawRows[0] : rawRows,
+					},
+				},
+			},
+		},
+	} as TablePptxElement;
+}
+
+function dataAfterDeletingMergeAnchor(element: TablePptxElement, axis: MergeAxis): PptxTableData {
+	const source = element.tableData!;
+	const anchor = source.rows[0].cells[0];
+	const target = axis === 'row' ? source.rows[1].cells[0] : source.rows[0].cells[1];
+	const promoted = {
+		...target,
+		text: anchor.text || target.text,
+		textRuns: anchor.text ? anchor.textRuns : target.textRuns,
+		style: target.style || anchor.style,
+		...(axis === 'row'
+			? { rowSpan: undefined, vMerge: undefined, gridSpan: anchor.gridSpan }
+			: { gridSpan: undefined, hMerge: undefined, rowSpan: anchor.rowSpan }),
+	};
+	return axis === 'row'
+		? { ...source, rows: [{ ...source.rows[1], cells: [promoted] }] }
+		: { ...source, columnWidths: [1], rows: [{ ...source.rows[0], cells: [promoted] }] };
+}
+
+function dataAfterDeletingMergeContinuation(
+	element: TablePptxElement,
+	axis: MergeAxis,
+): PptxTableData {
+	const source = element.tableData!;
+	const anchor = source.rows[0].cells[0];
+	const unmergedAnchor = {
+		...anchor,
+		...(axis === 'row' ? { rowSpan: undefined } : { gridSpan: undefined }),
+	};
+	return axis === 'row'
+		? { ...source, rows: [{ ...source.rows[0], cells: [unmergedAnchor] }] }
+		: { ...source, columnWidths: [1], rows: [{ ...source.rows[0], cells: [unmergedAnchor] }] };
 }
 
 describe('updateCellTextStyleInRawXml with bare properties elements', () => {
@@ -152,6 +395,245 @@ describe('updateCellTextInRawXml emits CT_TextBody in schema order', () => {
 		const run = paragraphsOf(result)[0]['a:r'] as XmlObject;
 		expect(Object.keys(run)).toStrictEqual(['a:rPr', 'a:t']);
 	});
+});
+
+describe('rebuildTableStructureInRawXml structural edit descriptors', () => {
+	it('inserts one blank row while retaining every surviving row and cell node', () => {
+		const source = structureTableElement();
+		const originalRawXml = structuredClone(source.rawXml);
+		const next = insertDataRow(source.tableData!, 1);
+		const result = rebuild(source, next, { axis: 'row', action: 'insert', index: 1 });
+		const rows = rawRowsOf(result);
+
+		expect(rows.map((row) => row['@_id'])).toStrictEqual(['r0', undefined, 'r1', 'r2']);
+		expect(rows.map((row) => row['@_h'])).toStrictEqual(['95250', '381000', '190500', '285750']);
+		expect(rows[0]['x:opaque']).toStrictEqual({ '@_id': 'row-0' });
+		expect(rows[2]['x:opaque']).toStrictEqual({ '@_id': 'row-1' });
+		expect(rows[3]['x:opaque']).toStrictEqual({ '@_id': 'row-2' });
+		expect(rawCellsOf(rows[1]).map((cell) => cell['@_id'])).toStrictEqual([
+			undefined,
+			undefined,
+			undefined,
+		]);
+		rawCellsOf(rows[1]).forEach((cell) => {
+			expect(cell['a:tcPr']).toStrictEqual({});
+			expect(cell['a:txBody']).toStrictEqual({
+				'a:bodyPr': {},
+				'a:lstStyle': {},
+				'a:p': { 'a:endParaRPr': { '@_lang': 'en-US', '@_dirty': '0' } },
+			});
+		});
+		expect(rawCellsOf(rows[2])[0]).toStrictEqual(rawCellsOf(rawRowsOf(originalRawXml!)[1])[0]);
+		expect(rawGridColumnsOf(result)).toStrictEqual(rawGridColumnsOf(originalRawXml!));
+		expect(source.rawXml).toStrictEqual(originalRawXml);
+	});
+
+	it('inserts one blank cell per row while retaining grid, row, and cell provenance', () => {
+		const source = structureTableElement();
+		const originalRows = rawRowsOf(source.rawXml!);
+		const next = insertDataColumn(source.tableData!, 1);
+		const result = rebuild(source, next, { axis: 'column', action: 'insert', index: 1 });
+		const rows = rawRowsOf(result);
+		const columns = rawGridColumnsOf(result);
+
+		expect(columns.map((column) => column['@_id'])).toStrictEqual(['g0', undefined, 'g1', 'g2']);
+		expect(columns.map((column) => column['@_w'])).toStrictEqual(['200', '150', '150', '500']);
+		expect(columns.reduce((sum, column) => sum + Number(column['@_w']), 0)).toBe(1000);
+		expect(columns[0]['x:opaque']).toStrictEqual({ '@_id': 'grid-0' });
+		expect(columns[2]['x:opaque']).toStrictEqual({ '@_id': 'grid-1' });
+		expect(columns[3]['x:opaque']).toStrictEqual({ '@_id': 'grid-2' });
+		expect(rows.map((row) => row['@_id'])).toStrictEqual(['r0', 'r1', 'r2']);
+		expect(rows.map((row) => row['@_h'])).toStrictEqual(['95250', '190500', '285750']);
+		rows.forEach((row, rowIndex) => {
+			const cells = rawCellsOf(row);
+			expect(cells.map((cell) => cell['@_id'])).toStrictEqual([
+				`r${rowIndex}c0`,
+				undefined,
+				`r${rowIndex}c1`,
+				`r${rowIndex}c2`,
+			]);
+			expect(cells[1]['a:tcPr']).toStrictEqual({});
+			expect(cells[2]['a:tcPr']).toStrictEqual(rawCellsOf(originalRows[rowIndex])[1]['a:tcPr']);
+		});
+	});
+
+	it('deletes only the described row and keeps surviving metadata aligned', () => {
+		const source = structureTableElement();
+		const next = deleteDataRow(source.tableData!, 1);
+		const result = rebuild(source, next, { axis: 'row', action: 'delete', index: 1 });
+		const rows = rawRowsOf(result);
+
+		expect(rows.map((row) => row['@_id'])).toStrictEqual(['r0', 'r2']);
+		expect(rows.map((row) => row['@_h'])).toStrictEqual(['95250', '285750']);
+		expect(rows[1]['x:opaque']).toStrictEqual({ '@_id': 'row-2' });
+		expect(rawCellsOf(rows[1]).map((cell) => cell['@_id'])).toStrictEqual(['r2c0', 'r2c1', 'r2c2']);
+		expect(rawGridColumnsOf(result).map((column) => column['@_id'])).toStrictEqual([
+			'g0',
+			'g1',
+			'g2',
+		]);
+	});
+
+	it('deletes only the described column and redistributes its width without losing metadata', () => {
+		const source = structureTableElement();
+		const next = deleteDataColumn(source.tableData!, 1);
+		const result = rebuild(source, next, { axis: 'column', action: 'delete', index: 1 });
+		const rows = rawRowsOf(result);
+		const columns = rawGridColumnsOf(result);
+
+		expect(columns.map((column) => column['@_id'])).toStrictEqual(['g0', 'g2']);
+		expect(columns.map((column) => column['@_w'])).toStrictEqual(['286', '714']);
+		expect(columns.reduce((sum, column) => sum + Number(column['@_w']), 0)).toBe(1000);
+		expect(columns[1]['x:opaque']).toStrictEqual({ '@_id': 'grid-2' });
+		rows.forEach((row, rowIndex) => {
+			expect(row['x:opaque']).toStrictEqual({ '@_id': `row-${rowIndex}` });
+			expect(rawCellsOf(row).map((cell) => cell['@_id'])).toStrictEqual([
+				`r${rowIndex}c0`,
+				`r${rowIndex}c2`,
+			]);
+			expect(rawCellsOf(row)[1]['a:tcPr']).toStrictEqual({
+				'@_marL': '91440',
+				'a:extLst': {
+					'a:ext': {
+						'@_uri': `urn:r${rowIndex}c2`,
+						'x:opaque': { '@_id': `r${rowIndex}c2` },
+					},
+				},
+			});
+		});
+	});
+
+	it('uses the current XML as provenance across repeated row and column insertions', () => {
+		let element = structureTableElement();
+		let data = insertDataRow(element.tableData!, 1);
+		let rawXml = rebuild(element, data, { axis: 'row', action: 'insert', index: 1 });
+		element = { ...element, tableData: data, rawXml };
+		data = insertDataRow(data, 3);
+		rawXml = rebuild(element, data, { axis: 'row', action: 'insert', index: 3 });
+
+		expect(rawRowsOf(rawXml).map((row) => row['@_id'])).toStrictEqual([
+			'r0',
+			undefined,
+			'r1',
+			undefined,
+			'r2',
+		]);
+
+		element = { ...element, tableData: data, rawXml };
+		data = insertDataColumn(data, 1);
+		rawXml = rebuild(element, data, { axis: 'column', action: 'insert', index: 1 });
+		element = { ...element, tableData: data, rawXml };
+		data = insertDataColumn(data, 3);
+		rawXml = rebuild(element, data, { axis: 'column', action: 'insert', index: 3 });
+
+		const columns = rawGridColumnsOf(rawXml);
+		expect(columns.map((column) => column['@_id'])).toStrictEqual([
+			'g0',
+			undefined,
+			'g1',
+			undefined,
+			'g2',
+		]);
+		expect(columns.reduce((sum, column) => sum + Number(column['@_w']), 0)).toBe(1000);
+		expect(rawCellsOf(rawRowsOf(rawXml)[0]).map((cell) => cell['@_id'])).toStrictEqual([
+			'r0c0',
+			undefined,
+			'r0c1',
+			undefined,
+			'r0c2',
+		]);
+	});
+
+	it.each([
+		{
+			name: 'an out-of-range insertion index',
+			edit: { axis: 'row', action: 'insert', index: 99 } as const,
+		},
+		{
+			name: 'a descriptor whose axis does not match the new dimensions',
+			edit: { axis: 'column', action: 'insert', index: 1 } as const,
+		},
+	])('falls back without a partial splice for $name', ({ edit }) => {
+		const source = structureTableElement();
+		const next = insertDataRow(source.tableData!, 3);
+		const result = rebuild(source, next, edit);
+		const rows = rawRowsOf(result);
+
+		// A rejected descriptor deliberately takes the legacy arbitrary-model
+		// rebuild. It must not leave behind part of the requested splice.
+		expect(rows.map((row) => row['@_id'])).toStrictEqual([
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+		]);
+		expect(rawGridColumnsOf(result).map((column) => column['@_id'])).toStrictEqual([
+			undefined,
+			undefined,
+			undefined,
+		]);
+		expect(rawCellsOf(rows[0]).map((cell) => cell['@_id'])).toStrictEqual(['r0c0', 'r0c1', 'r0c2']);
+		expect(rawCellsOf(rows[3]).map((cell) => cell['@_id'])).toStrictEqual([
+			undefined,
+			undefined,
+			undefined,
+		]);
+	});
+});
+
+describe('rebuildTableStructureInRawXml merged-anchor promotion', () => {
+	it.each<MergeAxis>(['row', 'column'])(
+		'promotes a non-empty %s anchor body but keeps the surviving cell identity and properties',
+		(axis) => {
+			const source = mergedTableElement(axis);
+			const sourceRows = rawRowsOf(source.rawXml!);
+			const anchorXml = rawCellsOf(sourceRows[0])[0];
+			const targetXml =
+				axis === 'row' ? rawCellsOf(sourceRows[1])[0] : rawCellsOf(sourceRows[0])[1];
+			const next = dataAfterDeletingMergeAnchor(source, axis);
+			const result = rebuild(source, next, { axis, action: 'delete', index: 0 });
+			const survivor = rawCellsOf(rawRowsOf(result)[0])[0];
+
+			expect(survivor['@_id']).toBe('target');
+			expect(survivor['a:txBody']).toStrictEqual(anchorXml['a:txBody']);
+			expect(survivor['a:tcPr']).toStrictEqual(targetXml['a:tcPr']);
+			expect(survivor[axis === 'row' ? '@_vMerge' : '@_hMerge']).toBeUndefined();
+			expect(survivor[axis === 'row' ? '@_rowSpan' : '@_gridSpan']).toBeUndefined();
+		},
+	);
+
+	it.each<MergeAxis>(['row', 'column'])(
+		'does not replace the %s anchor body when deleting a continuation',
+		(axis) => {
+			const source = mergedTableElement(axis);
+			const anchorXml = rawCellsOf(rawRowsOf(source.rawXml!)[0])[0];
+			const next = dataAfterDeletingMergeContinuation(source, axis);
+			const result = rebuild(source, next, { axis, action: 'delete', index: 1 });
+			const survivor = rawCellsOf(rawRowsOf(result)[0])[0];
+
+			expect(survivor['@_id']).toBe('anchor');
+			expect(survivor['a:txBody']).toStrictEqual(anchorXml['a:txBody']);
+			expect(survivor['a:tcPr']).toStrictEqual(anchorXml['a:tcPr']);
+			expect(survivor[axis === 'row' ? '@_rowSpan' : '@_gridSpan']).toBeUndefined();
+		},
+	);
+
+	it.each<MergeAxis>(['row', 'column'])(
+		'keeps the target rich body and properties when the removed %s anchor is empty',
+		(axis) => {
+			const source = mergedTableElement(axis, '', 'Target');
+			const sourceRows = rawRowsOf(source.rawXml!);
+			const targetXml =
+				axis === 'row' ? rawCellsOf(sourceRows[1])[0] : rawCellsOf(sourceRows[0])[1];
+			const next = dataAfterDeletingMergeAnchor(source, axis);
+			const result = rebuild(source, next, { axis, action: 'delete', index: 0 });
+			const survivor = rawCellsOf(rawRowsOf(result)[0])[0];
+
+			expect(survivor['@_id']).toBe('target');
+			expect(survivor['a:txBody']).toStrictEqual(targetXml['a:txBody']);
+			expect(survivor['a:tcPr']).toStrictEqual(targetXml['a:tcPr']);
+		},
+	);
 });
 
 describe('ensureArray', () => {

--- a/packages/core/src/core/core/runtime/table-cell-rawxml-ops.ts
+++ b/packages/core/src/core/core/runtime/table-cell-rawxml-ops.ts
@@ -10,10 +10,9 @@
  *
  * @module runtime/table-cell-rawxml-ops
  */
-import { EMU_PER_PX } from '../../constants';
 import type { PptxElement, PptxTableData, XmlObject } from '../../types';
 import { ensureXmlChild, ensureXmlChildOrCreate, ensureXmlChildren } from '../../utils/xml-access';
-import { DEFAULT_ROW_HEIGHT_EMU, ensureArray, getTblFromRawXml } from './table-structural-helpers';
+import { ensureArray, getTblFromRawXml } from './table-structural-helpers';
 
 // ── Cell text update ─────────────────────────────────────────────────────
 
@@ -339,126 +338,5 @@ export function updateMergeAttrsInRawXml(
 	return newRawXml;
 }
 
-// ── Structural XML synchronisation ────────────────────────────────────────
-
-/** Create a default XML cell element (<a:tc>) for structural rebuilds. */
-function createDefaultRebuildXmlCell(): XmlObject {
-	return {
-		'a:txBody': {
-			'a:bodyPr': {},
-			'a:lstStyle': {},
-			'a:p': {
-				'a:endParaRPr': { '@_lang': 'en-US' },
-			},
-		},
-		'a:tcPr': {},
-	};
-}
-
-/**
- * Deep-clone an element's rawXml and rebuild the table XML structure to match
- * the given `PptxTableData`. This handles adding/removing rows and columns
- * by rebuilding `<a:tblGrid>` and `<a:tr>` elements.
- *
- * Used when structural table operations (insert/delete row/column) change
- * the dimensions of the table.
- *
- * Returns the new rawXml object, or `undefined` if the element doesn't contain
- * an XML-based table.
- */
-export function rebuildTableStructureInRawXml(
-	element: PptxElement,
-	tableData: PptxTableData,
-): XmlObject | undefined {
-	if (!element.rawXml) {
-		return undefined;
-	}
-
-	const newRawXml = structuredClone(element.rawXml) as XmlObject;
-
-	const table = getTblFromRawXml(newRawXml);
-	if (!table) {
-		return undefined;
-	}
-
-	// ── Compute total table width from existing grid ──
-	const existingGridCols = ensureArray(
-		(table['a:tblGrid'] as XmlObject | undefined)?.['a:gridCol'] as
-			| XmlObject
-			| XmlObject[]
-			| undefined,
-	);
-	const totalWidthEmu =
-		existingGridCols.reduce((sum, col) => {
-			return sum + (parseInt(String(col?.['@_w'] || '0'), 10) || 0);
-		}, 0) || 9144000; // fallback: ~960px
-
-	// ── Rebuild a:tblGrid ──
-	const newGridCols: XmlObject[] = tableData.columnWidths.map((w) => ({
-		'@_w': String(Math.round(w * totalWidthEmu)),
-	}));
-	if (!table['a:tblGrid']) {
-		table['a:tblGrid'] = {};
-	}
-	(table['a:tblGrid'] as XmlObject)['a:gridCol'] =
-		newGridCols.length === 1 ? newGridCols[0] : newGridCols;
-
-	// ── Rebuild a:tr ──
-	const existingXmlRows = ensureArray(table['a:tr'] as XmlObject | XmlObject[] | undefined);
-
-	const newXmlRows: XmlObject[] = tableData.rows.map((dataRow, ri) => {
-		const existingRow = ri < existingXmlRows.length ? existingXmlRows[ri] : undefined;
-		const existingCells = existingRow
-			? ensureArray(existingRow['a:tc'] as XmlObject | XmlObject[] | undefined)
-			: [];
-
-		const heightEmu = dataRow.height
-			? Math.round(dataRow.height * EMU_PER_PX)
-			: existingRow?.['@_h']
-				? parseInt(String(existingRow['@_h']), 10)
-				: DEFAULT_ROW_HEIGHT_EMU;
-
-		const newXmlCells: XmlObject[] = dataRow.cells.map((cell, ci) => {
-			// Try to reuse existing cell XML for preserved cells
-			let xmlCell: XmlObject;
-			if (ci < existingCells.length) {
-				xmlCell = structuredClone(existingCells[ci]) as XmlObject;
-			} else {
-				xmlCell = createDefaultRebuildXmlCell();
-			}
-
-			// Update merge attributes
-			if (cell.gridSpan !== undefined && cell.gridSpan > 1) {
-				xmlCell['@_gridSpan'] = String(cell.gridSpan);
-			} else {
-				delete xmlCell['@_gridSpan'];
-			}
-			if (cell.rowSpan !== undefined && cell.rowSpan > 1) {
-				xmlCell['@_rowSpan'] = String(cell.rowSpan);
-			} else {
-				delete xmlCell['@_rowSpan'];
-			}
-			if (cell.hMerge) {
-				xmlCell['@_hMerge'] = '1';
-			} else {
-				delete xmlCell['@_hMerge'];
-			}
-			if (cell.vMerge) {
-				xmlCell['@_vMerge'] = '1';
-			} else {
-				delete xmlCell['@_vMerge'];
-			}
-
-			return xmlCell;
-		});
-
-		return {
-			'@_h': String(heightEmu),
-			'a:tc': newXmlCells.length === 1 ? newXmlCells[0] : newXmlCells,
-		} as XmlObject;
-	});
-
-	table['a:tr'] = newXmlRows.length === 1 ? newXmlRows[0] : newXmlRows;
-
-	return newRawXml;
-}
+export { rebuildTableStructureInRawXml } from './table-structure-rawxml';
+export type { TableStructureEdit } from './table-structure-rawxml';

--- a/packages/core/src/core/core/runtime/table-column-ops.ts
+++ b/packages/core/src/core/core/runtime/table-column-ops.ts
@@ -275,6 +275,7 @@ export function removeTableColumn(
 						adjustedCells[nextColIdx] = {
 							...nextCell,
 							text: cell.text || nextCell.text,
+							textRuns: cell.text ? cell.textRuns : nextCell.textRuns,
 							style: nextCell.style || cell.style,
 							gridSpan: gs - 1 > 1 ? gs - 1 : undefined,
 							hMerge: undefined, // No longer a continuation
@@ -320,7 +321,7 @@ export function removeTableColumn(
 
 			// Remove from each a:tr
 			const xmlRows = ensureArray(tbl['a:tr'] as XmlObject | XmlObject[]);
-			for (const xmlRow of xmlRows) {
+			for (const [rowIndex, xmlRow] of xmlRows.entries()) {
 				const xmlCells = ensureArray(xmlRow['a:tc'] as XmlObject | XmlObject[]);
 				if (index < xmlCells.length) {
 					const xmlCell = xmlCells[index];
@@ -357,7 +358,7 @@ export function removeTableColumn(
 									nextXmlCell['@_rowSpan'] = xmlCell['@_rowSpan'];
 								}
 								// Copy text body from anchor to new anchor
-								if (xmlCell['a:txBody']) {
+								if (tableData.rows[rowIndex]?.cells[index]?.text && xmlCell['a:txBody']) {
 									nextXmlCell['a:txBody'] = xmlCell['a:txBody'];
 								}
 							}

--- a/packages/core/src/core/core/runtime/table-row-ops.ts
+++ b/packages/core/src/core/core/runtime/table-row-ops.ts
@@ -221,6 +221,7 @@ export function removeTableRow(
 							return {
 								...cc,
 								text: cell.text, // Move text from anchor to new anchor
+								textRuns: cell.textRuns,
 								style: cc.style || cell.style,
 								rowSpan: newRs > 1 ? newRs : undefined,
 								vMerge: undefined, // No longer a continuation

--- a/packages/core/src/core/core/runtime/table-structural-ops.test.ts
+++ b/packages/core/src/core/core/runtime/table-structural-ops.test.ts
@@ -714,6 +714,64 @@ describe('rebuildTableXmlFromData', () => {
 // ===========================================================================
 
 describe('combined operations', () => {
+	it.each(['row', 'column'] as const)(
+		'preserves rich runs when deleting a merged %s anchor',
+		(axis) => {
+			const td = make2x3TableData();
+			const source = td.rows[0].cells[0];
+			const target = axis === 'row' ? td.rows[1].cells[0] : td.rows[0].cells[1];
+			source.textRuns = [
+				{ text: 'A', bold: true },
+				{ text: '1', italic: true },
+			];
+			target.text = '';
+			target.textRuns = [{ text: '', underline: true }];
+			if (axis === 'row') {
+				source.rowSpan = 2;
+				target.vMerge = true;
+			} else {
+				source.gridSpan = 2;
+				target.hMerge = true;
+			}
+			const result = axis === 'row' ? removeTableRow(td, 0) : removeTableColumn(td, 0);
+			expect(result.tableData.rows[0].cells[0].text).toBe(source.text);
+			expect(result.tableData.rows[0].cells[0].textRuns).toStrictEqual(source.textRuns);
+		},
+	);
+
+	it('keeps the existing empty row-anchor text policy and its matching runs', () => {
+		const td = make2x3TableData();
+		td.rows[0].cells[0] = { text: '', rowSpan: 2, textRuns: [{ text: '', bold: true }] };
+		td.rows[1].cells[0] = {
+			text: 'Fallback',
+			vMerge: true,
+			textRuns: [{ text: 'Fallback', italic: true }],
+		};
+		const result = removeTableRow(td, 0);
+		expect(result.tableData.rows[0].cells[0].text).toBe('');
+		expect(result.tableData.rows[0].cells[0].textRuns).toStrictEqual(td.rows[0].cells[0].textRuns);
+	});
+
+	it('retains the continuation text body when deleting an empty column anchor', () => {
+		const td = make2x3TableData();
+		const raw = make2x3RawXml();
+		td.rows[0].cells[0] = { text: '', gridSpan: 2, textRuns: [{ text: '', bold: true }] };
+		td.rows[0].cells[1] = {
+			text: 'B1',
+			hMerge: true,
+			textRuns: [{ text: 'B', italic: true }, { text: '1' }],
+		};
+		const cells = getXmlCells(getTbl(raw), 0);
+		cells[0] = makeTc('', { '@_gridSpan': '2' });
+		cells[1]['@_hMerge'] = '1';
+		cells[1]['a:txBody']['a:p']['a:r'] = [{ 'a:rPr': { '@_i': '1' }, 'a:t': 'B' }, { 'a:t': '1' }];
+		const expectedBody = structuredClone(cells[1]['a:txBody']);
+		const result = removeTableColumn(td, 0, raw);
+		expect(result.tableData.rows[0].cells[0].text).toBe('B1');
+		expect(result.tableData.rows[0].cells[0].textRuns).toStrictEqual(td.rows[0].cells[1].textRuns);
+		expect(getXmlCells(getTbl(result.rawXml!), 0)[0]['a:txBody']).toStrictEqual(expectedBody);
+	});
+
 	it('should support add row then remove row to return to original size', () => {
 		const td = make2x3TableData();
 		const { tableData: afterAdd } = addTableRow(td, 1);

--- a/packages/core/src/core/core/runtime/table-structural-ops.ts
+++ b/packages/core/src/core/core/runtime/table-structural-ops.ts
@@ -39,6 +39,7 @@ export {
 } from './table-create-xml';
 
 // Raw-XML cell/merge/structure mutations
+export type { TableStructureEdit } from './table-cell-rawxml-ops';
 export {
 	updateCellTextInRawXml,
 	updateCellTextStyleInRawXml,

--- a/packages/core/src/core/core/runtime/table-structure-edit-xml.ts
+++ b/packages/core/src/core/core/runtime/table-structure-edit-xml.ts
@@ -1,0 +1,118 @@
+import type { PptxTableCell, PptxTableData, XmlObject } from '../../types';
+import { createDefaultXmlCell, createDefaultXmlRow, ensureArray } from './table-structural-helpers';
+
+/** Absolute source-grid position of a single structural edit. */
+export interface TableStructureEdit {
+	axis: 'row' | 'column';
+	action: 'insert' | 'delete';
+	index: number;
+}
+
+function cells(row: XmlObject): XmlObject[] {
+	return ensureArray(row['a:tc'] as XmlObject | XmlObject[] | undefined);
+}
+
+/** Follow the logical operation's anchor promotion, not a guess from cell text. */
+function promoteTextBody(
+	source: PptxTableCell | undefined,
+	next: PptxTableCell | undefined,
+	removed: XmlObject | undefined,
+	survivor: XmlObject | undefined,
+	axis: TableStructureEdit['axis'],
+): void {
+	const span = axis === 'row' ? 'rowSpan' : 'gridSpan';
+	const continuation = axis === 'row' ? 'vMerge' : 'hMerge';
+	if (
+		!source?.text ||
+		!next ||
+		!removed ||
+		!survivor ||
+		source[continuation] ||
+		(source[span] ?? 1) <= 1 ||
+		next[continuation] ||
+		(next[span] ?? 1) !== (source[span] ?? 1) - 1
+	) {
+		return;
+	}
+	if (removed['a:txBody'] !== undefined) {
+		survivor['a:txBody'] = removed['a:txBody'];
+	}
+}
+
+/**
+ * Splice a caller-owned XML clone before its dimensions/merge flags are synced.
+ * The operation supplies provenance: destination indices alone cannot identify
+ * surviving cells, especially when multiple cells have identical visible text.
+ * Returns false without mutation for a descriptor that does not match the grid.
+ */
+export function applyTableStructureEditXml(
+	table: XmlObject,
+	source: PptxTableData | undefined,
+	next: PptxTableData,
+	edit: TableStructureEdit,
+): boolean {
+	const rows = ensureArray(table['a:tr'] as XmlObject | XmlObject[] | undefined);
+	const grid = table['a:tblGrid'] as XmlObject | undefined;
+	const columns = ensureArray(grid?.['a:gridCol'] as XmlObject | XmlObject[] | undefined);
+	const { axis, action, index } = edit;
+	if ((axis !== 'row' && axis !== 'column') || (action !== 'insert' && action !== 'delete')) {
+		return false;
+	}
+	const count = axis === 'row' ? rows.length : columns.length;
+	const delta = action === 'insert' ? 1 : -1;
+	if (
+		!grid ||
+		!Number.isInteger(index) ||
+		index < 0 ||
+		index > count - (action === 'delete' ? 1 : 0) ||
+		(action === 'delete' && count <= 1) ||
+		next.rows.length !== rows.length + (axis === 'row' ? delta : 0) ||
+		next.columnWidths.length !== columns.length + (axis === 'column' ? delta : 0)
+	) {
+		return false;
+	}
+
+	if (axis === 'row') {
+		if (action === 'insert') {
+			rows.splice(index, 0, createDefaultXmlRow(columns.length));
+		} else {
+			const removedCells = cells(rows[index]);
+			const nextCells = rows[index + 1] ? cells(rows[index + 1]) : [];
+			removedCells.forEach((removed, column) =>
+				promoteTextBody(
+					source?.rows[index]?.cells[column],
+					next.rows[index]?.cells[column],
+					removed,
+					nextCells[column],
+					axis,
+				),
+			);
+			rows.splice(index, 1);
+		}
+		table['a:tr'] = rows.length === 1 ? rows[0] : rows;
+	} else {
+		if (action === 'insert') {
+			columns.splice(index, 0, { '@_w': '0' });
+		} else {
+			columns.splice(index, 1);
+		}
+		grid['a:gridCol'] = columns.length === 1 ? columns[0] : columns;
+		rows.forEach((row, rowIndex) => {
+			const rowCells = cells(row);
+			if (action === 'insert') {
+				rowCells.splice(index, 0, createDefaultXmlCell());
+			} else {
+				promoteTextBody(
+					source?.rows[rowIndex]?.cells[index],
+					next.rows[rowIndex]?.cells[index],
+					rowCells[index],
+					rowCells[index + 1],
+					axis,
+				);
+				rowCells.splice(index, 1);
+			}
+			row['a:tc'] = rowCells.length === 1 ? rowCells[0] : rowCells;
+		});
+	}
+	return true;
+}

--- a/packages/core/src/core/core/runtime/table-structure-rawxml.ts
+++ b/packages/core/src/core/core/runtime/table-structure-rawxml.ts
@@ -1,0 +1,132 @@
+import { EMU_PER_PX } from '../../constants';
+import type { PptxElement, PptxTableData, XmlObject } from '../../types';
+import { serializeCellMergeAttributes } from './save-table-merge-helpers';
+import { DEFAULT_ROW_HEIGHT_EMU, ensureArray, getTblFromRawXml } from './table-structural-helpers';
+import { applyTableStructureEditXml } from './table-structure-edit-xml';
+import type { TableStructureEdit } from './table-structure-edit-xml';
+
+export type { TableStructureEdit } from './table-structure-edit-xml';
+
+// ── Structural XML synchronisation ────────────────────────────────────────
+
+/** Create a default XML cell element (<a:tc>) for structural rebuilds. */
+function createDefaultRebuildXmlCell(): XmlObject {
+	return {
+		'a:txBody': {
+			'a:bodyPr': {},
+			'a:lstStyle': {},
+			'a:p': {
+				'a:endParaRPr': { '@_lang': 'en-US' },
+			},
+		},
+		'a:tcPr': {},
+	};
+}
+
+/**
+ * Deep-clone an element's rawXml and rebuild the table XML structure to match
+ * the given `PptxTableData`. This handles adding/removing rows and columns
+ * by rebuilding `<a:tblGrid>` and `<a:tr>` elements.
+ *
+ * Pass the resolved `edit` position for an insert/delete command so surviving
+ * rich cells and opaque row/grid properties move with their logical cells.
+ * Without that provenance, retain the legacy destination-index rebuild for
+ * arbitrary model replacement; it cannot infer which source cells survived.
+ *
+ * Returns the new rawXml object, or `undefined` if the element doesn't contain
+ * an XML-based table.
+ */
+export function rebuildTableStructureInRawXml(
+	element: PptxElement,
+	tableData: PptxTableData,
+	edit?: TableStructureEdit,
+): XmlObject | undefined {
+	if (!element.rawXml) {
+		return undefined;
+	}
+
+	const newRawXml = structuredClone(element.rawXml) as XmlObject;
+
+	const table = getTblFromRawXml(newRawXml);
+	if (!table) {
+		return undefined;
+	}
+
+	// ── Compute total table width from existing grid ──
+	const existingGridCols = ensureArray(
+		(table['a:tblGrid'] as XmlObject | undefined)?.['a:gridCol'] as
+			| XmlObject
+			| XmlObject[]
+			| undefined,
+	);
+	const totalWidthEmu =
+		existingGridCols.reduce((sum, col) => {
+			return sum + (parseInt(String(col?.['@_w'] || '0'), 10) || 0);
+		}, 0) || 9144000; // fallback: ~960px
+
+	const appliedEdit = edit
+		? applyTableStructureEditXml(
+				table,
+				element.type === 'table' ? element.tableData : undefined,
+				tableData,
+				edit,
+			)
+		: false;
+	const alignedGridCols = ensureArray(
+		(table['a:tblGrid'] as XmlObject | undefined)?.['a:gridCol'] as
+			| XmlObject
+			| XmlObject[]
+			| undefined,
+	);
+
+	// ── Rebuild a:tblGrid ──
+	const newGridCols: XmlObject[] = tableData.columnWidths.map((w, index) => ({
+		...(appliedEdit ? alignedGridCols[index] : {}),
+		'@_w': String(Math.round(w * totalWidthEmu)),
+	}));
+	if (!table['a:tblGrid']) {
+		table['a:tblGrid'] = {};
+	}
+	(table['a:tblGrid'] as XmlObject)['a:gridCol'] =
+		newGridCols.length === 1 ? newGridCols[0] : newGridCols;
+
+	// ── Rebuild a:tr ──
+	const existingXmlRows = ensureArray(table['a:tr'] as XmlObject | XmlObject[] | undefined);
+
+	const newXmlRows: XmlObject[] = tableData.rows.map((dataRow, ri) => {
+		const existingRow = ri < existingXmlRows.length ? existingXmlRows[ri] : undefined;
+		const existingCells = existingRow
+			? ensureArray(existingRow['a:tc'] as XmlObject | XmlObject[] | undefined)
+			: [];
+
+		const heightEmu = dataRow.height
+			? Math.round(dataRow.height * EMU_PER_PX)
+			: existingRow?.['@_h']
+				? parseInt(String(existingRow['@_h']), 10)
+				: DEFAULT_ROW_HEIGHT_EMU;
+
+		const newXmlCells: XmlObject[] = dataRow.cells.map((cell, ci) => {
+			// Try to reuse existing cell XML for preserved cells
+			let xmlCell: XmlObject;
+			if (ci < existingCells.length) {
+				xmlCell = existingCells[ci];
+			} else {
+				xmlCell = createDefaultRebuildXmlCell();
+			}
+
+			serializeCellMergeAttributes(xmlCell, cell);
+
+			return xmlCell;
+		});
+
+		return {
+			...(appliedEdit ? existingRow : {}),
+			'@_h': String(heightEmu),
+			'a:tc': newXmlCells.length === 1 ? newXmlCells[0] : newXmlCells,
+		} as XmlObject;
+	});
+
+	table['a:tr'] = newXmlRows.length === 1 ? newXmlRows[0] : newXmlRows;
+
+	return newRawXml;
+}

--- a/packages/react/src/viewer/hooks/table-struct-handlers.test.ts
+++ b/packages/react/src/viewer/hooks/table-struct-handlers.test.ts
@@ -7,7 +7,6 @@ import { createTableStructHandlers } from './table-struct-handlers';
 // Mock the table-parse utilities so we don't depend on XML parsing
 vi.mock<typeof import('../utils/table-parse')>(import('../utils/table-parse'), () => ({
 	updateCellTextInRawXml: vi.fn(() => '<new-xml/>'),
-	rebuildTableStructureInRawXml: vi.fn(() => '<rebuilt-xml/>'),
 }));
 
 function createTableElement(tableData: PptxTableData, id = 'table-1'): TablePptxElement {
@@ -58,6 +57,43 @@ function createMockInput(
 }
 
 describe('createTableStructHandlers', () => {
+	it('commits aligned raw XML together with the inserted row data', () => {
+		const element = createTableElement(createSimpleTableData(2, 2));
+		element.tableData!.rows[1].cells[0] = {
+			text: 'Rich',
+			textRuns: [{ text: 'Rich', bold: true }],
+		};
+		const richCell = {
+			'a:txBody': { 'a:p': { 'a:r': { 'a:rPr': { '@_b': '1' }, 'a:t': 'Rich' } } },
+			'a:tcPr': {},
+		};
+		const blankCell = { 'a:txBody': { 'a:p': {} }, 'a:tcPr': {} };
+		element.rawXml = {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': { 'a:gridCol': [{ '@_w': '1000' }, { '@_w': '1000' }] },
+						'a:tr': [
+							{ '@_h': '381000', 'a:tc': [blankCell, blankCell] },
+							{ '@_h': '381000', 'a:tc': [richCell, blankCell] },
+						],
+					},
+				},
+			},
+		};
+		const input = createMockInput({
+			selectedElement: element,
+			tableEditorState: { rowIndex: 0, columnIndex: 0 },
+		});
+		createTableStructHandlers(input).handleInsertTableRow('below');
+		const update = vi.mocked(input.ops.updateSelectedElement).mock.calls[0][0] as TablePptxElement;
+		expect(update.tableData!.rows[1].cells[0].text).toBe('');
+		expect(update.tableData!.rows[2].cells[0].text).toBe('Rich');
+		expect(
+			update.rawXml!['a:graphic']['a:graphicData']['a:tbl']['a:tr'][2]['a:tc'][0],
+		).toStrictEqual(richCell);
+	});
+
 	// ── handleCommitCellEdit ──────────────────────────────────────────────
 
 	describe('handleCommitCellEdit', () => {
@@ -213,7 +249,7 @@ describe('createTableStructHandlers', () => {
 			const handlers = createTableStructHandlers(input);
 			handlers.handleInsertTableRow('below');
 			expect(input.ops.updateSelectedElement).toHaveBeenCalledWith(
-				expect.objectContaining({ rawXml: '<rebuilt-xml/>' }),
+				expect.objectContaining({ rawXml: undefined }),
 			);
 			const call = (input.ops.updateSelectedElement as ReturnType<typeof vi.fn>).mock.calls[0][0];
 			const td = call.tableData as PptxTableData;
@@ -225,7 +261,7 @@ describe('createTableStructHandlers', () => {
 			const handlers = createTableStructHandlers(input);
 			handlers.handleInsertTableRow('above');
 			expect(input.ops.updateSelectedElement).toHaveBeenCalledWith(
-				expect.objectContaining({ rawXml: '<rebuilt-xml/>' }),
+				expect.objectContaining({ rawXml: undefined }),
 			);
 			const call = (input.ops.updateSelectedElement as ReturnType<typeof vi.fn>).mock.calls[0][0];
 			const td = call.tableData as PptxTableData;

--- a/packages/react/src/viewer/hooks/table-struct-handlers.ts
+++ b/packages/react/src/viewer/hooks/table-struct-handlers.ts
@@ -6,21 +6,16 @@
  * adjustments and synchronise both `tableData` and `rawXml` so that
  * rendering and saving both reflect the changes.
  */
-import type { TablePptxElement } from 'pptx-viewer-core';
 import {
-	insertTableRow,
-	deleteTableRow,
-	insertTableColumn,
-	deleteTableColumn,
+	insertTableElementRow,
+	removeTableElementRow,
+	insertTableElementColumn,
+	removeTableElementColumn,
 	setCellText,
 } from 'pptx-viewer-shared';
 
 import type { TableCellEditorState } from '../types';
-import {
-	updateCellTextInRawXml,
-	updateCellTextStyleInRawXml,
-	rebuildTableStructureInRawXml,
-} from '../utils/table-parse';
+import { updateCellTextInRawXml, updateCellTextStyleInRawXml } from '../utils/table-parse';
 import type { UseTableOperationsInput, TableStructHandlers } from './table-operation-types';
 
 // ---------------------------------------------------------------------------
@@ -176,16 +171,8 @@ export function createTableStructHandlers(input: UseTableOperationsInput): Table
 			return;
 		}
 		const rowIdx = ts?.rowIndex ?? 0;
-		const newTableData = insertTableRow(selectedElement.tableData, rowIdx, position);
-
-		// Build update object
-		const updates: Partial<TablePptxElement> = { tableData: newTableData };
-		const newRawXml = rebuildTableStructureInRawXml(selectedElement, newTableData);
-		if (newRawXml) {
-			updates.rawXml = newRawXml;
-		}
-
-		ops.updateSelectedElement(updates);
+		const next = insertTableElementRow(selectedElement, rowIdx, position);
+		ops.updateSelectedElement({ tableData: next.tableData, rawXml: next.rawXml });
 		history.markDirty();
 	};
 
@@ -195,22 +182,12 @@ export function createTableStructHandlers(input: UseTableOperationsInput): Table
 		if (!selectedElement || selectedElement.type !== 'table' || !selectedElement.tableData) {
 			return;
 		}
-		const td = selectedElement.tableData;
 		const rowIdx = ts?.rowIndex ?? 0;
-		const newTableData = deleteTableRow(td, rowIdx);
-		// `deleteTableRow` returns the same reference when the delete is a no-op
-		// (single row or out-of-range index).
-		if (newTableData === td) {
+		const next = removeTableElementRow(selectedElement, rowIdx);
+		if (next === selectedElement) {
 			return;
 		}
-
-		const updates: Partial<TablePptxElement> = { tableData: newTableData };
-		const newRawXml = rebuildTableStructureInRawXml(selectedElement, newTableData);
-		if (newRawXml) {
-			updates.rawXml = newRawXml;
-		}
-
-		ops.updateSelectedElement(updates);
+		ops.updateSelectedElement({ tableData: next.tableData, rawXml: next.rawXml });
 		history.markDirty();
 	};
 
@@ -221,15 +198,8 @@ export function createTableStructHandlers(input: UseTableOperationsInput): Table
 			return;
 		}
 		const colIdx = ts?.columnIndex ?? 0;
-		const newTableData = insertTableColumn(selectedElement.tableData, colIdx, position);
-
-		const updates: Partial<TablePptxElement> = { tableData: newTableData };
-		const newRawXml = rebuildTableStructureInRawXml(selectedElement, newTableData);
-		if (newRawXml) {
-			updates.rawXml = newRawXml;
-		}
-
-		ops.updateSelectedElement(updates);
+		const next = insertTableElementColumn(selectedElement, colIdx, position);
+		ops.updateSelectedElement({ tableData: next.tableData, rawXml: next.rawXml });
 		history.markDirty();
 	};
 
@@ -239,22 +209,12 @@ export function createTableStructHandlers(input: UseTableOperationsInput): Table
 		if (!selectedElement || selectedElement.type !== 'table' || !selectedElement.tableData) {
 			return;
 		}
-		const td = selectedElement.tableData;
 		const colIdx = ts?.columnIndex ?? 0;
-		const newTableData = deleteTableColumn(td, colIdx);
-		// `deleteTableColumn` returns the same reference for no-op deletes
-		// (single column or out-of-range index).
-		if (newTableData === td) {
+		const next = removeTableElementColumn(selectedElement, colIdx);
+		if (next === selectedElement) {
 			return;
 		}
-
-		const updates: Partial<TablePptxElement> = { tableData: newTableData };
-		const newRawXml = rebuildTableStructureInRawXml(selectedElement, newTableData);
-		if (newRawXml) {
-			updates.rawXml = newRawXml;
-		}
-
-		ops.updateSelectedElement(updates);
+		ops.updateSelectedElement({ tableData: next.tableData, rawXml: next.rawXml });
 		history.markDirty();
 	};
 

--- a/packages/shared/src/render/table-data-grid-ops.ts
+++ b/packages/shared/src/render/table-data-grid-ops.ts
@@ -24,7 +24,7 @@
  *
  * @module render/table-data-grid-ops
  */
-import type { PptxTableData, TablePptxElement } from 'pptx-viewer-core';
+import type { PptxTableData, TablePptxElement, TableStructureEdit } from 'pptx-viewer-core';
 import { rebuildTableStructureInRawXml, updateCellTextInRawXml } from 'pptx-viewer-core';
 
 import { setCellText } from './table-cell-edit';
@@ -53,6 +53,7 @@ import {
 function withTableData(
 	element: TablePptxElement,
 	transform: (data: PptxTableData) => PptxTableData,
+	edit: TableStructureEdit,
 ): TablePptxElement {
 	const tableData = element.tableData;
 	if (!tableData) {
@@ -64,7 +65,7 @@ function withTableData(
 	}
 	const updated: TablePptxElement = { ...element, tableData: next };
 	if (element.rawXml) {
-		const rawXml = rebuildTableStructureInRawXml(element, next);
+		const rawXml = rebuildTableStructureInRawXml(element, next, edit);
 		if (rawXml) {
 			updated.rawXml = rawXml;
 		}
@@ -110,7 +111,11 @@ export function insertTableElementRow(
 	rowIdx: number,
 	position: 'above' | 'below',
 ): TablePptxElement {
-	return withTableData(element, (data) => insertTableRow(data, rowIdx, position));
+	return withTableData(element, (data) => insertTableRow(data, rowIdx, position), {
+		axis: 'row',
+		action: 'insert',
+		index: position === 'above' ? rowIdx : rowIdx + 1,
+	});
 }
 
 /**
@@ -121,7 +126,11 @@ export function insertTableElementRow(
  * @returns A new element with the row removed.
  */
 export function removeTableElementRow(element: TablePptxElement, rowIdx: number): TablePptxElement {
-	return withTableData(element, (data) => deleteTableRow(data, rowIdx));
+	return withTableData(element, (data) => deleteTableRow(data, rowIdx), {
+		axis: 'row',
+		action: 'delete',
+		index: rowIdx,
+	});
 }
 
 /**
@@ -137,7 +146,11 @@ export function insertTableElementColumn(
 	colIdx: number,
 	position: 'left' | 'right',
 ): TablePptxElement {
-	return withTableData(element, (data) => insertTableColumn(data, colIdx, position));
+	return withTableData(element, (data) => insertTableColumn(data, colIdx, position), {
+		axis: 'column',
+		action: 'insert',
+		index: position === 'left' ? colIdx : colIdx + 1,
+	});
 }
 
 /**
@@ -151,7 +164,11 @@ export function removeTableElementColumn(
 	element: TablePptxElement,
 	colIdx: number,
 ): TablePptxElement {
-	return withTableData(element, (data) => deleteTableColumn(data, colIdx));
+	return withTableData(element, (data) => deleteTableColumn(data, colIdx), {
+		axis: 'column',
+		action: 'delete',
+		index: colIdx,
+	});
 }
 
 /**

--- a/packages/shared/src/render/table-data-grid.test.ts
+++ b/packages/shared/src/render/table-data-grid.test.ts
@@ -1,4 +1,4 @@
-import type { TablePptxElement } from 'pptx-viewer-core';
+import type { PptxTableCell, TablePptxElement, XmlObject } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import { buildTableDataGrid } from './table-data-grid';
@@ -191,6 +191,162 @@ function xmlRows(element: TablePptxElement): unknown[] {
 	return Array.isArray(rows) ? rows : [rows];
 }
 
+function asArray<T>(value: T | T[] | undefined): T[] {
+	return value === undefined ? [] : Array.isArray(value) ? value : [value];
+}
+
+/**
+ * A real-deck-shaped table whose cells deliberately all have the same text.
+ * Their rich text and opaque extension markers differ, so an implementation
+ * cannot guess cell provenance by matching the displayed string.
+ */
+function makeRichXmlTable(rowCount = 3, columnCount = 3): TablePptxElement {
+	const rowData = Array.from({ length: rowCount }, (_, row) =>
+		Array.from({ length: columnCount }, (_cell, column) => {
+			const marker = `r${row}c${column}`;
+			const cell: PptxTableCell = {
+				text: 'Same',
+				style: { fontFamily: marker },
+				textRuns: [
+					{ text: 'Sa', bold: true, fontFamily: marker },
+					{ text: 'me', italic: true },
+				],
+			};
+			const xml: XmlObject = {
+				'a:txBody': {
+					'a:bodyPr': {},
+					'a:p': {
+						'a:r': [
+							{
+								'a:rPr': {
+									'@_b': '1',
+									'a:latin': { '@_typeface': marker },
+								},
+								'a:t': 'Sa',
+							},
+							{ 'a:rPr': { '@_i': '1' }, 'a:t': 'me' },
+						],
+					},
+				},
+				'a:tcPr': {
+					'a:extLst': {
+						'a:ext': { '@_uri': `urn:${marker}`, 'x:opaque': { '@_marker': marker } },
+					},
+				},
+			};
+			return { cell, xml };
+		}),
+	);
+	return {
+		id: 'rich-table',
+		type: 'table',
+		x: 0,
+		y: 0,
+		width: 300,
+		height: 180,
+		tableData: {
+			columnWidths: Array.from({ length: columnCount }, () => 1 / columnCount),
+			rows: rowData.map((row) => ({ cells: row.map(({ cell }) => cell) })),
+		},
+		rawXml: {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': {
+							'a:gridCol': Array.from({ length: columnCount }, () => ({ '@_w': '1000' })),
+						},
+						'a:tr': rowData.map((row) => ({
+							'@_h': '370840',
+							'a:tc': row.map(({ xml }) => xml),
+						})),
+					},
+				},
+			},
+		},
+	};
+}
+
+function xmlCells(element: TablePptxElement): XmlObject[][] {
+	return (xmlRows(element) as XmlObject[]).map((row) =>
+		asArray(row['a:tc'] as XmlObject | XmlObject[] | undefined),
+	);
+}
+
+function rawCellText(cell: XmlObject): string {
+	const body = cell['a:txBody'] as XmlObject | undefined;
+	return asArray(body?.['a:p'] as XmlObject | XmlObject[] | undefined)
+		.map((paragraph) =>
+			['a:r', 'a:fld']
+				.flatMap((tag) => asArray(paragraph[tag] as XmlObject | XmlObject[] | undefined))
+				.map((run) => String(run['a:t'] ?? ''))
+				.join(''),
+		)
+		.join('\n');
+}
+
+function rawCellMarker(cell: XmlObject): string | undefined {
+	const properties = cell['a:tcPr'] as XmlObject | undefined;
+	const extensions = properties?.['a:extLst'] as XmlObject | undefined;
+	const extension = extensions?.['a:ext'] as XmlObject | undefined;
+	const opaque = extension?.['x:opaque'] as XmlObject | undefined;
+	return typeof opaque?.['@_marker'] === 'string' ? opaque['@_marker'] : undefined;
+}
+
+function expectRawXmlAlignedAndPreserved(source: TablePptxElement, result: TablePptxElement): void {
+	const sourceByMarker = new Map(
+		xmlCells(source)
+			.flat()
+			.map((cell) => [rawCellMarker(cell), cell] as const),
+	);
+	const resultCells = xmlCells(result);
+	const rows = result.tableData!.rows;
+	expect(resultCells).toHaveLength(rows.length);
+	rows.forEach((row, rowIndex) => {
+		expect(resultCells[rowIndex]).toHaveLength(result.tableData!.columnWidths.length);
+		row.cells.forEach((cell, columnIndex) => {
+			const rawCell = resultCells[rowIndex]![columnIndex]!;
+			const marker = cell.style?.fontFamily;
+			expect(rawCellText(rawCell)).toBe(cell.text);
+			expect(rawCellMarker(rawCell)).toBe(marker);
+			if (marker) {
+				expect(rawCell).toStrictEqual(sourceByMarker.get(marker));
+			}
+		});
+	});
+}
+
+type StructureCase = {
+	name: string;
+	mutate: (element: TablePptxElement) => TablePptxElement;
+};
+
+const ROW_STRUCTURE_CASES: StructureCase[] = [
+	{ name: 'inserts the first row', mutate: (table) => insertTableElementRow(table, 0, 'above') },
+	{ name: 'inserts a middle row', mutate: (table) => insertTableElementRow(table, 0, 'below') },
+	{ name: 'inserts the final row', mutate: (table) => insertTableElementRow(table, 2, 'below') },
+	{ name: 'removes the first row', mutate: (table) => removeTableElementRow(table, 0) },
+	{ name: 'removes a middle row', mutate: (table) => removeTableElementRow(table, 1) },
+	{ name: 'removes the final row', mutate: (table) => removeTableElementRow(table, 2) },
+];
+
+const COLUMN_STRUCTURE_CASES: StructureCase[] = [
+	{
+		name: 'inserts the first column',
+		mutate: (table) => insertTableElementColumn(table, 0, 'left'),
+	},
+	{
+		name: 'inserts a middle column',
+		mutate: (table) => insertTableElementColumn(table, 0, 'right'),
+	},
+	{
+		name: 'inserts the final column',
+		mutate: (table) => insertTableElementColumn(table, 2, 'right'),
+	},
+	{ name: 'removes the first column', mutate: (table) => removeTableElementColumn(table, 0) },
+	{ name: 'removes a middle column', mutate: (table) => removeTableElementColumn(table, 1) },
+	{ name: 'removes the final column', mutate: (table) => removeTableElementColumn(table, 2) },
+];
+
 describe('rawXml synchronisation', () => {
 	// A tableData-only patch is invisible: both the renderers and the save
 	// writer read rawXml in preference, so without this the panel would appear
@@ -230,5 +386,27 @@ describe('rawXml synchronisation', () => {
 
 		expect(next.tableData?.rows[0].cells[0].text).toBe('Z');
 		expect(next.rawXml).toBeUndefined();
+	});
+
+	it.each(ROW_STRUCTURE_CASES)(
+		'$name without moving or flattening surviving rich cells',
+		(test) => {
+			const source = makeRichXmlTable();
+			expectRawXmlAlignedAndPreserved(source, test.mutate(source));
+		},
+	);
+
+	it.each(COLUMN_STRUCTURE_CASES)(
+		'$name without moving or flattening surviving rich cells',
+		(test) => {
+			const source = makeRichXmlTable();
+			expectRawXmlAlignedAndPreserved(source, test.mutate(source));
+		},
+	);
+
+	it('does not touch rich raw XML when the last row or column cannot be removed', () => {
+		const source = makeRichXmlTable(1, 1);
+		expect(removeTableElementRow(source, 0)).toBe(source);
+		expect(removeTableElementColumn(source, 0)).toBe(source);
 	});
 });

--- a/packages/shared/src/render/table-layout.test.ts
+++ b/packages/shared/src/render/table-layout.test.ts
@@ -50,6 +50,53 @@ describe('insertTableRow', () => {
 });
 
 describe('deleteTableRow', () => {
+	it.each(['row', 'column'] as const)('keeps rich text with the promoted %s anchor', (axis) => {
+		const table = makeTable(2, 2);
+		const source = table.rows[0].cells[0];
+		const target = axis === 'row' ? table.rows[1].cells[0] : table.rows[0].cells[1];
+		source.text = 'Rich text';
+		source.textRuns = [
+			{ text: 'Rich ', bold: true },
+			{ text: 'text', italic: true },
+		];
+		if (axis === 'row') {
+			source.rowSpan = 2;
+			target.vMerge = true;
+		} else {
+			source.gridSpan = 2;
+			target.hMerge = true;
+		}
+		target.textRuns = [{ text: '', underline: true }];
+		target.style = { fontSize: 24 };
+		const result = axis === 'row' ? deleteTableRow(table, 0) : deleteTableColumn(table, 0);
+		expect(result.rows[0].cells[0].text).toBe(source.text);
+		expect(result.rows[0].cells[0].textRuns).toStrictEqual(source.textRuns);
+		expect(result.rows[0].cells[0].style).toStrictEqual(target.style);
+		expect(target.textRuns).toStrictEqual([{ text: '', underline: true }]);
+	});
+
+	it.each(['row', 'column'] as const)(
+		'retains fallback rich text for an empty %s anchor',
+		(axis) => {
+			const table = makeTable(2, 2);
+			const source = table.rows[0].cells[0];
+			const target = axis === 'row' ? table.rows[1].cells[0] : table.rows[0].cells[1];
+			source.textRuns = [{ text: '', bold: true }];
+			target.text = 'Fallback';
+			target.textRuns = [{ text: 'Fallback', italic: true }];
+			if (axis === 'row') {
+				source.rowSpan = 2;
+				target.vMerge = true;
+			} else {
+				source.gridSpan = 2;
+				target.hMerge = true;
+			}
+			const result = axis === 'row' ? deleteTableRow(table, 0) : deleteTableColumn(table, 0);
+			expect(result.rows[0].cells[0].text).toBe(target.text);
+			expect(result.rows[0].cells[0].textRuns).toStrictEqual(target.textRuns);
+		},
+	);
+
 	it('should remove the row at the index', () => {
 		const table = makeTable(3, 2);
 		const result = deleteTableRow(table, 1);

--- a/packages/shared/src/render/table-layout.ts
+++ b/packages/shared/src/render/table-layout.ts
@@ -168,6 +168,7 @@ export function deleteTableRow(tableData: PptxTableData, rowIdx: number): PptxTa
 							return {
 								...cc,
 								text: cell.text || cc.text,
+								textRuns: cell.text ? cell.textRuns : cc.textRuns,
 								style: cc.style || cell.style,
 								rowSpan: newRs > 1 ? newRs : undefined,
 								vMerge: undefined,
@@ -315,6 +316,7 @@ export function deleteTableColumn(tableData: PptxTableData, colIdx: number): Ppt
 						adjustedCells[nextColIdx] = {
 							...nextCell,
 							text: cell.text || nextCell.text,
+							textRuns: cell.text ? cell.textRuns : nextCell.textRuns,
 							style: nextCell.style || cell.style,
 							gridSpan: gs - 1 > 1 ? gs - 1 : undefined,
 							hMerge: undefined,

--- a/packages/svelte/src/viewer/components/inspector/TableSection.svelte
+++ b/packages/svelte/src/viewer/components/inspector/TableSection.svelte
@@ -1,14 +1,19 @@
 <script lang="ts">
-	import type { ParsedTableStyleMap, PptxElement, PptxTableData } from 'pptx-viewer-core';
+	import type {
+		ParsedTableStyleMap,
+		PptxElement,
+		PptxTableData,
+		TablePptxElement,
+	} from 'pptx-viewer-core';
 	import {
 		applyTableStylePreset,
 		applyUniformCellPaddingPatch,
-		deleteTableColumn,
-		deleteTableRow,
 		evenColumnWidths,
 		evenRowHeights,
-		insertTableColumn,
-		insertTableRow,
+		insertTableElementColumn,
+		insertTableElementRow,
+		removeTableElementColumn,
+		removeTableElementRow,
 		redistributeColumnWidth,
 		TABLE_STYLE_PRESETS,
 		tableInspectorPatch,
@@ -41,7 +46,8 @@
 	} = $props();
 	const t = useTranslator();
 	const inspectorState = $derived(tableInspectorStateOf(el));
-	const table = $derived(el.type === 'table' ? el.tableData : undefined);
+	const tableElement = $derived(el.type === 'table' ? (el as TablePptxElement) : undefined);
+	const table = $derived(tableElement?.tableData);
 	// eslint-disable-next-line prefer-const
 	let activeRow = $state(0);
 	// eslint-disable-next-line prefer-const
@@ -53,6 +59,25 @@
 		if (el.type === 'table' && table) {
 			editor.applyElementPatch(el.id, { tableData: { ...table, ...next } });
 		}
+	}
+
+	function editStructure(
+		transform: (element: TablePptxElement) => TablePptxElement,
+	): void {
+		if (!tableElement) {
+			return;
+		}
+		// Props may be deeply reactive proxies, which `structuredClone` cannot
+		// consume. The shared raw-XML helpers operate on a plain immutable value.
+		const source = $state.snapshot(tableElement);
+		const next = transform(source);
+		if (next === source) {
+			return;
+		}
+		editor.applyElementPatch(tableElement.id, {
+			tableData: next.tableData,
+			rawXml: next.rawXml,
+		});
 	}
 
 	function setCellPadding(value: string): void {
@@ -104,7 +129,7 @@
 	{/if}
 
 	<label>Cell padding<input type="number" min="0" value={Math.round(inspectorState.cellPadding)} onchange={(event) => setCellPadding(event.currentTarget.value)} /></label>
-	<div class="structure"><label>Row<input type="number" min="1" max={table.rows.length} value={activeRow + 1} onchange={(event) => (activeRow = Math.max(0, Number(event.currentTarget.value) - 1))} /></label><button type="button" onclick={() => patchData(insertTableRow(table, activeRow, 'below'))}>Insert row</button><button type="button" disabled={table.rows.length <= 1} onclick={() => patchData(deleteTableRow(table, activeRow))}>Delete row</button><label>Column<input type="number" min="1" max={table.columnWidths.length} value={activeColumn + 1} onchange={(event) => (activeColumn = Math.max(0, Number(event.currentTarget.value) - 1))} /></label><button type="button" onclick={() => patchData(insertTableColumn(table, activeColumn, 'right'))}>Insert column</button><button type="button" disabled={table.columnWidths.length <= 1} onclick={() => patchData(deleteTableColumn(table, activeColumn))}>Delete column</button></div>
+	<div class="structure"><label>Row<input type="number" min="1" max={table.rows.length} value={activeRow + 1} onchange={(event) => (activeRow = Math.max(0, Number(event.currentTarget.value) - 1))} /></label><button type="button" onclick={() => editStructure((element) => insertTableElementRow(element, activeRow, 'below'))}>Insert row</button><button type="button" disabled={table.rows.length <= 1} onclick={() => editStructure((element) => removeTableElementRow(element, activeRow))}>Delete row</button><label>Column<input type="number" min="1" max={table.columnWidths.length} value={activeColumn + 1} onchange={(event) => (activeColumn = Math.max(0, Number(event.currentTarget.value) - 1))} /></label><button type="button" onclick={() => editStructure((element) => insertTableElementColumn(element, activeColumn, 'right'))}>Insert column</button><button type="button" disabled={table.columnWidths.length <= 1} onclick={() => editStructure((element) => removeTableElementColumn(element, activeColumn))}>Delete column</button></div>
 	{#if table.bandedRows}<label>Row band cycle<input type="number" min="1" value={table.bandRowCycle ?? 1} onchange={(event) => patchData({ bandRowCycle: Math.max(1, Number(event.currentTarget.value)) })} /></label>{/if}
 	{#if table.bandedColumns}<label>Column band cycle<input type="number" min="1" value={table.bandColCycle ?? 1} onchange={(event) => patchData({ bandColCycle: Math.max(1, Number(event.currentTarget.value)) })} /></label>{/if}
 	<details><summary>Column widths</summary><button type="button" onclick={() => patchData({ columnWidths: evenColumnWidths(table.columnWidths.length) })}>Distribute evenly</button>{#each table.columnWidths as width, index}<label>Column {index + 1}<input type="range" min="5" max="80" value={Math.round(width * 100)} onchange={(event) => patchData({ columnWidths: redistributeColumnWidth(table.columnWidths, index, Number(event.currentTarget.value) / 100) })} /></label>{/each}</details>

--- a/packages/svelte/src/viewer/components/inspector/TableSection.svelte.test.ts
+++ b/packages/svelte/src/viewer/components/inspector/TableSection.svelte.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable eslint/one-var -- many independent it() blocks, each with
    its own short arrange/act/assert consts. */
-import type { ParsedTableStyleMap, PptxElement } from 'pptx-viewer-core';
+import type { ParsedTableStyleMap, PptxElement, TablePptxElement } from 'pptx-viewer-core';
 import { flushSync, mount, unmount } from 'svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -21,8 +21,8 @@ afterEach(() => {
 	cleanup = undefined;
 });
 
-function tableEl(): PptxElement {
-	return {
+function tableEl(withRawXml = false): PptxElement {
+	const element: TablePptxElement = {
 		type: 'table',
 		id: 'tbl1',
 		x: 0,
@@ -33,7 +33,35 @@ function tableEl(): PptxElement {
 			rows: [{ cells: [{ text: 'A' }, { text: 'B' }] }, { cells: [{ text: 'C' }, { text: 'D' }] }],
 			columnWidths: [0.5, 0.5],
 		},
-	} as PptxElement;
+	};
+	if (withRawXml) {
+		element.rawXml = {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': { 'a:gridCol': [{ '@_w': '1000' }, { '@_w': '1000' }] },
+						'a:tr': [
+							{
+								'@_h': '370840',
+								'a:tc': [
+									{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'A' } } }, 'a:tcPr': {} },
+									{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'B' } } }, 'a:tcPr': {} },
+								],
+							},
+							{
+								'@_h': '370840',
+								'a:tc': [
+									{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'C' } } }, 'a:tcPr': {} },
+									{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'D' } } }, 'a:tcPr': {} },
+								],
+							},
+						],
+					},
+				},
+			},
+		};
+	}
+	return element;
 }
 
 function makeEditor(el: PptxElement): EditorState {
@@ -127,6 +155,23 @@ describe('tableSection', () => {
 				expect(cell.style?.marginLeft).toBe(8);
 			}
 		}
+	});
+
+	it('commits rawXml with tableData for a structural edit', () => {
+		const source = tableEl(true);
+		const editor = makeEditor(source);
+		const { target } = mountSection(editor, currentEl(editor));
+		const insertRow = Array.from(target.querySelectorAll('button')).find(
+			(button) => button.textContent === 'Insert row',
+		);
+		expect(insertRow).toBeTruthy();
+		insertRow!.click();
+		flushSync();
+
+		const current = currentEl(editor) as TablePptxElement;
+		expect(current.tableData?.rows).toHaveLength(3);
+		expect(current.rawXml).toBeDefined();
+		expect(current.rawXml).not.toBe((source as TablePptxElement).rawXml);
 	});
 
 	it('sets a column to the exact requested width, proportionally rescaling the others', () => {

--- a/packages/svelte/src/viewer/components/inspector/table-structure.test.ts
+++ b/packages/svelte/src/viewer/components/inspector/table-structure.test.ts
@@ -1,9 +1,9 @@
-import type { PptxTableData } from 'pptx-viewer-core';
+import type { PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import {
-	deleteTableColumn,
-	deleteTableRow,
-	insertTableColumn,
-	insertTableRow,
+	insertTableElementColumn,
+	insertTableElementRow,
+	removeTableElementColumn,
+	removeTableElementRow,
 } from 'pptx-viewer-shared';
 import { describe, expect, it } from 'vitest';
 
@@ -13,33 +13,36 @@ import { describe, expect, it } from 'vitest';
 // Inserting or deleting a row/column through a merged cell region silently
 // corrupted the merge (a dangling hMerge/vMerge continuation with no valid
 // anchor, or a stale gridSpan/rowSpan). TableSection.svelte now imports the
-// same shared functions the other four bindings use; these tests exercise them
+// same shared element functions the other four bindings use; these tests exercise them
 // through the exact call convention TableSection.svelte uses (insert relative
 // to an "active" row/column, delete by index) to guard against that import
 // being swapped back out for a local reimplementation.
 
-function table(): PptxTableData {
-	return {
+function element(tableData: PptxTableData): TablePptxElement {
+	return { type: 'table', id: 'tbl', x: 0, y: 0, width: 300, height: 200, tableData };
+}
+
+function table(): TablePptxElement {
+	return element({
 		rows: [
 			{ cells: [{ text: 'a', rowSpan: 3 }, { text: 'b' }] },
 			{ cells: [{ text: '', vMerge: true }, { text: 'd' }] },
 			{ cells: [{ text: '', vMerge: true }, { text: 'f' }] },
 		],
 		columnWidths: [0.5, 0.5],
-	};
+	});
 }
 
-function wideTable(): PptxTableData {
-	return {
+function wideTable(): TablePptxElement {
+	return element({
 		rows: [{ cells: [{ text: 'a', gridSpan: 2 }, { text: '', hMerge: true }, { text: 'c' }] }],
 		columnWidths: [1 / 3, 1 / 3, 1 / 3],
-	};
+	});
 }
 
 describe('table structure editing (merge-aware, via pptx-viewer-shared)', () => {
 	it('grows a vertical merge anchor when inserting a row through its span', () => {
-		// TableSection calls insertTableRow(table, activeRow, 'below') on click.
-		const result = insertTableRow(table(), 1, 'below');
+		const result = insertTableElementRow(table(), 1, 'below').tableData!;
 		expect(result.rows).toHaveLength(4);
 		expect(result.rows[0].cells[0].rowSpan).toBe(4);
 		// The newly inserted row's cell in the merged column is a continuation,
@@ -48,8 +51,7 @@ describe('table structure editing (merge-aware, via pptx-viewer-shared)', () => 
 	});
 
 	it('migrates the merge anchor when deleting the anchor row', () => {
-		// TableSection calls deleteTableRow(table, activeRow) on click.
-		const result = deleteTableRow(table(), 0);
+		const result = removeTableElementRow(table(), 0).tableData!;
 		expect(result.rows).toHaveLength(2);
 		// The anchor's text/span move onto the next surviving row instead of
 		// leaving row 0 (now the old vMerge continuation) as a broken anchor.
@@ -59,15 +61,13 @@ describe('table structure editing (merge-aware, via pptx-viewer-shared)', () => 
 	});
 
 	it('grows a horizontal merge anchor when inserting a column through its span', () => {
-		// TableSection calls insertTableColumn(table, activeColumn, 'right').
-		const result = insertTableColumn(wideTable(), 0, 'right');
+		const result = insertTableElementColumn(wideTable(), 0, 'right').tableData!;
 		expect(result.rows[0].cells).toHaveLength(4);
 		expect(result.rows[0].cells[0].gridSpan).toBe(3);
 	});
 
 	it('migrates the merge anchor when deleting the anchor column', () => {
-		// TableSection calls deleteTableColumn(table, activeColumn).
-		const result = deleteTableColumn(wideTable(), 0);
+		const result = removeTableElementColumn(wideTable(), 0).tableData!;
 		expect(result.rows[0].cells).toHaveLength(2);
 		expect(result.rows[0].cells[0].hMerge).toBeUndefined();
 		expect(result.rows[0].cells[0].gridSpan).toBeUndefined();

--- a/packages/svelte/src/viewer/editor/context-menu-dispatch.ts
+++ b/packages/svelte/src/viewer/editor/context-menu-dispatch.ts
@@ -1,4 +1,4 @@
-import type { PptxElement, PptxTableData } from 'pptx-viewer-core';
+import type { PptxElement, PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import type { CellCoord, ContextMenuCommandId, ContextMenuEntry } from 'pptx-viewer-shared';
 import {
 	buildContextMenuEntries,
@@ -7,11 +7,11 @@ import {
 	computeMergeCellDown,
 	computeMergeCellRight,
 	computeSplitCell,
-	deleteTableColumn,
-	deleteTableRow,
-	insertTableColumn,
-	insertTableRow,
+	insertTableElementColumn,
+	insertTableElementRow,
 	mergeCells,
+	removeTableElementColumn,
+	removeTableElementRow,
 } from 'pptx-viewer-shared';
 
 import type { EditorState } from './editor-state.svelte';
@@ -139,22 +139,6 @@ function computeTableCommand(
 ): PptxTableData | null {
 	const { rowIndex, columnIndex } = cell;
 	switch (id) {
-		case 'table-insert-row-above':
-			return insertTableRow(tableData, rowIndex, 'above');
-		case 'table-insert-row-below':
-			return insertTableRow(tableData, rowIndex, 'below');
-		case 'table-delete-row': {
-			const next = deleteTableRow(tableData, rowIndex);
-			return next === tableData ? null : next;
-		}
-		case 'table-insert-col-left':
-			return insertTableColumn(tableData, columnIndex, 'left');
-		case 'table-insert-col-right':
-			return insertTableColumn(tableData, columnIndex, 'right');
-		case 'table-delete-col': {
-			const next = deleteTableColumn(tableData, columnIndex);
-			return next === tableData ? null : next;
-		}
 		case 'table-merge-right': {
 			const rows = computeMergeCellRight(tableData, rowIndex, columnIndex);
 			return rows ? { ...tableData, rows } : null;
@@ -185,14 +169,50 @@ function computeTableCommand(
 	}
 }
 
+/** A structural table result, or `undefined` when `id` is not structural. */
+function computeTableStructureCommand(
+	id: ContextMenuCommandId,
+	element: TablePptxElement,
+	cell: ContextMenuCellTarget,
+): TablePptxElement | undefined {
+	const { rowIndex, columnIndex } = cell;
+	switch (id) {
+		case 'table-insert-row-above':
+			return insertTableElementRow(element, rowIndex, 'above');
+		case 'table-insert-row-below':
+			return insertTableElementRow(element, rowIndex, 'below');
+		case 'table-delete-row':
+			return removeTableElementRow(element, rowIndex);
+		case 'table-insert-col-left':
+			return insertTableElementColumn(element, columnIndex, 'left');
+		case 'table-insert-col-right':
+			return insertTableElementColumn(element, columnIndex, 'right');
+		case 'table-delete-col':
+			return removeTableElementColumn(element, columnIndex);
+		default:
+			return undefined;
+	}
+}
+
 /** Apply a table command to the selected table as one undoable step. */
 function runTableCommand(id: ContextMenuCommandId, deps: ContextMenuDispatchDeps): void {
 	const element = deps.editor.selectedElement;
-	const tableData = selectedTableData(deps.editor);
 	const cell = deps.cell;
-	if (!element || !tableData || !cell) {
+	if (!element || element.type !== 'table' || !element.tableData || !cell) {
 		return;
 	}
+	const structural = computeTableStructureCommand(id, element, cell);
+	if (structural) {
+		if (structural !== element) {
+			deps.editor.applyElementPatch(element.id, {
+				tableData: structural.tableData,
+				rawXml: structural.rawXml,
+			} as Partial<PptxElement>);
+			deps.editor.tableCells.clear();
+		}
+		return;
+	}
+	const tableData = element.tableData;
 	const next = computeTableCommand(
 		id,
 		tableData,

--- a/packages/svelte/src/viewer/editor/table-cell-selection.svelte.test.ts
+++ b/packages/svelte/src/viewer/editor/table-cell-selection.svelte.test.ts
@@ -1,4 +1,4 @@
-import type { PptxElement, PptxTableData } from 'pptx-viewer-core';
+import type { PptxElement, PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import { buildEditorContextMenuEntries, runContextMenuCommand } from './context-menu-dispatch';
@@ -23,8 +23,8 @@ function tableData(rows = 3, cols = 3): PptxTableData {
 	};
 }
 
-function tableElement(data: PptxTableData = tableData()): PptxElement {
-	return {
+function tableElement(data: PptxTableData = tableData(), withRawXml = false): PptxElement {
+	const element: TablePptxElement = {
 		type: 'table',
 		id: 'tbl',
 		x: 0,
@@ -33,7 +33,28 @@ function tableElement(data: PptxTableData = tableData()): PptxElement {
 		height: 200,
 		rotation: 0,
 		tableData: data,
-	} as PptxElement;
+	};
+	if (withRawXml) {
+		element.rawXml = {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': {
+							'a:gridCol': data.columnWidths.map(() => ({ '@_w': '1000' })),
+						},
+						'a:tr': data.rows.map((row) => ({
+							'@_h': '370840',
+							'a:tc': row.cells.map((cell) => ({
+								'a:txBody': { 'a:p': { 'a:r': { 'a:t': cell.text } } },
+								'a:tcPr': {},
+							})),
+						})),
+					},
+				},
+			},
+		};
+	}
+	return element;
 }
 
 function makeEditor(element: PptxElement = tableElement()): EditorState {
@@ -159,5 +180,22 @@ describe('block merge through the context menu', () => {
 
 		editor.undo();
 		expect(modelOf(editor).rows[0].cells[0].gridSpan).toBeUndefined();
+	});
+});
+
+describe('structural table commands through the context menu', () => {
+	it('commits rawXml with tableData', () => {
+		const source = tableElement(tableData(2, 2), true);
+		const editor = makeEditor(source);
+
+		runContextMenuCommand('table-insert-row-below', {
+			editor,
+			cell: { rowIndex: 0, columnIndex: 0 },
+		});
+
+		const current = editor.selectedElement as TablePptxElement;
+		expect(current.tableData?.rows).toHaveLength(3);
+		expect(current.rawXml).toBeDefined();
+		expect(current.rawXml).not.toBe((source as TablePptxElement).rawXml);
 	});
 });

--- a/packages/tools/src/__tests__/tools/table-tools.test.ts
+++ b/packages/tools/src/__tests__/tools/table-tools.test.ts
@@ -1,4 +1,5 @@
-import type { PptxData, TablePptxElement } from 'pptx-viewer-core';
+import { PptxHandler, PresentationBuilder } from 'pptx-viewer-core';
+import type { PptxData, TablePptxElement, XmlObject } from 'pptx-viewer-core';
 import { describe, it, expect } from 'vitest';
 
 import { updateTableCells, manageTableStructure } from '../../tools/table-tools.js';
@@ -11,6 +12,66 @@ function ctx(pptxData?: PptxData): ToolContext {
 
 function getTable(c: ToolContext): TablePptxElement {
 	return c.pptxData.slides[0].elements.find((e) => e.id === 'tbl-0') as TablePptxElement;
+}
+
+function xmlItems(value: unknown): XmlObject[] {
+	if (Array.isArray(value)) {
+		return value as XmlObject[];
+	}
+	return value && typeof value === 'object' ? [value as XmlObject] : [];
+}
+
+function tableXmlRows(table: TablePptxElement): XmlObject[] {
+	const graphic = table.rawXml?.['a:graphic'] as XmlObject | undefined;
+	const graphicData = graphic?.['a:graphicData'] as XmlObject | undefined;
+	const xmlTable = graphicData?.['a:tbl'] as XmlObject | undefined;
+	return xmlItems(xmlTable?.['a:tr']);
+}
+
+async function makeRichTableContext(): Promise<{
+	context: ToolContext;
+	handler: PptxHandler;
+	table: TablePptxElement;
+}> {
+	const { handler: creator, data, createSlide } = await PresentationBuilder.create();
+	data.slides.push(
+		createSlide('Blank')
+			.addTable(
+				{
+					rows: Array.from({ length: 2 }, () => ({
+						height: 40,
+						cells: Array.from({ length: 2 }, () => ({ text: 'Rich text' })),
+					})),
+				},
+				{ x: 20, y: 80, width: 400, height: 160 },
+			)
+			.build(),
+	);
+	const initial = await creator.save(data.slides);
+	const fixtureHandler = new PptxHandler();
+	const fixture = await fixtureHandler.load(initial.buffer as ArrayBuffer);
+	const fixtureTable = fixture.slides[0].elements.find(
+		(element) => element.type === 'table',
+	) as TablePptxElement;
+	for (const row of tableXmlRows(fixtureTable)) {
+		for (const cell of xmlItems(row['a:tc'])) {
+			const textBody = cell['a:txBody'] as XmlObject;
+			textBody['a:p'] = {
+				'a:r': [
+					{ 'a:rPr': { '@_b': '1' }, 'a:t': 'Rich ' },
+					{ 'a:rPr': { '@_i': '1' }, 'a:t': 'text' },
+				],
+			};
+		}
+	}
+	fixtureTable.x += 1;
+	const richBytes = await fixtureHandler.save(fixture.slides);
+	const handler = new PptxHandler();
+	const pptxData = await handler.load(richBytes.buffer as ArrayBuffer);
+	const table = pptxData.slides[0].elements.find(
+		(element) => element.type === 'table',
+	) as TablePptxElement;
+	return { context: { pptxData }, handler, table };
 }
 
 // ── updateTableCells ────────────────────────────────────────────────────────
@@ -99,6 +160,120 @@ describe('updateTableCells', () => {
 // ── manageTableStructure ────────────────────────────────────────────────────
 
 describe('manageTableStructure', () => {
+	it.each(['insertRow', 'deleteRow', 'insertColumn', 'deleteColumn'] as const)(
+		'keeps surviving raw cells aligned for %s at the first position',
+		(action) => {
+			const c = ctx();
+			const table = getTable(c);
+			const sourceRows = table.tableData!.rows.map((row, r) => ({
+				'@_h': '381000',
+				'a:tc': row.cells.map((cell, col) => ({
+					'@_id': `${r}:${col}`,
+					'a:txBody': {
+						'a:p': {
+							'a:r': [
+								{ 'a:rPr': { '@_b': '1' }, 'a:t': cell.text.slice(0, 1) },
+								{ 'a:rPr': { '@_i': '1' }, 'a:t': cell.text.slice(1) },
+							],
+						},
+					},
+					'a:tcPr': { 'a:solidFill': { 'a:srgbClr': { '@_val': '123456' } } },
+				})),
+			}));
+			table.rawXml = {
+				'a:graphic': {
+					'a:graphicData': {
+						'a:tbl': {
+							'a:tblGrid': { 'a:gridCol': [0, 1, 2].map(() => ({ '@_w': '1000' })) },
+							'a:tr': sourceRows,
+						},
+					},
+				},
+			};
+			const original = structuredClone(table.rawXml);
+			const rowOperation = action.endsWith('Row');
+			const insertion = action.startsWith('insert');
+			manageTableStructure(c, {
+				slideIndex: 0,
+				elementId: 'tbl-0',
+				action,
+				position: 0,
+				referenceIndex: 0,
+			});
+			const actual = table.rawXml['a:graphic']['a:graphicData']['a:tbl']['a:tr'];
+			for (let r = 0; r < table.tableData!.rows.length; r++) {
+				for (let col = 0; col < table.tableData!.columnWidths.length; col++) {
+					if (insertion && (rowOperation ? r : col) === 0) {
+						continue;
+					}
+					const sourceR = r + (rowOperation ? (insertion ? -1 : 1) : 0);
+					const sourceCol = col + (rowOperation ? 0 : insertion ? -1 : 1);
+					expect(actual[r]['a:tc'][col]).toStrictEqual(sourceRows[sourceR]['a:tc'][sourceCol]);
+				}
+			}
+			expect(original['a:graphic']['a:graphicData']['a:tbl']['a:tr']).toStrictEqual(sourceRows);
+		},
+	);
+
+	it.each([
+		{
+			name: 'row',
+			action: 'insertRow' as const,
+			cellTexts: ['Inserted A', 'Inserted B'],
+			isInserted: (row: number, _column: number) => row === 1,
+			insertedText: (_row: number, column: number) => ['Inserted A', 'Inserted B'][column],
+		},
+		{
+			name: 'column',
+			action: 'insertColumn' as const,
+			cellTexts: ['Inserted A', 'Inserted B'],
+			isInserted: (_row: number, column: number) => column === 1,
+			insertedText: (row: number, _column: number) => ['Inserted A', 'Inserted B'][row],
+		},
+	])(
+		'writes supplied $name text on save without flattening rich survivors',
+		async ({ action, cellTexts, isInserted, insertedText }) => {
+			const { context, handler, table } = await makeRichTableContext();
+			const expectedRuns = table.tableData!.rows[0].cells[0].textRuns;
+			expect(expectedRuns).toStrictEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ text: 'Rich ', bold: true }),
+					expect.objectContaining({ text: 'text', italic: true }),
+				]),
+			);
+			const sourceRaw = table.rawXml;
+			const sourceRawSnapshot = structuredClone(sourceRaw);
+
+			manageTableStructure(context, {
+				slideIndex: 0,
+				elementId: table.id,
+				action,
+				position: 1,
+				cellTexts,
+			});
+
+			// The tool replaces rawXml with the edited clone; the caller's source
+			// tree remains untouched and is still safe for history/snapshots.
+			expect(sourceRaw).toStrictEqual(sourceRawSnapshot);
+			const saved = await handler.save(context.pptxData.slides);
+			const reloaded = await new PptxHandler().load(saved.buffer as ArrayBuffer);
+			const result = reloaded.slides[0].elements.find(
+				(element) => element.type === 'table',
+			) as TablePptxElement;
+
+			for (const [rowIndex, row] of result.tableData!.rows.entries()) {
+				for (const [columnIndex, cell] of row.cells.entries()) {
+					if (isInserted(rowIndex, columnIndex)) {
+						expect(cell.text).toBe(insertedText(rowIndex, columnIndex));
+					} else {
+						expect(cell.text).toBe('Rich text');
+						expect(cell.textRuns).toStrictEqual(expectedRuns);
+					}
+				}
+			}
+		},
+	);
+
 	describe('insertRow', () => {
 		it('inserts a row at the end by default', () => {
 			const c = ctx();

--- a/packages/tools/src/tools/table-tools.ts
+++ b/packages/tools/src/tools/table-tools.ts
@@ -1,4 +1,5 @@
-import type { TablePptxElement } from 'pptx-viewer-core';
+import { rebuildTableStructureInRawXml } from 'pptx-viewer-core';
+import type { TablePptxElement, TableStructureEdit } from 'pptx-viewer-core';
 
 import type { ToolContext, ToolResult } from '../types.js';
 import { validateSlideIndex } from './helpers.js';
@@ -92,6 +93,8 @@ export function manageTableStructure(
 	}
 
 	const { rows, columnWidths } = tbl.tableData;
+	const source = { ...tbl, tableData: structuredClone(tbl.tableData) };
+	let edit: TableStructureEdit;
 	const colCount = columnWidths.length;
 	const rowCount = rows.length;
 
@@ -106,6 +109,7 @@ export function manageTableStructure(
 				})),
 			};
 			rows.splice(pos, 0, newRow);
+			edit = { axis: 'row', action: 'insert', index: pos };
 			break;
 		}
 
@@ -118,6 +122,7 @@ export function manageTableStructure(
 				throw new Error(`Row index ${ref} out of range (0–${rowCount - 1}).`);
 			}
 			rows.splice(ref, 1);
+			edit = { axis: 'row', action: 'delete', index: ref };
 			break;
 		}
 
@@ -131,6 +136,7 @@ export function manageTableStructure(
 				columnWidths[i] *= scaleFactor;
 			}
 			columnWidths.splice(pos, 0, newWidth);
+			edit = { axis: 'column', action: 'insert', index: pos };
 			// insert cell in each row
 			for (let r = 0; r < rows.length; r++) {
 				rows[r].cells.splice(pos, 0, {
@@ -151,6 +157,7 @@ export function manageTableStructure(
 			// redistribute widths
 			const removedWidth = columnWidths[ref];
 			columnWidths.splice(ref, 1);
+			edit = { axis: 'column', action: 'delete', index: ref };
 			const remaining = columnWidths.length;
 			if (remaining > 0) {
 				const extra = removedWidth / remaining;
@@ -170,6 +177,10 @@ export function manageTableStructure(
 		}
 	}
 
+	const rawXml = rebuildTableStructureInRawXml(source, tbl.tableData, edit);
+	if (rawXml) {
+		tbl.rawXml = rawXml;
+	}
 	return {
 		pptxData: ctx.pptxData,
 		dirty: true,

--- a/packages/vanilla/src/viewer/editor/editor-inspector-actions.ts
+++ b/packages/vanilla/src/viewer/editor/editor-inspector-actions.ts
@@ -278,11 +278,13 @@ export function createInspectorActions(applyToSelected: ApplyToSelected): Inspec
 					: {},
 			),
 		mutateTableStructure: (cell, action) =>
-			applyToSelected((el) =>
-				el.type === 'table' && el.tableData
-					? { tableData: mutateTableStructure(el.tableData, cell, action) }
-					: {},
-			),
+			applyToSelected((el) => {
+				if (el.type !== 'table' || !el.tableData) {
+					return {};
+				}
+				const next = mutateTableStructure(el, cell, action);
+				return next === el ? {} : { tableData: next.tableData, rawXml: next.rawXml };
+			}),
 		setTableColumnWidth: (column, percent) =>
 			applyToSelected((el) =>
 				el.type === 'table' && el.tableData

--- a/packages/vanilla/src/viewer/editor/table-editor-mutations.test.ts
+++ b/packages/vanilla/src/viewer/editor/table-editor-mutations.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable eslint/one-var -- many independent `it()` blocks, each with
    its own short arrange/act/assert consts. */
-import type { PptxTableData } from 'pptx-viewer-core';
+import type { PptxTableData, TablePptxElement, XmlObject } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -22,16 +22,69 @@ function table(): PptxTableData {
 	};
 }
 
+function rawTableRows(element: TablePptxElement): XmlObject[] {
+	const graphic = element.rawXml!['a:graphic'] as XmlObject;
+	const data = graphic['a:graphicData'] as XmlObject;
+	return (data['a:tbl'] as XmlObject)['a:tr'] as XmlObject[];
+}
+
 describe('table editor mutations', () => {
+	it('moves surviving raw cells with an inserted row and deleted column', () => {
+		const data = table();
+		const rawRows = data.rows.map((row) => ({
+			'@_h': '381000',
+			'a:tc': row.cells.map((cell) => ({
+				'a:txBody': { 'a:p': { 'a:r': { 'a:rPr': { '@_b': '1' }, 'a:t': cell.text } } },
+				'a:tcPr': {},
+			})),
+		}));
+		const element: TablePptxElement = {
+			id: 'table',
+			type: 'table',
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 100,
+			tableData: data,
+			rawXml: {
+				'a:graphic': {
+					'a:graphicData': {
+						'a:tbl': {
+							'a:tblGrid': { 'a:gridCol': [{ '@_w': '1000' }, { '@_w': '1000' }] },
+							'a:tr': rawRows,
+						},
+					},
+				},
+			},
+		};
+		const withRow = mutateTableStructure(element, { row: 0, column: 0 }, 'insertRowBelow');
+		expect(rawTableRows(withRow)[2]['a:tc']).toStrictEqual(rawRows[1]['a:tc']);
+		const withColumnRemoved = mutateTableStructure(withRow, { row: 0, column: 0 }, 'deleteColumn');
+		expect(withColumnRemoved.tableData!.rows[2].cells[0].text).toBe('D');
+		expect(rawTableRows(withColumnRemoved)[2]['a:tc']).toStrictEqual(rawRows[1]['a:tc'][1]);
+	});
+
 	it('inserts and deletes rows and columns', () => {
-		const withRow = mutateTableStructure(table(), { row: 0, column: 0 }, 'insertRowBelow');
-		expect(withRow.rows).toHaveLength(3);
+		const element: TablePptxElement = {
+			id: 'table',
+			type: 'table',
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 100,
+			tableData: table(),
+		};
+		const withRow = mutateTableStructure(element, { row: 0, column: 0 }, 'insertRowBelow');
+		expect(withRow.tableData!.rows).toHaveLength(3);
 		const withColumn = mutateTableStructure(withRow, { row: 0, column: 0 }, 'insertColumnRight');
-		expect(withColumn.columnWidths).toHaveLength(3);
+		expect(withColumn.tableData!.columnWidths).toHaveLength(3);
 		expect(
-			mutateTableStructure(withColumn, { row: 0, column: 1 }, 'deleteColumn').columnWidths,
+			mutateTableStructure(withColumn, { row: 0, column: 1 }, 'deleteColumn').tableData!
+				.columnWidths,
 		).toHaveLength(2);
-		expect(mutateTableStructure(withRow, { row: 1, column: 0 }, 'deleteRow').rows).toHaveLength(2);
+		expect(
+			mutateTableStructure(withRow, { row: 1, column: 0 }, 'deleteRow').tableData!.rows,
+		).toHaveLength(2);
 	});
 
 	it('formats a cell range without touching other cells', () => {

--- a/packages/vanilla/src/viewer/editor/table-editor-mutations.ts
+++ b/packages/vanilla/src/viewer/editor/table-editor-mutations.ts
@@ -1,14 +1,14 @@
 /* oxlint-disable eslint/one-var -- pervasive pre-existing pattern in this file
    (independent short-lived `const`s per operation); merging them isn't a
    style choice here. */
-import type { PptxTableCellStyle, PptxTableData } from 'pptx-viewer-core';
+import type { PptxTableCellStyle, PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import {
 	canMergeCells,
 	computeSplitCell,
-	deleteTableColumn,
-	deleteTableRow,
-	insertTableColumn,
-	insertTableRow,
+	removeTableElementColumn,
+	removeTableElementRow,
+	insertTableElementColumn,
+	insertTableElementRow,
 	mergeCells,
 	redistributeColumnWidth,
 } from 'pptx-viewer-shared';
@@ -46,23 +46,23 @@ export function patchTableCells(
 }
 
 export function mutateTableStructure(
-	data: PptxTableData,
+	element: TablePptxElement,
 	cell: TableCellPosition,
 	action: TableStructureAction,
-): PptxTableData {
+): TablePptxElement {
 	switch (action) {
 		case 'insertRowAbove':
-			return insertTableRow(data, cell.row, 'above');
+			return insertTableElementRow(element, cell.row, 'above');
 		case 'insertRowBelow':
-			return insertTableRow(data, cell.row, 'below');
+			return insertTableElementRow(element, cell.row, 'below');
 		case 'deleteRow':
-			return deleteTableRow(data, cell.row);
+			return removeTableElementRow(element, cell.row);
 		case 'insertColumnLeft':
-			return insertTableColumn(data, cell.column, 'left');
+			return insertTableElementColumn(element, cell.column, 'left');
 		case 'insertColumnRight':
-			return insertTableColumn(data, cell.column, 'right');
+			return insertTableElementColumn(element, cell.column, 'right');
 		case 'deleteColumn':
-			return deleteTableColumn(data, cell.column);
+			return removeTableElementColumn(element, cell.column);
 	}
 }
 

--- a/packages/vue/src/viewer/components/inspector/TablePanel.test.ts
+++ b/packages/vue/src/viewer/components/inspector/TablePanel.test.ts
@@ -28,6 +28,31 @@ function makeTableElement(rows: number, cols: number): TablePptxElement {
 	};
 }
 
+function makeRawTableElement(rows: number, cols: number): TablePptxElement {
+	const element = makeTableElement(rows, cols);
+	return {
+		...element,
+		rawXml: {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': {
+							'a:gridCol': Array.from({ length: cols }, () => ({ '@_w': '1000' })),
+						},
+						'a:tr': element.tableData!.rows.map((row) => ({
+							'@_h': '370840',
+							'a:tc': row.cells.map((cell) => ({
+								'a:txBody': { 'a:p': { 'a:r': { 'a:t': cell.text } } },
+								'a:tcPr': {},
+							})),
+						})),
+					},
+				},
+			},
+		},
+	};
+}
+
 function makeSelectionContext(initial: TableSelectionState | null): TableSelectionContext {
 	const selection = ref<TableSelectionState | null>(initial);
 	return {
@@ -47,11 +72,16 @@ function mountPanel(element: PptxElement, selection: TableSelectionState | null 
 	});
 }
 
-/** Extract the tableData from the most recent `update` emit. */
-function lastEmittedTableData(wrapper: ReturnType<typeof mountPanel>): PptxTableData {
+/** Extract the most recent `update` patch. */
+function lastEmittedPatch(wrapper: ReturnType<typeof mountPanel>): Partial<PptxElement> {
 	const events = wrapper.emitted('update');
 	expect(events).toBeTruthy();
-	const last = events![events!.length - 1][0] as Partial<PptxElement>;
+	return events![events!.length - 1][0] as Partial<PptxElement>;
+}
+
+/** Extract the tableData from the most recent `update` emit. */
+function lastEmittedTableData(wrapper: ReturnType<typeof mountPanel>): PptxTableData {
+	const last = lastEmittedPatch(wrapper);
 	const td = (last as { tableData?: PptxTableData }).tableData;
 	expect(td).toBeTruthy();
 	return td as PptxTableData;
@@ -98,7 +128,7 @@ describe('tablePanel', () => {
 	});
 
 	it('insert row below inserts after the selected row', () => {
-		const wrapper = mountPanel(makeTableElement(2, 2), {
+		const wrapper = mountPanel(makeRawTableElement(2, 2), {
 			elementId: 'tbl1',
 			rowIndex: 0,
 			columnIndex: 0,
@@ -107,6 +137,7 @@ describe('tablePanel', () => {
 		const td = lastEmittedTableData(wrapper);
 		expect(td.rows).toHaveLength(3);
 		expect(td.rows[1].cells.every((c) => c.text === '')).toBeTruthy();
+		expect(lastEmittedPatch(wrapper).rawXml).toBeDefined();
 	});
 
 	it('delete row removes the selected row', () => {

--- a/packages/vue/src/viewer/components/inspector/TablePanel.vue
+++ b/packages/vue/src/viewer/components/inspector/TablePanel.vue
@@ -53,9 +53,10 @@ const { t } = useI18n();
 
 const isTable = computed(() => props.element.type === 'table');
 
-const tableData = computed<PptxTableData | undefined>(() =>
-	props.element.type === 'table' ? (props.element as TablePptxElement).tableData : undefined,
+const tableElement = computed<TablePptxElement | undefined>(() =>
+	props.element.type === 'table' ? (props.element as TablePptxElement) : undefined,
 );
+const tableData = computed<PptxTableData | undefined>(() => tableElement.value?.tableData);
 
 const rowCount = computed(() => tableData.value?.rows.length ?? 0);
 const colCount = computed(() => tableData.value?.columnWidths.length ?? 0);
@@ -91,39 +92,47 @@ function emitTableData(next: PptxTableData): void {
 	emit('update', { tableData: next } as Partial<PptxElement>);
 }
 
+/** Emit both table representations produced by an element-level structural operation. */
+function emitTableElement(next: TablePptxElement): void {
+	if (next === tableElement.value) {
+		return;
+	}
+	emit('update', { tableData: next.tableData, rawXml: next.rawXml } as Partial<PptxElement>);
+}
+
 function insertRow(position: 'above' | 'below'): void {
-	const td = tableData.value;
-	if (td) {
-		emitTableData(applyInsertRow(td, activeRow.value, position));
+	const element = tableElement.value;
+	if (element) {
+		emitTableElement(applyInsertRow(element, activeRow.value, position));
 	}
 }
 
 function deleteRow(): void {
-	const td = tableData.value;
-	if (!td) {
+	const element = tableElement.value;
+	if (!element) {
 		return;
 	}
-	const next = applyDeleteRow(td, activeRow.value);
+	const next = applyDeleteRow(element, activeRow.value);
 	if (next) {
-		emitTableData(next);
+		emitTableElement(next);
 	}
 }
 
 function insertColumn(position: 'left' | 'right'): void {
-	const td = tableData.value;
-	if (td) {
-		emitTableData(applyInsertColumn(td, activeColumn.value, position));
+	const element = tableElement.value;
+	if (element) {
+		emitTableElement(applyInsertColumn(element, activeColumn.value, position));
 	}
 }
 
 function deleteColumn(): void {
-	const td = tableData.value;
-	if (!td) {
+	const element = tableElement.value;
+	if (!element) {
 		return;
 	}
-	const next = applyDeleteColumn(td, activeColumn.value);
+	const next = applyDeleteColumn(element, activeColumn.value);
 	if (next) {
-		emitTableData(next);
+		emitTableElement(next);
 	}
 }
 

--- a/packages/vue/src/viewer/composables/table-mutations.test.ts
+++ b/packages/vue/src/viewer/composables/table-mutations.test.ts
@@ -1,4 +1,4 @@
-import type { PptxTableData } from 'pptx-viewer-core';
+import type { PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -21,34 +21,46 @@ function makeTableData(rows: number, cols: number): PptxTableData {
 	};
 }
 
+function makeTableElement(rows: number, cols: number): TablePptxElement {
+	return {
+		type: 'table',
+		id: 'table-1',
+		x: 0,
+		y: 0,
+		width: 400,
+		height: 200,
+		tableData: makeTableData(rows, cols),
+	};
+}
+
 describe('table-mutations', () => {
 	it('inserts a row above the target index', () => {
-		const next = applyInsertRow(makeTableData(2, 2), 0, 'above');
-		expect(next.rows).toHaveLength(3);
-		expect(next.rows[0].cells.every((c) => c.text === '')).toBeTruthy();
+		const next = applyInsertRow(makeTableElement(2, 2), 0, 'above');
+		expect(next.tableData?.rows).toHaveLength(3);
+		expect(next.tableData?.rows[0].cells.every((c) => c.text === '')).toBeTruthy();
 	});
 
 	it('inserts a row below the target index', () => {
-		const next = applyInsertRow(makeTableData(2, 2), 0, 'below');
-		expect(next.rows).toHaveLength(3);
-		expect(next.rows[1].cells.every((c) => c.text === '')).toBeTruthy();
+		const next = applyInsertRow(makeTableElement(2, 2), 0, 'below');
+		expect(next.tableData?.rows).toHaveLength(3);
+		expect(next.tableData?.rows[1].cells.every((c) => c.text === '')).toBeTruthy();
 	});
 
 	it('deletes a row and returns null on a single-row no-op', () => {
-		expect(applyDeleteRow(makeTableData(2, 2), 0)?.rows).toHaveLength(1);
-		expect(applyDeleteRow(makeTableData(1, 2), 0)).toBeNull();
+		expect(applyDeleteRow(makeTableElement(2, 2), 0)?.tableData?.rows).toHaveLength(1);
+		expect(applyDeleteRow(makeTableElement(1, 2), 0)).toBeNull();
 	});
 
 	it('inserts a column keeping widths normalised', () => {
-		const next = applyInsertColumn(makeTableData(2, 2), 0, 'right');
-		expect(next.columnWidths).toHaveLength(3);
-		expect(next.rows[0].cells).toHaveLength(3);
-		expect(next.columnWidths.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 6);
+		const next = applyInsertColumn(makeTableElement(2, 2), 0, 'right');
+		expect(next.tableData?.columnWidths).toHaveLength(3);
+		expect(next.tableData?.rows[0].cells).toHaveLength(3);
+		expect(next.tableData?.columnWidths.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 6);
 	});
 
 	it('deletes a column and returns null on a single-column no-op', () => {
-		expect(applyDeleteColumn(makeTableData(2, 2), 0)?.columnWidths).toHaveLength(1);
-		expect(applyDeleteColumn(makeTableData(2, 1), 0)).toBeNull();
+		expect(applyDeleteColumn(makeTableElement(2, 2), 0)?.tableData?.columnWidths).toHaveLength(1);
+		expect(applyDeleteColumn(makeTableElement(2, 1), 0)).toBeNull();
 	});
 
 	it('merges the cell to the right (gridSpan + hMerge)', () => {

--- a/packages/vue/src/viewer/composables/table-mutations.ts
+++ b/packages/vue/src/viewer/composables/table-mutations.ts
@@ -1,53 +1,62 @@
-import type { PptxTableData } from 'pptx-viewer-core';
+import type { PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import type { CellCoord } from 'pptx-viewer-shared';
 import {
 	canMergeCells,
 	computeMergeCellDown,
 	computeMergeCellRight,
 	computeSplitCell,
-	deleteTableColumn,
-	deleteTableRow,
-	insertTableColumn,
-	insertTableRow,
+	insertTableElementColumn,
+	insertTableElementRow,
 	mergeCells,
+	removeTableElementColumn,
+	removeTableElementRow,
 } from 'pptx-viewer-shared';
+import { toRaw } from 'vue';
 
 /**
  * table-mutations: thin, pure wrappers over the framework-agnostic table
- * transforms in `pptx-viewer-shared`, returning a new `PptxTableData` (or `null`
- * for a no-op) so both the inspector `TablePanel` (emits an element patch) and
+ * transforms in `pptx-viewer-shared`, returning a new table element (or `null`
+ * for a structural no-op) so both the inspector `TablePanel` and
  * the canvas context menu (applies via `useEditorOperations`) drive edits from
  * one merge-aware implementation. Mirrors React's table operation handlers.
  */
 
 /** Insert a blank row above/below `rowIndex` (merge span aware). */
 export function applyInsertRow(
-	td: PptxTableData,
+	element: TablePptxElement,
 	rowIndex: number,
 	position: 'above' | 'below',
-): PptxTableData {
-	return insertTableRow(td, rowIndex, position);
+): TablePptxElement {
+	return insertTableElementRow(toRaw(element), rowIndex, position);
 }
 
 /** Delete the row at `rowIndex`; returns `null` when the delete is a no-op. */
-export function applyDeleteRow(td: PptxTableData, rowIndex: number): PptxTableData | null {
-	const next = deleteTableRow(td, rowIndex);
-	return next === td ? null : next;
+export function applyDeleteRow(
+	element: TablePptxElement,
+	rowIndex: number,
+): TablePptxElement | null {
+	const source = toRaw(element);
+	const next = removeTableElementRow(source, rowIndex);
+	return next === source ? null : next;
 }
 
 /** Insert a blank column left/right of `colIndex` (merge span aware). */
 export function applyInsertColumn(
-	td: PptxTableData,
+	element: TablePptxElement,
 	colIndex: number,
 	position: 'left' | 'right',
-): PptxTableData {
-	return insertTableColumn(td, colIndex, position);
+): TablePptxElement {
+	return insertTableElementColumn(toRaw(element), colIndex, position);
 }
 
 /** Delete the column at `colIndex`; returns `null` when the delete is a no-op. */
-export function applyDeleteColumn(td: PptxTableData, colIndex: number): PptxTableData | null {
-	const next = deleteTableColumn(td, colIndex);
-	return next === td ? null : next;
+export function applyDeleteColumn(
+	element: TablePptxElement,
+	colIndex: number,
+): TablePptxElement | null {
+	const source = toRaw(element);
+	const next = removeTableElementColumn(source, colIndex);
+	return next === source ? null : next;
 }
 
 /** Merge the cursor cell with its right neighbour; `null` when not mergeable. */

--- a/packages/vue/src/viewer/composables/useContextMenu.commands.test.ts
+++ b/packages/vue/src/viewer/composables/useContextMenu.commands.test.ts
@@ -1,6 +1,6 @@
 // oxlint-disable react-hooks/rules-of-hooks
 import { mount } from '@vue/test-utils';
-import type { PptxElement } from 'pptx-viewer-core';
+import type { PptxElement, TablePptxElement } from 'pptx-viewer-core';
 import { describe, expect, it, vi } from 'vitest';
 import { computed, defineComponent, h, ref } from 'vue';
 
@@ -39,6 +39,38 @@ const GROUP = {
 	height: 40,
 	children: [],
 } as unknown as PptxElement;
+
+const TABLE = {
+	id: 'table-1',
+	type: 'table',
+	x: 0,
+	y: 0,
+	width: 200,
+	height: 100,
+	tableData: {
+		rows: [{ cells: [{ text: 'A' }] }, { cells: [{ text: 'B' }] }],
+		columnWidths: [1],
+	},
+	rawXml: {
+		'a:graphic': {
+			'a:graphicData': {
+				'a:tbl': {
+					'a:tblGrid': { 'a:gridCol': { '@_w': '1000' } },
+					'a:tr': [
+						{
+							'@_h': '370840',
+							'a:tc': { 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'A' } } }, 'a:tcPr': {} },
+						},
+						{
+							'@_h': '370840',
+							'a:tc': { 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'B' } } }, 'a:tcPr': {} },
+						},
+					],
+				},
+			},
+		},
+	},
+} as TablePptxElement;
 
 /**
  * `<div data-element-id="group-1"><div data-element-id="child-1"><span/></div></div>`,
@@ -160,6 +192,25 @@ describe('useContextMenu command set', () => {
 		const onAddComment = vi.fn();
 		setup({ onAddComment }).onContextSelect('comment');
 		expect(onAddComment).toHaveBeenCalledOnce();
+	});
+
+	it('commits rawXml with tableData for a structural table command', () => {
+		const updateElement = vi.fn();
+		const menu = setup({
+			findActiveElement: (id) => (id === TABLE.id ? TABLE : undefined),
+			tableSelection: ref({ elementId: TABLE.id, rowIndex: 0, columnIndex: 0 }),
+			selectedElementIds: ref<string[]>([TABLE.id]),
+			ops: { updateElement } as unknown as EditorOperations,
+		});
+		menu.contextMenu.value = { open: true, x: 0, y: 0, elementId: TABLE.id };
+
+		menu.onContextSelect('table-insert-row-below');
+
+		expect(updateElement).toHaveBeenCalledOnce();
+		expect(updateElement.mock.calls[0]?.[1]).toMatchObject({
+			tableData: { rows: expect.any(Array) },
+			rawXml: expect.any(Object),
+		});
 	});
 });
 

--- a/packages/vue/src/viewer/composables/useContextMenu.ts
+++ b/packages/vue/src/viewer/composables/useContextMenu.ts
@@ -1,4 +1,4 @@
-import type { PptxElement, PptxTableData } from 'pptx-viewer-core';
+import type { PptxElement, PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import {
 	buildContextMenuEntries,
 	resolveContextMenuElementId,
@@ -179,6 +179,17 @@ export function useContextMenu(input: UseContextMenuInput): UseContextMenuResult
 			ops.updateElement(tbl.el.id, { tableData: next } as Partial<PptxElement>);
 		}
 	}
+
+	/** Apply a structural result with its synchronised raw table XML. */
+	function applyContextTableElement(next: TablePptxElement | null): void {
+		const tbl = contextTable.value;
+		if (tbl && next && next !== tbl.el) {
+			ops.updateElement(tbl.el.id, {
+				tableData: next.tableData,
+				rawXml: next.rawXml,
+			} as Partial<PptxElement>);
+		}
+	}
 	function onCanvasContextMenu(event: MouseEvent): void {
 		if (!canEdit()) {
 			return;
@@ -274,22 +285,22 @@ export function useContextMenu(input: UseContextMenuInput): UseContextMenuResult
 		const { rowIndex, columnIndex } = tbl.sel;
 		switch (actionId) {
 			case 'table-insert-row-above':
-				applyContextTableData(applyInsertRow(td, rowIndex, 'above'));
+				applyContextTableElement(applyInsertRow(tbl.el, rowIndex, 'above'));
 				break;
 			case 'table-insert-row-below':
-				applyContextTableData(applyInsertRow(td, rowIndex, 'below'));
+				applyContextTableElement(applyInsertRow(tbl.el, rowIndex, 'below'));
 				break;
 			case 'table-delete-row':
-				applyContextTableData(applyDeleteRow(td, rowIndex));
+				applyContextTableElement(applyDeleteRow(tbl.el, rowIndex));
 				break;
 			case 'table-insert-col-left':
-				applyContextTableData(applyInsertColumn(td, columnIndex, 'left'));
+				applyContextTableElement(applyInsertColumn(tbl.el, columnIndex, 'left'));
 				break;
 			case 'table-insert-col-right':
-				applyContextTableData(applyInsertColumn(td, columnIndex, 'right'));
+				applyContextTableElement(applyInsertColumn(tbl.el, columnIndex, 'right'));
 				break;
 			case 'table-delete-col':
-				applyContextTableData(applyDeleteColumn(td, columnIndex));
+				applyContextTableElement(applyDeleteColumn(tbl.el, columnIndex));
 				break;
 			case 'table-merge-right':
 				applyContextTableData(applyMergeRight(td, rowIndex, columnIndex));


### PR DESCRIPTION
## What this fixes

Inserting a row in the middle of an existing table can show the following row's text in the new blank row. Saving and reopening then loses mixed formatting in the shifted cells. Deleting a column can similarly give a surviving cell the removed cell's formatting.

The logical cells move, but the raw XML rebuild reuses cells by their destination index. This pairs a surviving cell with the wrong original text body, which the save writer then treats as changed text.

## Approach

- Give the existing structural XML rebuild an optional insert/delete position. Move the original row/cell/grid nodes by that position before synchronizing dimensions and merge flags.
- Preserve surviving rich text, borders, fills, and opaque metadata. Create default XML only for newly inserted cells. Keep the existing two-argument API's behavior.
- Route controls through the existing shared element-level helpers and commit `tableData` and `rawXml` together, respecting each framework's reactive-state boundary.
- Keep rich runs with text when the existing merge logic promotes a deleted anchor. Retain the current merge, default-style, and width-distribution policies.
- Apply the same XML synchronization to the tooling's structural commands.

This extends the existing raw-XML synchronization rather than replacing its model or guessing cell identity from text. Duplicate visible strings are covered by regression tests. It is separate from #227, which concerns field/break ordering inside a retained paragraph.

## Binding coverage

React, Vue, Angular, Svelte, and Vanilla were checked and are covered. All inherit the shared fix, and each had a structural-control route that also needed to pass the synchronized XML. Angular's helper already returned it, but its context-menu component dropped it when committing the edit; the browser review caught that additional route.

## Validation

- Unit tests cover first/middle/last insertion and deletion on both axes, duplicate cell text, input immutability, repeated edits, opaque metadata, merged anchors/continuations, empty-anchor fallback, and last-row/column no-ops.
- Save/reload tests cover all 12 positional operation combinations with mixed-format cells, plus tool-supplied text during row/column insertion.
- Focused binding tests: React 25, Vue 33, Angular 50, Svelte 20; Vanilla editor suite 358. Tool suite: 301 passed.
- Two framework-neutral tests in the existing table styling E2E spec passed on all five bindings (10/10). They use the checked-in PowerPoint-authored fixture, real context-menu actions, File Save, and downloaded ZIP checks for authored run formatting.
- Independent code review and browser review completed. React also passed typed-cell editing, two-step undo/redo, and save/reload controls.
- Final rebased full suites: core 14,223 passed / 231 skipped; shared 8,857 passed / 3 skipped. Focused binding suites and the tool suite above were also rerun on the rebased commit using Node 22.

No new binary fixture or dependency is added.
