### PR TITLE
fix: preserve unchanged table text during merge and split

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -45,7 +45,13 @@ import type { Locator, Page } from '@playwright/test';
 import JSZip from 'jszip';
 
 import { savePptxViaBackstage } from './save-pptx';
-import { centreOf, chooseCommand, openMenuOn, selectTableCell } from './support/context-menu';
+import {
+	centreOf,
+	chooseCommand,
+	menuIsOpen,
+	openMenuAt,
+	openMenuOn,
+} from './support/context-menu';
 import { resetTabSession } from './support/deck';
 
 const fixturePath = resolve(
@@ -254,14 +260,6 @@ async function savedSlideFourTable(page: Page): Promise<RawTableCell[][]> {
 	);
 }
 
-/** Drive one table-cell context-menu command through the neutral UI contract. */
-async function chooseTableCommand(page: Page, cell: Locator, label: string): Promise<void> {
-	await selectTableCell(page, cell);
-	const menu = await openMenuOn(page, cell);
-	expect(menu.labels).toContain(label.toLowerCase());
-	await chooseCommand(page, label);
-}
-
 function expectMixedRevenueRuns(cell: RawTableCell): void {
 	expect(cell.text).toBe('Revenue grew 42%');
 	expect(cell.runs.map((run) => run.text)).toEqual(['Revenue ', 'grew 42%']);
@@ -272,6 +270,35 @@ function expectMixedRevenueRuns(cell: RawTableCell): void {
 	expect(cell.runs[1]?.xml).toContain('b="1"');
 	expect(cell.runs[1]?.xml).toContain('val="C00000"');
 	expect(cell.runs[1]?.xml).toContain('typeface="Georgia"');
+}
+
+/** Make the cell to the right of the authored rich cell empty without changing its anchor. */
+async function richAnchorWithEmptyRightDeck(): Promise<DeckPayload> {
+	const zip = await JSZip.loadAsync(await readFile(fixturePath));
+	const slidePath = 'ppt/slides/slide4.xml';
+	const slide = zip.file(slidePath);
+	if (!slide) {
+		throw new Error(`${slidePath} is missing from the table styling fixture`);
+	}
+	const xml = await slide.async('string');
+	const table = xml.match(/<a:tbl>.*?<\/a:tbl>/su)?.[0];
+	const row = table ? [...table.matchAll(/<a:tr\b.*?<\/a:tr>/gsu)][1]?.[0] : undefined;
+	const rightCell = row ? [...row.matchAll(/<a:tc\b[^>]*>.*?<\/a:tc>/gsu)][2]?.[0] : undefined;
+	if (!table || !row || !rightCell || !rightCell.includes('<a:t>R2C3</a:t>')) {
+		throw new Error('the expected cell to the right of Revenue is missing from slide 4');
+	}
+	const emptyCell = rightCell.replace(
+		/<a:txBody>.*?<\/a:txBody>/su,
+		'<a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="en-US"/></a:p></a:txBody>',
+	);
+	const updatedRow = row.replace(rightCell, emptyCell);
+	const updatedTable = table.replace(row, updatedRow);
+	zip.file(slidePath, xml.replace(table, updatedTable));
+	return {
+		name: 'table-rich-anchor-empty-right.pptx',
+		mimeType: PPTX_MIME,
+		buffer: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),
+	};
 }
 
 async function gotoSlide(page: Page, slideNumber: number): Promise<void> {
@@ -315,6 +342,110 @@ function canvasCell(page: Page, text: string): Locator {
 		.locator('td')
 		.filter({ hasText: new RegExp(`^\\s*${text}\\s*$`, 'u') })
 		.first();
+}
+
+/** A cell by rendered row and column, independent of its binding-specific merged text. */
+function canvasCellAt(page: Page, row: number, column: number): Locator {
+	return page
+		.locator('[aria-roledescription="slide"]')
+		.first()
+		.locator('table tr')
+		.nth(row)
+		.locator('td')
+		.nth(column);
+}
+
+/**
+ * Select and invoke a cell command through the context menu.
+ *
+ * Right-click the cell first. If that opens the table-level menu, dismiss it
+ * without clearing the table selection, then one left click selects the cell
+ * before the second right-click. Re-measure because the inspector moves it.
+ */
+async function chooseTableCommand(page: Page, cell: Locator, label: string): Promise<void> {
+	const box = await cell.boundingBox();
+	expect(box, 'the table cell should have a layout box').not.toBeNull();
+	const directMenu = await openMenuAt(page, {
+		x: box!.x + box!.width / 4,
+		y: box!.y + box!.height / 2,
+	});
+	if (directMenu.labels.includes(label.toLowerCase())) {
+		await chooseCommand(page, label);
+		return;
+	}
+
+	await page.keyboard.press('Escape');
+	await expect.poll(() => menuIsOpen(page)).toBe(false);
+	const movedBox = await cell.boundingBox();
+	expect(movedBox, 'the cell should remain laid out after dismissing the menu').not.toBeNull();
+	await page.mouse.click(movedBox!.x + movedBox!.width / 4, movedBox!.y + movedBox!.height / 2);
+	await page.waitForTimeout(350);
+	const selectedBox = await cell.boundingBox();
+	expect(selectedBox, 'the selected cell should remain laid out').not.toBeNull();
+	const selectedMenu = await openMenuAt(page, {
+		x: selectedBox!.x + selectedBox!.width / 4,
+		y: selectedBox!.y + selectedBox!.height / 2,
+	});
+	expect(selectedMenu.labels, `context menu commands after selecting the cell`).toContain(
+		label.toLowerCase(),
+	);
+	await chooseCommand(page, label);
+}
+
+interface RawRevenueRun {
+	text: string;
+	rPr: string;
+}
+
+/** Read the authored rich cell on slide 4 from a saved PPTX. */
+async function rawRevenueRuns(path: string): Promise<RawRevenueRun[]> {
+	const zip = await JSZip.loadAsync(await readFile(path));
+	const slide = zip.file('ppt/slides/slide4.xml');
+	if (!slide) {
+		throw new Error('saved deck is missing ppt/slides/slide4.xml');
+	}
+	const xml = await slide.async('string');
+	const table = xml.match(/<a:tbl>.*?<\/a:tbl>/su)?.[0] ?? '';
+	const row = [...table.matchAll(/<a:tr\b.*?<\/a:tr>/gsu)][1]?.[0] ?? '';
+	const cell = [...row.matchAll(/<a:tc\b[^>]*>.*?<\/a:tc>/gsu)][1]?.[0] ?? '';
+	return [...cell.matchAll(/<a:r>(.*?)<\/a:r>/gsu)].map((run) => ({
+		text: [...run[1].matchAll(/<a:t>(.*?)<\/a:t>/gsu)].map((match) => match[1]).join(''),
+		rPr: run[1].match(/<a:rPr\b.*?<\/a:rPr>|<a:rPr\b[^>]*\/>/su)?.[0] ?? '',
+	}));
+}
+
+function expectAuthoredRevenueRuns(runs: RawRevenueRun[]): void {
+	expect(runs.map((run) => run.text)).toStrictEqual(['Revenue ', 'grew 42%']);
+	expect(runs[0]?.rPr).toMatch(/\bsz="1200"/u);
+	expect(runs[0]?.rPr).toMatch(/\bb="0"/u);
+	expect(runs[0]?.rPr).toMatch(/\btypeface="Arial"/u);
+	expect(runs[1]?.rPr).toMatch(/\bsz="2400"/u);
+	expect(runs[1]?.rPr).toMatch(/\bb="1"/u);
+	expect(runs[1]?.rPr).toMatch(/\btypeface="Georgia"/u);
+	expect(runs[1]?.rPr).toMatch(/\bval="C00000"/u);
+}
+
+async function expectTopRowCellCount(page: Page, count: number): Promise<void> {
+	await expect
+		.poll(async () => {
+			const table = await measureTable(page);
+			return table.cells.filter((cell) => cell.row === 0).length;
+		})
+		.toBe(count);
+}
+
+function expectRenderedRevenueRuns(table: TablePaint): void {
+	const cell = table.cells.find((candidate) => candidate.text === 'Revenue grew 42%');
+	expect(cell, 'the untouched rich-text cell should remain rendered').toBeTruthy();
+	const plain = cell!.runs.find((run) => run.text === 'Revenue ');
+	const emphasis = cell!.runs.find((run) => run.text === 'grew 42%');
+	expect(plain, 'the regular Arial run should remain separate').toBeTruthy();
+	expect(emphasis, 'the bold red Georgia run should remain separate').toBeTruthy();
+	expect(Number(plain!.fontWeight) || 400).toBeLessThan(700);
+	expect(plain!.fontFamily).toContain('Arial');
+	expect(Number(emphasis!.fontWeight)).toBeGreaterThanOrEqual(700);
+	expect(emphasis!.fontFamily).toContain('Georgia');
+	expect(distance(emphasis!.color, { r: 192, g: 0, b: 0 })).toBeLessThan(30);
 }
 
 test.describe('table styling', () => {
@@ -567,6 +698,79 @@ test.describe('table styling', () => {
 			text.r + text.g + text.b,
 			`an unstyled body cell painted ${body.color}, which is the host chrome's colour, not the deck's`,
 		).toBeLessThan(240);
+	});
+
+	test('preserves an untouched rich cell through merge and split saves', async ({ page }) => {
+		await gotoSlide(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
+
+		await chooseTableCommand(page, canvasCellAt(page, 0, 0), 'Merge Right');
+		await expectTopRowCellCount(page, 3);
+		expectRenderedRevenueRuns(await measureTable(page));
+
+		const undo = page.getByRole('button', { name: 'Undo', exact: true });
+		const redo = page.getByRole('button', { name: 'Redo', exact: true });
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expectTopRowCellCount(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
+		await expect(redo).toBeEnabled();
+		await redo.click();
+		await expectTopRowCellCount(page, 3);
+		expectRenderedRevenueRuns(await measureTable(page));
+
+		const mergedDownload = await savePptxViaBackstage(page);
+		const mergedPath = await mergedDownload.path();
+		expect(mergedPath, 'the browser should retain the merged PPTX').not.toBeNull();
+		expectAuthoredRevenueRuns(await rawRevenueRuns(mergedPath!));
+		await loadDeck(page, mergedPath!);
+		await gotoSlide(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
+
+		await chooseTableCommand(page, canvasCellAt(page, 0, 0), 'Split Cell');
+		await expectTopRowCellCount(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
+
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expectTopRowCellCount(page, 3);
+		expectRenderedRevenueRuns(await measureTable(page));
+		await expect(redo).toBeEnabled();
+		await redo.click();
+		await expectTopRowCellCount(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
+
+		const splitDownload = await savePptxViaBackstage(page);
+		const splitPath = await splitDownload.path();
+		expect(splitPath, 'the browser should retain the split PPTX').not.toBeNull();
+		expectAuthoredRevenueRuns(await rawRevenueRuns(splitPath!));
+		await loadDeck(page, splitPath!);
+		await gotoSlide(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
+	});
+
+	test('preserves a rich anchor when merging its empty right neighbour', async ({ page }) => {
+		await loadDeck(page, await richAnchorWithEmptyRightDeck());
+		await gotoSlide(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
+		await expect(canvasCellAt(page, 1, 2)).toHaveText('');
+
+		await chooseTableCommand(page, canvasCellAt(page, 1, 1), 'Merge Right');
+		await expect
+			.poll(async () => {
+				const table = await measureTable(page);
+				return table.cells.filter((cell) => cell.row === 1).length;
+			})
+			.toBe(3);
+		expectRenderedRevenueRuns(await measureTable(page));
+
+		const download = await savePptxViaBackstage(page);
+		const savedPath = await download.path();
+		expect(savedPath, 'the browser should retain the merged PPTX').not.toBeNull();
+		expectAuthoredRevenueRuns(await rawRevenueRuns(savedPath!));
+		await loadDeck(page, savedPath!);
+		await gotoSlide(page, 4);
+		expectRenderedRevenueRuns(await measureTable(page));
 	});
 
 	/**

--- a/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
@@ -2,10 +2,43 @@ import JSZip from 'jszip';
 import { describe, it, expect } from 'vitest';
 
 import { PresentationBuilder } from '../../core/builders/sdk/PresentationBuilder';
+import { updateMergeAttrsInRawXml } from '../../core/core';
 import { rebuildTableStructureInRawXml } from '../../core/core/runtime/table-cell-rawxml-ops';
 import type { TableStructureEdit } from '../../core/core/runtime/table-cell-rawxml-ops';
 import { PptxHandler } from '../../core/PptxHandler';
 import type { TablePptxElement } from '../../core/types/elements';
+
+const RICH_CELL_BODY =
+	'<a:txBody><a:bodyPr/><a:lstStyle/><a:p>' +
+	'<a:r><a:rPr lang="en-US" b="1"/><a:t>Rich</a:t></a:r>' +
+	'<a:fld id="{AAAA0000-0000-4000-A000-000000000001}" type="slidenum"><a:rPr/><a:t>1</a:t></a:fld>' +
+	'<a:r><a:rPr lang="en-US" i="1"/><a:t>Text</a:t></a:r>' +
+	'<a:endParaRPr lang="en-US"/></a:p></a:txBody>';
+
+async function buildDeckWithRichTableCell(): Promise<Uint8Array> {
+	const { handler, data, createSlide } = await PresentationBuilder.create();
+	data.slides.push(
+		createSlide('Blank')
+			.addTable(
+				{
+					rows: [
+						{ cells: [{ text: 'A' }, { text: 'B' }] },
+						{ cells: [{ text: 'RichText1' }, { text: '' }] },
+					],
+				},
+				{ x: 20, y: 20, width: 400, height: 120 },
+			)
+			.build(),
+	);
+	const zip = await JSZip.loadAsync(await handler.save(data.slides));
+	const path = 'ppt/slides/slide1.xml';
+	const xml = await zip.file(path)!.async('string');
+	const richBody =
+		/<a:txBody>(?:(?!<\/a:txBody>)[\s\S])*?<a:t>RichText1<\/a:t>(?:(?!<\/a:txBody>)[\s\S])*?<\/a:txBody>/;
+	expect(xml, 'fixture precondition: rich-cell marker body').toMatch(richBody);
+	zip.file(path, xml.replace(richBody, RICH_CELL_BODY));
+	return zip.generateAsync({ type: 'uint8array' });
+}
 
 /**
  * Regression test for SDK-created tables being silently dropped on save.
@@ -367,5 +400,65 @@ describe('sDK-created table survives save round-trip', () => {
 		expect(slideXml).toMatch(/<a16:colId\s+val="\d+"/);
 		expect(slideXml).toContain('xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"');
 		expect(slideXml).toMatch(/mc:Ignorable="[^"]*\ba16\b[^"]*"/);
+	});
+
+	it('preserves rich cells through unrelated and equal-text merge save round-trips', async () => {
+		let handler = new PptxHandler();
+		let loaded = await handler.load((await buildDeckWithRichTableCell()).buffer as ArrayBuffer);
+		let table = loaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		const richRuns = structuredClone(table.tableData!.rows[1].cells[0].textRuns);
+		expect(richRuns).toStrictEqual([
+			{ text: 'Rich', bold: true },
+			{ text: '1', isField: true },
+			{ text: 'Text', italic: true },
+		]);
+
+		const merged = structuredClone(table.tableData!);
+		merged.rows[0].cells[0].text = 'A B';
+		delete merged.rows[0].cells[0].textRuns;
+		merged.rows[0].cells[0].gridSpan = 2;
+		merged.rows[0].cells[1].text = '';
+		delete merged.rows[0].cells[1].textRuns;
+		merged.rows[0].cells[1].hMerge = true;
+		table.rawXml = updateMergeAttrsInRawXml(table, merged);
+		table.tableData = merged;
+
+		let saved = await handler.save(loaded.slides);
+		handler = new PptxHandler();
+		loaded = await handler.load(saved.buffer as ArrayBuffer);
+		table = loaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		expect(table.tableData!.rows[0].cells[0].textRuns).toHaveLength(1);
+		expect(table.tableData!.rows[0].cells[0].textRuns?.[0].text).toBe('A B');
+		expect(table.tableData!.rows[1].cells[0].textRuns).toStrictEqual(richRuns);
+
+		const split = structuredClone(table.tableData!);
+		delete split.rows[0].cells[0].gridSpan;
+		delete split.rows[0].cells[1].hMerge;
+		table.rawXml = updateMergeAttrsInRawXml(table, split);
+		table.tableData = split;
+
+		saved = await handler.save(loaded.slides);
+		const splitHandler = new PptxHandler();
+		const reloaded = await splitHandler.load(saved.buffer as ArrayBuffer);
+		const splitTable = reloaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		expect(splitTable.tableData!.rows[1].cells[0].textRuns).toStrictEqual(richRuns);
+
+		const equalTextMerge = structuredClone(splitTable.tableData!);
+		equalTextMerge.rows[1].cells[0].gridSpan = 2;
+		equalTextMerge.rows[1].cells[1].hMerge = true;
+		splitTable.rawXml = updateMergeAttrsInRawXml(splitTable, equalTextMerge);
+		splitTable.tableData = equalTextMerge;
+		const equalTextSaved = await splitHandler.save(reloaded.slides);
+		const equalTextReloaded = await new PptxHandler().load(equalTextSaved.buffer as ArrayBuffer);
+		const equalTextTable = equalTextReloaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		expect(equalTextTable.tableData!.rows[1].cells[0].textRuns).toStrictEqual(richRuns);
 	});
 });

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveTableStyles.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveTableStyles.ts
@@ -7,39 +7,11 @@ import {
 	writeDiagonalBorders,
 	writeCellTextFormatting,
 } from './table-cell-save-helpers';
+import { tableCellTextBodyMatches } from './table-cell-text-xml';
+
+export { flattenCellTxBodyText } from './table-cell-text-xml';
 
 type EnsureArray = (value: unknown) => XmlObject[];
-
-/**
- * Flatten a cell `a:txBody` to the same `\n`-joined plain string that
- * `PptxTableDataParser.extractTableCellText` produces at load time
- * (per-paragraph run text followed by field text). Used to detect whether a
- * cell's text was actually edited so an unedited cell can keep its rich
- * multi-run / multi-paragraph structure verbatim (#68).
- */
-export function flattenCellTxBodyText(
-	txBody: XmlObject | undefined,
-	ensureArray: EnsureArray,
-): string {
-	if (!txBody) {
-		return '';
-	}
-	const paragraphs = ensureArray(txBody['a:p']);
-	const lines: string[] = [];
-	for (const paragraph of paragraphs) {
-		const runs = ensureArray((paragraph as XmlObject)?.['a:r']);
-		const fields = ensureArray((paragraph as XmlObject)?.['a:fld']);
-		let lineText = '';
-		for (const run of runs) {
-			lineText += String((run as XmlObject)?.['a:t'] ?? '');
-		}
-		for (const field of fields) {
-			lineText += String((field as XmlObject)?.['a:t'] ?? '');
-		}
-		lines.push(lineText);
-	}
-	return lines.join('\n');
-}
 
 /**
  * Whether a cell `a:txBody` carries rich content that the single cell-level
@@ -87,10 +59,8 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 		// rebuild below, which is the best we can do from a flat string.
 		const ensureArray = this.ensureArray.bind(this);
 		const existingTxBody = xmlCell['a:txBody'] as XmlObject | undefined;
-		if (existingTxBody && ensureArray(existingTxBody['a:p']).length > 0) {
-			if (flattenCellTxBodyText(existingTxBody, ensureArray) === text) {
-				return;
-			}
+		if (tableCellTextBodyMatches(existingTxBody, text, ensureArray)) {
+			return;
 		}
 
 		if (!xmlCell['a:txBody']) {

--- a/packages/core/src/core/core/runtime/table-cell-rawxml-ops.test.ts
+++ b/packages/core/src/core/core/runtime/table-cell-rawxml-ops.test.ts
@@ -14,6 +14,7 @@ import {
 	rebuildTableStructureInRawXml,
 	updateCellTextInRawXml,
 	updateCellTextStyleInRawXml,
+	updateMergeAttrsInRawXml,
 } from './table-cell-rawxml-ops';
 import { ensureArray } from './table-structural-helpers';
 
@@ -22,13 +23,14 @@ const parser = new XMLParser({
 	attributeNamePrefix: '@_',
 	parseAttributeValue: false,
 	parseTagValue: false,
+	trimValues: false,
 });
 const builder = new XMLBuilder({ ignoreAttributes: false, attributeNamePrefix: '@_' });
 
 /** Wrap cell markup in the graphic-frame envelope `getTblFromRawXml` walks. */
-function tableElement(cellsXml: string): PptxElement {
+function tableElement(cellsXml: string, columnCount = 1): PptxElement {
 	const parsed = parser.parse(
-		`<f><a:graphic><a:graphicData><a:tbl><a:tblPr/><a:tblGrid><a:gridCol w="100"/></a:tblGrid>` +
+		`<f><a:graphic><a:graphicData><a:tbl><a:tblPr/><a:tblGrid>${'<a:gridCol w="100"/>'.repeat(columnCount)}</a:tblGrid>` +
 			`<a:tr h="100">${cellsXml}</a:tr></a:tbl></a:graphicData></a:graphic></f>`,
 	) as Record<string, XmlObject>;
 	return {
@@ -43,11 +45,11 @@ function tableElement(cellsXml: string): PptxElement {
 }
 
 function cellOf(rawXml: XmlObject): XmlObject {
-	const graphic = rawXml['a:graphic'] as XmlObject;
-	const data = graphic['a:graphicData'] as XmlObject;
-	const table = data['a:tbl'] as XmlObject;
-	const row = table['a:tr'] as XmlObject;
-	return row['a:tc'] as XmlObject;
+	return cellsOf(rawXml)[0];
+}
+
+function cellsOf(rawXml: XmlObject, rowIndex = 0): XmlObject[] {
+	return rawCellsOf(rawRowsOf(rawXml)[rowIndex]);
 }
 
 function paragraphsOf(rawXml: XmlObject): XmlObject[] {
@@ -646,4 +648,109 @@ describe('ensureArray', () => {
 		expect(ensureArray(undefined)).toStrictEqual([]);
 		expect(ensureArray(null)).toStrictEqual([]);
 	});
+});
+
+describe('updateMergeAttrsInRawXml preserves unchanged text bodies', () => {
+	const richCell =
+		'<a:tc><a:txBody><a:bodyPr wrap="square"/><a:lstStyle/>' +
+		'<a:p><a:pPr marL="91440"><a:spcBef><a:spcPts val="600"/></a:spcBef></a:pPr>' +
+		'<a:r><a:rPr b="1"><a:hlinkClick r:id="rIdLink"/></a:rPr><a:t>Rich </a:t></a:r>' +
+		'<a:br/><a:r><a:rPr i="1"/><a:t>text</a:t></a:r>' +
+		'<a:fld id="field-1" type="slidenum"><a:rPr/><a:t>7</a:t></a:fld><a:endParaRPr lang="en-US"/></a:p>' +
+		'<a:p><a:pPr algn="r"/><a:r><a:t>tail</a:t></a:r><a:endParaRPr sz="1800"/></a:p>' +
+		'</a:txBody><a:tcPr marL="91440"/></a:tc>';
+	// Match the existing load/save comparison: runs, then fields per paragraph.
+	const richText = 'Rich text7\ntail';
+	const plainCell = (text: string, attrs = '') =>
+		`<a:tc${attrs}><a:txBody><a:bodyPr/><a:p><a:r><a:rPr/><a:t>${text}</a:t></a:r></a:p></a:txBody><a:tcPr/></a:tc>`;
+	const data = (texts: string[]): PptxTableData => ({
+		columnWidths: texts.map(() => 1 / texts.length),
+		rows: [{ cells: texts.map((text) => ({ text })) }],
+	});
+
+	it('keeps unrelated runs, fields, breaks, hyperlinks and paragraph properties during merge', () => {
+		const element = tableElement(plainCell('A') + plainCell('B') + richCell, 3);
+		const original = structuredClone(element.rawXml);
+		const next = data(['A B', '', richText]);
+		next.rows[0].cells[0].gridSpan = 2;
+		next.rows[0].cells[1].hMerge = true;
+		const result = updateMergeAttrsInRawXml(element, next)!;
+		const cells = cellsOf(result);
+		expect(cells[2]).toStrictEqual(cellsOf(original!)[2]);
+		expect(cells[0]['@_gridSpan']).toBe('2');
+		expect(cells[1]['@_hMerge']).toBe('1');
+		expect(cells[0]['a:txBody']['a:p']['a:r']['a:t']).toBe('A B');
+		expect(cells[1]['a:txBody']['a:p']['a:r']['a:t']).toBe('');
+		expect(element.rawXml).toStrictEqual(original);
+	});
+
+	it('removes merge flags without rewriting text bodies during split', () => {
+		const element = tableElement(
+			plainCell('Combined', ' gridSpan="2"') + plainCell('', ' hMerge="1"') + richCell,
+			3,
+		);
+		const original = structuredClone(element.rawXml);
+		const result = updateMergeAttrsInRawXml(element, data(['Combined', '', richText]))!;
+		const cells = cellsOf(result);
+		expect(cells[0]['@_gridSpan']).toBeUndefined();
+		expect(cells[1]['@_hMerge']).toBeUndefined();
+		expect(cells.map((cell) => cell['a:txBody'])).toStrictEqual(
+			cellsOf(original!).map((cell) => cell['a:txBody']),
+		);
+		expect(element.rawXml).toStrictEqual(original);
+	});
+
+	it('still rebuilds text that actually changed', () => {
+		const element = tableElement(richCell);
+		const result = updateMergeAttrsInRawXml(element, data(['Edited']))!;
+		expect(paragraphsOf(result)).toHaveLength(1);
+		expect(paragraphsOf(result)[0]['a:r']['a:t']).toBe('Edited');
+		expect(paragraphsOf(result)[0]['a:r']['a:rPr']['@_b']).toBe('1');
+	});
+
+	it('preserves a rich anchor when merging it with an empty neighbor', () => {
+		const element = tableElement(richCell + plainCell(''), 2);
+		const next = data([richText, '']);
+		next.rows[0].cells[0].gridSpan = 2;
+		next.rows[0].cells[1].hMerge = true;
+		const result = updateMergeAttrsInRawXml(element, next)!;
+		expect(cellsOf(result)[0]['a:txBody']).toStrictEqual(cellsOf(element.rawXml!)[0]['a:txBody']);
+		expect(cellsOf(result)[0]['@_gridSpan']).toBe('2');
+		expect(cellsOf(result)[1]['@_hMerge']).toBe('1');
+	});
+
+	it('clears absorbed rich text while retaining unchanged vertical merge anchors', () => {
+		const element = tableElement(richCell);
+		const table = rawTableOf(element.rawXml!);
+		table['a:tr'] = [table['a:tr'], structuredClone(table['a:tr'])];
+		const next: PptxTableData = {
+			columnWidths: [1],
+			rows: [{ cells: [{ text: richText }] }, { cells: [{ text: '' }] }],
+		};
+		next.rows[0].cells[0].rowSpan = 2;
+		next.rows[1].cells[0].vMerge = true;
+		const result = updateMergeAttrsInRawXml(element, next)!;
+		expect(cellsOf(result)[0]['a:txBody']).toStrictEqual(cellsOf(element.rawXml!)[0]['a:txBody']);
+		expect(cellsOf(result)[0]['@_rowSpan']).toBe('2');
+		expect(cellsOf(result, 1)[0]['@_vMerge']).toBe('1');
+		const clearedBody = cellsOf(result, 1)[0]['a:txBody'] as XmlObject;
+		expect(clearedBody['a:p']['a:r']['a:t']).toBe('');
+		expect(clearedBody['a:p']['a:fld']).toBeUndefined();
+		expect(clearedBody['a:p']['a:br']).toBeUndefined();
+	});
+
+	it('retains an unchanged bare empty paragraph', () => {
+		const element = tableElement('<a:tc><a:txBody><a:bodyPr/><a:p/></a:txBody><a:tcPr/></a:tc>');
+		const result = updateMergeAttrsInRawXml(element, data(['']))!;
+		expect(cellOf(result)['a:txBody']).toStrictEqual(cellOf(element.rawXml!)['a:txBody']);
+	});
+
+	it.each(['<a:tc><a:tcPr/></a:tc>', '<a:tc><a:txBody><a:bodyPr/></a:txBody></a:tc>'])(
+		'creates a paragraph when the input text body is missing one: %s',
+		(cell) => {
+			const result = updateMergeAttrsInRawXml(tableElement(cell), data(['']))!;
+			expect(paragraphsOf(result)).toHaveLength(1);
+			expect(paragraphsOf(result)[0]['a:r']['a:t']).toBe('');
+		},
+	);
 });

--- a/packages/core/src/core/core/runtime/table-cell-rawxml-ops.ts
+++ b/packages/core/src/core/core/runtime/table-cell-rawxml-ops.ts
@@ -12,6 +12,7 @@
  */
 import type { PptxElement, PptxTableData, XmlObject } from '../../types';
 import { ensureXmlChild, ensureXmlChildOrCreate, ensureXmlChildren } from '../../utils/xml-access';
+import { rebuildCellTextBody, tableCellTextBodyMatches } from './table-cell-text-xml';
 import { ensureArray, getTblFromRawXml } from './table-structural-helpers';
 
 // ── Cell text update ─────────────────────────────────────────────────────
@@ -55,56 +56,6 @@ export function updateCellTextInRawXml(
 	);
 
 	return newRawXml;
-}
-
-/**
- * Rebuild a cell's `<a:txBody>` around a single run of `text`, carrying over
- * the body properties, list style, first paragraph's properties and first
- * run's properties.
- *
- * Every key is inserted in SCHEMA order, because fast-xml-parser's builder
- * emits object keys in insertion order and the three types involved are all
- * `xsd:sequence`s: `CT_TextBody` is (`a:bodyPr`, `a:lstStyle?`, `a:p+`),
- * `CT_TextParagraph` is (`a:pPr?`, runs...), `CT_RegularTextRun` is
- * (`a:rPr?`, `a:t`). Building the content first and appending the properties
- * afterwards - which both copies of this code did - emits an out-of-order
- * package, the spelling PowerPoint reads by silently discarding the group.
- *
- * Carry-over tests are `!== undefined` rather than truthiness, because a bare
- * `<a:pPr/>` or `<a:rPr/>` parses to the empty STRING and a truthiness test
- * drops it.
- */
-function rebuildCellTextBody(existingTxBody: XmlObject | undefined, text: string): XmlObject {
-	const existingParagraphs = ensureArray(
-		existingTxBody?.['a:p'] as XmlObject | XmlObject[] | undefined,
-	);
-	const firstParagraph = existingParagraphs.length > 0 ? existingParagraphs[0] : undefined;
-	const existingRuns = firstParagraph
-		? ensureArray(firstParagraph['a:r'] as XmlObject | XmlObject[] | undefined)
-		: [];
-	const firstRunProps = existingRuns.length > 0 ? existingRuns[0]['a:rPr'] : undefined;
-
-	const newRun: XmlObject = {};
-	if (firstRunProps !== undefined) {
-		newRun['a:rPr'] = firstRunProps;
-	}
-	newRun['a:t'] = text;
-
-	const newParagraph: XmlObject = {};
-	if (firstParagraph?.['a:pPr'] !== undefined) {
-		newParagraph['a:pPr'] = firstParagraph['a:pPr'];
-	}
-	newParagraph['a:r'] = newRun;
-
-	const newTxBody: XmlObject = {};
-	if (existingTxBody?.['a:bodyPr'] !== undefined) {
-		newTxBody['a:bodyPr'] = existingTxBody['a:bodyPr'];
-	}
-	if (existingTxBody?.['a:lstStyle'] !== undefined) {
-		newTxBody['a:lstStyle'] = existingTxBody['a:lstStyle'];
-	}
-	newTxBody['a:p'] = newParagraph;
-	return newTxBody;
 }
 
 // ── Cell text style update ───────────────────────────────────────────────
@@ -325,12 +276,10 @@ export function updateMergeAttrsInRawXml(
 				delete xmlCell['@_vMerge'];
 			}
 
-			// Sync cell text for merged cells that were cleared
-			if (cell.text !== undefined) {
-				xmlCell['a:txBody'] = rebuildCellTextBody(
-					xmlCell['a:txBody'] as XmlObject | undefined,
-					cell.text,
-				);
+			// Rebuild only changed text, preserving rich bodies just as save does (#68).
+			const txBody = xmlCell['a:txBody'] as XmlObject | undefined;
+			if (cell.text !== undefined && !tableCellTextBodyMatches(txBody, cell.text)) {
+				xmlCell['a:txBody'] = rebuildCellTextBody(txBody, cell.text);
 			}
 		}
 	}

--- a/packages/core/src/core/core/runtime/table-cell-text-xml.ts
+++ b/packages/core/src/core/core/runtime/table-cell-text-xml.ts
@@ -1,0 +1,103 @@
+import type { XmlObject } from '../../types';
+import { ensureArray as toArray } from './table-structural-helpers';
+
+type EnsureArray = (value: unknown) => XmlObject[];
+
+const xmlArray: EnsureArray = (value) => toArray(value as XmlObject | XmlObject[] | undefined);
+
+/**
+ * Flatten a cell `a:txBody` to the same `\n`-joined plain string that
+ * `PptxTableDataParser.extractTableCellText` produces at load time
+ * (per-paragraph run text followed by field text). Used to detect whether a
+ * cell's text was actually edited so an unedited cell can keep its rich
+ * multi-run / multi-paragraph structure verbatim (#68).
+ */
+export function flattenCellTxBodyText(
+	txBody: XmlObject | undefined,
+	ensureArray: EnsureArray,
+): string {
+	if (!txBody) {
+		return '';
+	}
+	const paragraphs = ensureArray(txBody['a:p']);
+	const lines: string[] = [];
+	for (const paragraph of paragraphs) {
+		const runs = ensureArray((paragraph as XmlObject)?.['a:r']);
+		const fields = ensureArray((paragraph as XmlObject)?.['a:fld']);
+		let lineText = '';
+		for (const run of runs) {
+			lineText += String((run as XmlObject)?.['a:t'] ?? '');
+		}
+		for (const field of fields) {
+			lineText += String((field as XmlObject)?.['a:t'] ?? '');
+		}
+		lines.push(lineText);
+	}
+	return lines.join('\n');
+}
+
+/** Keep valid, unchanged text bodies intact; a missing paragraph still needs rebuilding. */
+export function tableCellTextBodyMatches(
+	txBody: XmlObject | undefined,
+	text: string,
+	ensureArray: EnsureArray = xmlArray,
+): boolean {
+	return Boolean(
+		txBody &&
+		ensureArray(txBody['a:p']).length > 0 &&
+		flattenCellTxBodyText(txBody, ensureArray) === text,
+	);
+}
+
+/**
+ * Rebuild a cell's `<a:txBody>` around a single run of `text`, carrying over
+ * the body properties, list style, first paragraph's properties and first
+ * run's properties.
+ *
+ * Every key is inserted in SCHEMA order, because fast-xml-parser's builder
+ * emits object keys in insertion order and the three types involved are all
+ * `xsd:sequence`s: `CT_TextBody` is (`a:bodyPr`, `a:lstStyle?`, `a:p+`),
+ * `CT_TextParagraph` is (`a:pPr?`, runs...), `CT_RegularTextRun` is
+ * (`a:rPr?`, `a:t`). Building the content first and appending the properties
+ * afterwards - which both copies of this code did - emits an out-of-order
+ * package, the spelling PowerPoint reads by silently discarding the group.
+ *
+ * Carry-over tests are `!== undefined` rather than truthiness, because a bare
+ * `<a:pPr/>` or `<a:rPr/>` parses to the empty STRING and a truthiness test
+ * drops it.
+ */
+export function rebuildCellTextBody(
+	existingTxBody: XmlObject | undefined,
+	text: string,
+): XmlObject {
+	const existingParagraphs = toArray(
+		existingTxBody?.['a:p'] as XmlObject | XmlObject[] | undefined,
+	);
+	const firstParagraph = existingParagraphs.length > 0 ? existingParagraphs[0] : undefined;
+	const existingRuns = firstParagraph
+		? toArray(firstParagraph['a:r'] as XmlObject | XmlObject[] | undefined)
+		: [];
+	const firstRunProps = existingRuns.length > 0 ? existingRuns[0]['a:rPr'] : undefined;
+
+	const newRun: XmlObject = {};
+	if (firstRunProps !== undefined) {
+		newRun['a:rPr'] = firstRunProps;
+	}
+	newRun['a:t'] = text;
+
+	const newParagraph: XmlObject = {};
+	if (firstParagraph?.['a:pPr'] !== undefined) {
+		newParagraph['a:pPr'] = firstParagraph['a:pPr'];
+	}
+	newParagraph['a:r'] = newRun;
+
+	const newTxBody: XmlObject = {};
+	if (existingTxBody?.['a:bodyPr'] !== undefined) {
+		newTxBody['a:bodyPr'] = existingTxBody['a:bodyPr'];
+	}
+	if (existingTxBody?.['a:lstStyle'] !== undefined) {
+		newTxBody['a:lstStyle'] = existingTxBody['a:lstStyle'];
+	}
+	newTxBody['a:p'] = newParagraph;
+	return newTxBody;
+}

--- a/packages/react/src/viewer/hooks/table-merge-handlers.test.ts
+++ b/packages/react/src/viewer/hooks/table-merge-handlers.test.ts
@@ -1,6 +1,10 @@
-import type { PptxElement, PptxTableData, TablePptxElement } from 'pptx-viewer-core';
+import type { PptxElement, PptxTableData, TablePptxElement, XmlObject } from 'pptx-viewer-core';
+import { updateMergeAttrsInRawXml as updateMergeAttrsInRawXmlActual } from 'pptx-viewer-core';
+import { mergeCells as mergeCellsActual, splitCell as splitCellActual } from 'pptx-viewer-shared';
 import { describe, it, expect, vi } from 'vitest';
 
+import { mergeCells, splitCell } from '../utils/table-merge-utils';
+import { updateMergeAttrsInRawXml } from '../utils/table-parse';
 import { createTableMergeHandlers } from './table-merge-handlers';
 import type { UseTableOperationsInput } from './table-operation-types';
 
@@ -62,6 +66,80 @@ function createTableElement(tableData: PptxTableData, id = 'table-1'): TablePptx
 		height: 200,
 		tableData,
 	} as TablePptxElement;
+}
+
+function rawTextCell(runs: XmlObject[], marker?: string): XmlObject {
+	return {
+		'a:txBody': { 'a:p': { 'a:r': runs } },
+		'a:tcPr': marker ? { 'x:opaque': { '@_marker': marker } } : {},
+	};
+}
+
+function createRichTableElement(): TablePptxElement {
+	const tableData: PptxTableData = {
+		columnWidths: [0.5, 0.5],
+		rows: [
+			{
+				height: 40,
+				cells: [
+					{ text: 'A', textRuns: [{ text: 'A', bold: true }] },
+					{ text: 'B', textRuns: [{ text: 'B', italic: true }] },
+				],
+			},
+			{
+				height: 40,
+				cells: [
+					{
+						text: 'Rich text',
+						textRuns: [
+							{ text: 'Rich ', bold: true },
+							{ text: 'text', italic: true },
+						],
+					},
+					{ text: 'D' },
+				],
+			},
+		],
+	};
+	return {
+		...createTableElement(tableData),
+		rawXml: {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tr': [
+							{
+								'a:tc': [
+									rawTextCell([{ 'a:rPr': { '@_b': '1' }, 'a:t': 'A' }]),
+									rawTextCell([{ 'a:rPr': { '@_i': '1' }, 'a:t': 'B' }]),
+								],
+							},
+							{
+								'a:tc': [
+									rawTextCell(
+										[
+											{ 'a:rPr': { '@_b': '1' }, 'a:t': 'Rich ' },
+											{ 'a:rPr': { '@_i': '1' }, 'a:t': 'text' },
+										],
+										'unrelated',
+									),
+									rawTextCell([{ 'a:t': 'D' }]),
+								],
+							},
+						],
+					},
+				},
+			},
+		},
+	};
+}
+
+function rawCell(rawXml: XmlObject, row: number, column: number): XmlObject {
+	const graphic = rawXml['a:graphic'] as XmlObject;
+	const graphicData = graphic['a:graphicData'] as XmlObject;
+	const table = graphicData['a:tbl'] as XmlObject;
+	const rows = table['a:tr'] as XmlObject[];
+	return (rows[row]['a:tc'] as XmlObject[])[column];
 }
 
 function createMockInput(
@@ -150,6 +228,56 @@ describe('createTableMergeHandlers', () => {
 			const handlers = createTableMergeHandlers(input);
 			handlers.handleMergeCellRight();
 			expect(input.ops.updateSelectedElement).not.toHaveBeenCalled();
+		});
+
+		it('preserves an unrelated rich raw cell through merge-right and split commits', () => {
+			const element = createRichTableElement();
+			const originalRichBody = structuredClone(rawCell(element.rawXml!, 1, 0)['a:txBody']);
+			vi.mocked(mergeCells).mockImplementationOnce(mergeCellsActual);
+			vi.mocked(updateMergeAttrsInRawXml).mockImplementationOnce(updateMergeAttrsInRawXmlActual);
+			const mergeInput = createMockInput({ selectedElement: element });
+
+			createTableMergeHandlers(mergeInput).handleMergeCellRight();
+
+			const mergePatch = vi.mocked(mergeInput.ops.updateSelectedElement).mock
+				.calls[0][0] as Partial<TablePptxElement>;
+			expect(mergePatch.tableData?.rows[0].cells[0].gridSpan).toBe(2);
+			expect(mergePatch.tableData?.rows[0].cells[0].textRuns).toBeUndefined();
+			expect(rawCell(mergePatch.rawXml!, 1, 0)['a:txBody']).toStrictEqual(originalRichBody);
+
+			const mergedElement: TablePptxElement = { ...element, ...mergePatch };
+			vi.mocked(splitCell).mockImplementationOnce(splitCellActual);
+			vi.mocked(updateMergeAttrsInRawXml).mockImplementationOnce(updateMergeAttrsInRawXmlActual);
+			const splitInput = createMockInput({ selectedElement: mergedElement });
+
+			createTableMergeHandlers(splitInput).handleSplitCell();
+
+			const splitPatch = vi.mocked(splitInput.ops.updateSelectedElement).mock
+				.calls[0][0] as Partial<TablePptxElement>;
+			expect(splitPatch.tableData?.rows[0].cells[0].gridSpan).toBeUndefined();
+			expect(rawCell(splitPatch.rawXml!, 1, 0)['a:txBody']).toStrictEqual(originalRichBody);
+			expect(rawCell(element.rawXml!, 1, 0)['a:txBody']).toStrictEqual(originalRichBody);
+		});
+
+		it('keeps a rich anchor when an empty neighbour leaves its text unchanged', () => {
+			const element = createRichTableElement();
+			const richCell = structuredClone(element.tableData!.rows[1].cells[0]);
+			const richBody = structuredClone(rawCell(element.rawXml!, 1, 0)['a:txBody']);
+			element.tableData!.rows[0].cells = [richCell, { text: '', textRuns: [{ text: 'stale' }] }];
+			rawCell(element.rawXml!, 0, 0)['a:txBody'] = structuredClone(richBody);
+			rawCell(element.rawXml!, 0, 1)['a:txBody'] = rawTextCell([{ 'a:t': '' }])['a:txBody'];
+			vi.mocked(mergeCells).mockImplementationOnce(mergeCellsActual);
+			vi.mocked(updateMergeAttrsInRawXml).mockImplementationOnce(updateMergeAttrsInRawXmlActual);
+			const input = createMockInput({ selectedElement: element });
+
+			createTableMergeHandlers(input).handleMergeCellRight();
+
+			const patch = vi.mocked(input.ops.updateSelectedElement).mock
+				.calls[0][0] as Partial<TablePptxElement>;
+			expect(patch.tableData?.rows[0].cells[0]).toMatchObject({ text: 'Rich text', gridSpan: 2 });
+			expect(patch.tableData?.rows[0].cells[0].textRuns).toStrictEqual(richCell.textRuns);
+			expect(patch.tableData?.rows[0].cells[1].textRuns).toBeUndefined();
+			expect(rawCell(patch.rawXml!, 0, 0)['a:txBody']).toStrictEqual(richBody);
 		});
 	});
 

--- a/packages/shared/src/render/table-merge.test.ts
+++ b/packages/shared/src/render/table-merge.test.ts
@@ -211,6 +211,61 @@ describe('mergeCells', () => {
 		// Immutable: the source keeps its runs.
 		expect(table.rows[0].cells[0].textRuns).toHaveLength(1);
 	});
+
+	it.each(['', ' \t '])(
+		'preserves rich anchor runs when neighbour %j leaves its text unchanged',
+		(neighbour) => {
+			const table = makeTable(1, 2, [['Page 7', neighbour]]);
+			const anchorRuns = [
+				{ text: 'Page ', bold: true },
+				{ text: '7', isField: true },
+				{ text: '', isLineBreak: true },
+			];
+			table.rows[0].cells[0].textRuns = anchorRuns;
+			table.rows[0].cells[1].textRuns = [{ text: 'stale' }];
+
+			const result = mergeCells(
+				[
+					{ row: 0, col: 0 },
+					{ row: 0, col: 1 },
+				],
+				table,
+			);
+
+			expect(result.rows[0].cells[0].text).toBe('Page 7');
+			expect(result.rows[0].cells[0].textRuns).toBe(anchorRuns);
+			expect(result.rows[0].cells[1].text).toBe('');
+			expect(result.rows[0].cells[1].textRuns).toBeUndefined();
+			// Immutable: the absorbed source cell keeps its original run model.
+			expect(table.rows[0].cells[1].textRuns).toStrictEqual([{ text: 'stale' }]);
+		},
+	);
+
+	it.each([
+		['Page 7', 'of 10', 'Page 7 of 10'],
+		[' Page 7 ', '', 'Page 7'],
+	])(
+		'drops rich anchor runs when merging %j and %j changes the text',
+		(anchor, neighbour, expected) => {
+			const table = makeTable(1, 2, [[anchor, neighbour]]);
+			table.rows[0].cells[0].textRuns = [
+				{ text: anchor.slice(0, 4), bold: true },
+				{ text: anchor.slice(4), italic: true },
+			];
+
+			const result = mergeCells(
+				[
+					{ row: 0, col: 0 },
+					{ row: 0, col: 1 },
+				],
+				table,
+			);
+
+			expect(result.rows[0].cells[0].text).toBe(expected);
+			expect(result.rows[0].cells[0].textRuns).toBeUndefined();
+			expect(table.rows[0].cells[0].textRuns).toHaveLength(2);
+		},
+	);
 });
 
 describe('splitCell', () => {

--- a/packages/shared/src/render/table-merge.ts
+++ b/packages/shared/src/render/table-merge.ts
@@ -267,16 +267,16 @@ export function mergeCells(cells: CellCoord[], tableData: PptxTableData): PptxTa
 				return cell;
 			}
 
-			// Every branch below re-texts the cell, so each goes through
-			// `withCellText`: the anchor takes the CONCATENATION of the group and
-			// the absorbed cells are emptied, and a cell that kept the `textRuns`
-			// describing its old content would paint that content instead (the
-			// renderers prefer the run model over the flat string).
+			// A cell whose text changes goes through `withCellText`: keeping runs
+			// that describe its OLD content would make the renderer paint those
+			// runs instead. When an empty selection neighbour leaves the anchor's
+			// text unchanged, however, its existing rich runs still describe the
+			// result and must remain available for rendering and save ordering.
 
 			// Top-left anchor cell
 			if (ri === rect.startRow && ci === rect.startCol) {
 				return {
-					...withCellText(cell, combinedText),
+					...(cell.text === combinedText ? cell : withCellText(cell, combinedText)),
 					gridSpan: colCount > 1 ? colCount : undefined,
 					rowSpan: rowCount > 1 ? rowCount : undefined,
 					hMerge: undefined,


### PR DESCRIPTION
## What does this change?

Preserve unchanged table-cell text bodies when synchronizing merge/split attributes. Merging cells in one row should not remove mixed fonts, bold text, hyperlinks, fields, soft breaks or paragraph properties from a different cell.

Reproduced with the existing `table-styling.pptx` fixture: in React, merging the first two cells of slide 4 collapsed the untouched Revenue cell from two runs (12pt Arial and 24pt bold red Georgia) into one 12pt Arial run in the saved file.

`updateMergeAttrsInRawXml` was rebuilding every cell with a defined `text`, although its comment described synchronizing cleared merge cells. This reuses the unchanged-text comparison already established by #68 in the save writer. A small pure helper extraction keeps that policy shared without importing the runtime class chain into the XML utility.

Genuinely changed/cleared text still uses the existing rebuild. Missing paragraphs still get created. A rich anchor merged with an empty neighbor also retains its unchanged run model, which preserves its live styling and lets #227 retain field/break ordering after raw XML cloning. Merge concatenation policy and public APIs are unchanged.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

Checked React, Vue, Angular, Svelte and Vanilla through their real merge/split UI routes. React's four merge/split handlers use this eager core XML helper; the other bindings' save-time comparison already preserves unchanged bodies. The shared unchanged-anchor fix is inherited by every consumer of rectangular merge. All five bindings passed the browser matrix, including controls for the recently merged row/column preservation fix.

## Testing

- Existing core XML tests cover unchanged rich bodies, horizontal/vertical merge flags, split, equal-text rich anchors, changed/cleared text, bare/missing paragraphs and source immutability.
- Existing React handler test delegates to the actual shared merge/split and core XML helpers.
- Existing core integration test saves and reloads after merge and split, checking the unrelated rich runs both times.
- Latest-main baseline with the new tests fails the targeted preservation cases while the existing structural cases pass.
- Full core suite: 14,264 passed, 231 skipped. Full shared suite: 8,874 passed, 3 skipped.
- React merge and structural handler regressions: 43 passed. Core, shared and React typechecks passed.
- Browser regressions: 20 passed across all five bindings. Includes untouched rich cells through merge/split, undo/redo, save/reload; rich anchors merged with an empty neighbor; and row/column structural controls.
- Formatting, lint, diff checks and the framework-neutral E2E contract passed. Independent code and browser reviews completed.

## Conventional Commits

- [x] Conventional commit with a signed personal-account commit.
