### PR TITLE
fix(shared): clear absorbed table cell runs during cursor merge

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -51,6 +51,7 @@ import {
 	menuIsOpen,
 	openMenuAt,
 	openMenuOn,
+	selectTableCell,
 } from './support/context-menu';
 import { resetTabSession } from './support/deck';
 
@@ -473,6 +474,17 @@ function expectRenderedRevenueRuns(table: TablePaint): void {
 	expect(distance(emphasis!.color, { r: 192, g: 0, b: 0 })).toBeLessThan(30);
 }
 
+async function expectRenderedRowCellCount(page: Page, row: number, count: number): Promise<void> {
+	await expect(
+		page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('table tr')
+			.nth(row)
+			.locator('td'),
+	).toHaveCount(count);
+}
+
 test.describe('table styling', () => {
 	test.beforeEach(async ({ page }) => {
 		await loadDeck(page);
@@ -797,6 +809,50 @@ test.describe('table styling', () => {
 		await gotoSlide(page, 4);
 		expectRenderedRevenueRuns(await measureTable(page));
 	});
+
+	for (const merge of [
+		{ name: 'right', command: 'Merge Right', row: 1, column: 0 },
+		{ name: 'down', command: 'Merge Down', row: 0, column: 1 },
+	] as const) {
+		test(`keeps the absorbed rich cell empty after merge ${merge.name} and split`, async ({
+			page,
+		}) => {
+			await gotoSlide(page, 4);
+			await chooseTableCommand(page, canvasCellAt(page, merge.row, merge.column), merge.command);
+			await expectRenderedRowCellCount(page, 1, 3);
+
+			const undo = page.getByRole('button', { name: 'Undo', exact: true });
+			const redo = page.getByRole('button', { name: 'Redo', exact: true });
+			await expect(undo).toBeEnabled();
+			await undo.click();
+			await expectRenderedRowCellCount(page, 1, 4);
+			await expect(canvasCellAt(page, 1, 1)).toContainText('Revenue grew 42%');
+			await expect(redo).toBeEnabled();
+			await redo.click();
+			await expectRenderedRowCellCount(page, 1, 3);
+
+			const splitMenu = await openMenuOn(page, canvasCellAt(page, merge.row, merge.column));
+			expect(splitMenu.labels).toContain('split cell');
+			await chooseCommand(page, 'Split Cell');
+			await expectRenderedRowCellCount(page, 1, 4);
+			await expect(canvasCellAt(page, 1, 1)).toHaveText('');
+
+			await expect(undo).toBeEnabled();
+			await undo.click();
+			await expectRenderedRowCellCount(page, 1, 3);
+			await expect(redo).toBeEnabled();
+			await redo.click();
+			await expectRenderedRowCellCount(page, 1, 4);
+			await expect(canvasCellAt(page, 1, 1)).toHaveText('');
+
+			const download = await savePptxViaBackstage(page);
+			const savedPath = await download.path();
+			expect(savedPath, 'the browser should retain the split PPTX').not.toBeNull();
+			await loadDeck(page, savedPath!);
+			await gotoSlide(page, 4);
+			await expect(canvasCellAt(page, 1, 1)).toHaveText('');
+		});
+	}
 
 	/**
 	 * Shift-click has to build a real cell RANGE, or block merge is unreachable.

--- a/packages/angular/src/viewer/editor-context-menu-dispatch.test.ts
+++ b/packages/angular/src/viewer/editor-context-menu-dispatch.test.ts
@@ -251,6 +251,32 @@ describe('tableCommandOp', () => {
 		expect(rawRows(element)).toHaveLength(3);
 	});
 
+	it('commits cleared absorbed runs from a cursor merge', () => {
+		const element = makeTable();
+		const anchorRuns = [{ text: 'r0c0', bold: true }];
+		element.tableData!.rows[0].cells[0].textRuns = anchorRuns;
+		element.tableData!.rows[0].cells[1].textRuns = [{ text: 'r0c1', italic: true }];
+		const updateElement = vi.fn();
+		const harness = {
+			tableCtx: () => ({ element, sel: selectionAt(0, 0) }),
+			slideIndex: () => 4,
+			editor: { updateElement },
+		};
+		const applyTable = (
+			EditorContextMenuComponent.prototype as unknown as {
+				applyTable(op: TableCommandOp): void;
+			}
+		).applyTable;
+
+		applyTable.call(harness, tableCommandOp('table-merge-right')!);
+
+		expect(updateElement).toHaveBeenCalledOnce();
+		const [, , patch] = updateElement.mock.calls[0] as [number, string, TablePptxElement];
+		expect(patch.tableData?.rows[0].cells[0].textRuns).toBe(anchorRuns);
+		expect(patch.tableData?.rows[0].cells[1]).toMatchObject({ text: '', hMerge: true });
+		expect(patch.tableData?.rows[0].cells[1].textRuns).toBeUndefined();
+	});
+
 	it.each(['table-delete-row', 'table-delete-col'] as const)(
 		'does not commit %s when the table has only one cell',
 		(id) => {

--- a/packages/angular/src/viewer/table-data-helpers.test.ts
+++ b/packages/angular/src/viewer/table-data-helpers.test.ts
@@ -15,12 +15,14 @@ import { describe, expect, it } from 'vitest';
 import {
 	insertColumn,
 	insertRow,
+	mergeDown,
 	mergeRight,
 	mergeSelection,
 	patchTableData,
 	removeColumn,
 	removeRow,
 	setCellText,
+	splitCursorCell,
 	splitMergedCell,
 } from './table-data-helpers';
 
@@ -270,6 +272,25 @@ describe('mergeSelection / splitMergedCell', () => {
 		const result = mergeRight(el, 0, 0);
 		expect(cellAt(result, 0, 0)?.gridSpan).toBe(2);
 		expect(cellAt(result, 0, 1)?.hMerge).toBeTruthy();
+	});
+
+	it('keeps the anchor runs and clears absorbed runs through merge-down then split', () => {
+		const el = makeTable([
+			['A', 'B'],
+			['C', 'D'],
+		]);
+		const anchorRuns = [{ text: 'A', bold: true }];
+		el.tableData!.rows[0].cells[0].textRuns = anchorRuns;
+		el.tableData!.rows[1].cells[0].textRuns = [{ text: 'C', italic: true }];
+
+		const merged = mergeDown(el, 0, 0);
+		expect(cellAt(merged, 0, 0)?.textRuns).toBe(anchorRuns);
+		expect(cellAt(merged, 1, 0)?.textRuns).toBeUndefined();
+
+		const split = splitCursorCell(merged, 0, 0);
+		expect(cellAt(split, 0, 0)?.textRuns).toBe(anchorRuns);
+		expect(cellAt(split, 1, 0)).toMatchObject({ text: '' });
+		expect(cellAt(split, 1, 0)?.textRuns).toBeUndefined();
 	});
 });
 

--- a/packages/react/src/viewer/components/inspector/TablePropertiesPanel.test.tsx
+++ b/packages/react/src/viewer/components/inspector/TablePropertiesPanel.test.tsx
@@ -48,13 +48,18 @@ afterEach(() => {
 	host.remove();
 });
 
-function render(element: TablePptxElement, onUpdateElement: (u: Partial<PptxElement>) => void) {
+function render(
+	element: TablePptxElement,
+	onUpdateElement: (u: Partial<PptxElement>) => void,
+	tableEditorState?: { rowIndex: number; columnIndex: number },
+) {
 	act(() => {
 		root.render(
 			React.createElement(TablePropertiesPanel, {
 				tableElement: element,
 				canEdit: true,
 				onUpdateElement,
+				tableEditorState,
 			}),
 		);
 	});
@@ -130,6 +135,36 @@ describe('tablePropertiesPanel', () => {
 		const rows = (onUpdate.mock.calls[0][0] as Partial<TablePptxElement>).tableData?.rows;
 		expect(rows?.[0].cells[0].style?.backgroundColor).toBe('#4472C4');
 		expect(rows?.[0].cells[0].style?.bold).toBeTruthy();
+	});
+
+	it('keeps anchor runs and clears absorbed runs through merge-right then split', () => {
+		const el = table();
+		const anchorRuns = [{ text: 'a', bold: true }];
+		el.tableData!.rows[0].cells[0].textRuns = anchorRuns;
+		el.tableData!.rows[0].cells[1].textRuns = [{ text: 'b', italic: true }];
+		const onUpdate = vi.fn();
+		render(el, onUpdate, { rowIndex: 0, columnIndex: 0 });
+
+		const mergeRight = [...host.querySelectorAll('button')].find(
+			(button) => button.textContent === 'pptx.table.mergeRight',
+		);
+		act(() => mergeRight?.click());
+
+		const merged = (onUpdate.mock.calls[0][0] as Partial<TablePptxElement>).tableData!;
+		expect(merged.rows[0].cells[0].textRuns).toBe(anchorRuns);
+		expect(merged.rows[0].cells[1].textRuns).toBeUndefined();
+
+		const mergedElement = { ...el, tableData: merged };
+		render(mergedElement, onUpdate, { rowIndex: 0, columnIndex: 0 });
+		const split = [...host.querySelectorAll('button')].find(
+			(button) => button.textContent === 'pptx.table.split',
+		);
+		act(() => split?.click());
+
+		const splitData = (onUpdate.mock.calls[1][0] as Partial<TablePptxElement>).tableData!;
+		expect(splitData.rows[0].cells[0].textRuns).toBe(anchorRuns);
+		expect(splitData.rows[0].cells[1]).toMatchObject({ text: '' });
+		expect(splitData.rows[0].cells[1].textRuns).toBeUndefined();
 	});
 
 	it('enables "Edit style..." with no tableStyleId, and assigns a created style to the table', () => {

--- a/packages/shared/src/render/table-cell-merge.test.ts
+++ b/packages/shared/src/render/table-cell-merge.test.ts
@@ -1,4 +1,4 @@
-import type { PptxTableData } from 'pptx-viewer-core';
+import type { PptxTableCell, PptxTableData } from 'pptx-viewer-core';
 import { describe, it, expect } from 'vitest';
 
 import { computeMergeCellRight, computeMergeCellDown, computeSplitCell } from './table-cell-merge';
@@ -6,10 +6,7 @@ import { computeMergeCellRight, computeMergeCellDown, computeSplitCell } from '.
 function makeTable(
 	rows: number,
 	cols: number,
-	overrides?: Record<
-		string,
-		Partial<{ gridSpan: number; rowSpan: number; hMerge: boolean; vMerge: boolean; text: string }>
-	>,
+	overrides?: Record<string, Partial<PptxTableCell>>,
 ): PptxTableData {
 	return {
 		rows: Array.from({ length: rows }, (_row, ri) => ({
@@ -160,4 +157,93 @@ describe('computeSplitCell', () => {
 		expect(result![0].cells[2].text).toBe('0-2');
 		expect(result![1].cells[0].text).toBe('1-0');
 	});
+});
+
+describe('rich cell text through cursor merge and split', () => {
+	it.each([
+		['right', computeMergeCellRight, 0, 1],
+		['down', computeMergeCellDown, 1, 0],
+	] as const)(
+		'clears absorbed runs when merging %s without changing the anchor',
+		(_direction, merge, row, col) => {
+			const anchorRuns: PptxTableCell['textRuns'] = [
+				{ text: 'Keep', bold: true },
+				{ text: '', isLineBreak: true },
+				{ text: 'me', italic: true },
+			];
+			const absorbedRuns: PptxTableCell['textRuns'] = [
+				{ text: 'Remove', bold: true },
+				{ text: ' me', italic: true },
+			];
+			const table = makeTable(2, 2, {
+				'0,0': { text: 'Keep\nme', textRuns: anchorRuns },
+				[`${row},${col}`]: { text: 'Remove me', textRuns: absorbedRuns, style: { fontSize: 24 } },
+			});
+			const original = structuredClone(table);
+			const rows = merge(table, 0, 0)!;
+			expect(rows[row].cells[col].text).toBe('');
+			expect(rows[row].cells[col].textRuns).toBeUndefined();
+			expect(rows[row].cells[col].style).toStrictEqual({ fontSize: 24 });
+			expect(rows[0].cells[0].text).toBe('Keep\nme');
+			expect(rows[0].cells[0].textRuns).toBe(anchorRuns);
+			const split = computeSplitCell({ ...table, rows }, 0, 0)!;
+			expect(split[row].cells[col].text).toBe('');
+			expect(split[row].cells[col].textRuns).toBeUndefined();
+			expect(split[0].cells[0].textRuns).toBe(anchorRuns);
+			expect(split[1 - row].cells[1 - col]).toBe(table.rows[1 - row].cells[1 - col]);
+			expect(table).toStrictEqual(original);
+		},
+	);
+
+	it('clears every absorbed horizontal span cell, including stale runs on empty text', () => {
+		const runs: PptxTableCell['textRuns'] = [{ text: 'Old content', bold: true }];
+		const table = makeTable(1, 4, {
+			'0,1': { gridSpan: 2, text: 'Old content', textRuns: runs },
+			'0,2': { hMerge: true, text: '', textRuns: runs },
+		});
+		const original = structuredClone(table);
+		const rows = computeMergeCellRight(table, 0, 0)!;
+		expect(rows[0].cells[0].gridSpan).toBe(3);
+		for (const index of [1, 2]) {
+			expect(rows[0].cells[index]).toMatchObject({ text: '', hMerge: true });
+			expect(rows[0].cells[index].textRuns).toBeUndefined();
+		}
+		const split = computeSplitCell({ ...table, rows }, 0, 0)!;
+		expect(split[0].cells.slice(1, 3).map((cell) => cell.textRuns)).toStrictEqual([
+			undefined,
+			undefined,
+		]);
+		expect(rows[0].cells[3]).toBe(table.rows[0].cells[3]);
+		expect(table).toStrictEqual(original);
+	});
+
+	it('clears a vertically spanning neighbor without changing its empty continuation cells', () => {
+		const table = makeTable(4, 2, {
+			'1,0': { rowSpan: 2, text: 'Remove', textRuns: [{ text: 'Remove', isField: true }] },
+			'2,0': { vMerge: true, text: '' },
+		});
+		const original = structuredClone(table);
+		const rows = computeMergeCellDown(table, 0, 0)!;
+		expect(rows[0].cells[0].rowSpan).toBe(3);
+		expect(rows[1].cells[0]).toMatchObject({ text: '', vMerge: true });
+		expect(rows[1].cells[0].textRuns).toBeUndefined();
+		expect(rows[2]).toBe(table.rows[2]);
+		const split = computeSplitCell({ ...table, rows }, 0, 0)!;
+		expect(split[1].cells[0].textRuns).toBeUndefined();
+		expect(split[2].cells[0].text).toBe('');
+		expect(split[2].cells[0].vMerge).toBeUndefined();
+		expect(table).toStrictEqual(original);
+	});
+
+	it.each([computeMergeCellRight, computeMergeCellDown])(
+		'leaves rich text untouched for an unavailable neighbor',
+		(merge) => {
+			const table = makeTable(1, 1, {
+				'0,0': { text: 'Keep', textRuns: [{ text: 'Keep', bold: true }] },
+			});
+			const original = structuredClone(table);
+			expect(merge(table, 0, 0)).toBeNull();
+			expect(table).toStrictEqual(original);
+		},
+	);
 });

--- a/packages/shared/src/render/table-cell-merge.ts
+++ b/packages/shared/src/render/table-cell-merge.ts
@@ -15,6 +15,8 @@
  */
 import type { PptxTableData } from 'pptx-viewer-core';
 
+import { withCellText } from './table-cell-edit';
+
 /**
  * Merge the cell at `(rowIndex, columnIndex)` with the next cell to its right.
  * Returns the new `rows` array, or `null` when there is no mergeable neighbour.
@@ -45,7 +47,7 @@ export function computeMergeCellRight(
 				return { ...c, gridSpan: currentSpan + nextSpan };
 			}
 			if (ci >= nextColumnIndex && ci < nextColumnIndex + nextSpan) {
-				return { ...c, hMerge: true, text: '' };
+				return { ...withCellText(c, ''), hMerge: true };
 			}
 			return c;
 		});
@@ -93,7 +95,9 @@ export function computeMergeCellDown(
 		if (ri === targetNextRowIndex) {
 			return {
 				...r,
-				cells: r.cells.map((c, ci) => (ci === columnIndex ? { ...c, vMerge: true, text: '' } : c)),
+				cells: r.cells.map((c, ci) =>
+					ci === columnIndex ? { ...withCellText(c, ''), vMerge: true } : c,
+				),
 			};
 		}
 		return r;

--- a/packages/svelte/src/viewer/editor/table-cell-selection.svelte.test.ts
+++ b/packages/svelte/src/viewer/editor/table-cell-selection.svelte.test.ts
@@ -239,6 +239,31 @@ describe('block merge through the context menu', () => {
 });
 
 describe('structural table commands through the context menu', () => {
+	it('keeps the anchor runs and does not revive absorbed runs after merge-right then split', () => {
+		const data = tableData(2, 2);
+		const anchorRuns = [{ text: 'r0c0', bold: true }];
+		data.rows[0].cells[0].textRuns = anchorRuns;
+		data.rows[0].cells[1].textRuns = [{ text: 'r0c1', italic: true }];
+		const editor = makeEditor(tableElement(data));
+
+		runContextMenuCommand('table-merge-right', {
+			editor,
+			cell: { rowIndex: 0, columnIndex: 0 },
+		});
+		const merged = modelOf(editor);
+		expect(merged.rows[0].cells[0].textRuns).toStrictEqual(anchorRuns);
+		expect(merged.rows[0].cells[1].textRuns).toBeUndefined();
+
+		runContextMenuCommand('table-split', {
+			editor,
+			cell: { rowIndex: 0, columnIndex: 0 },
+		});
+		const split = modelOf(editor);
+		expect(split.rows[0].cells[0].textRuns).toStrictEqual(anchorRuns);
+		expect(split.rows[0].cells[1]).toMatchObject({ text: '' });
+		expect(split.rows[0].cells[1].textRuns).toBeUndefined();
+	});
+
 	it('commits rawXml with tableData', () => {
 		const source = tableElement(tableData(2, 2), true);
 		const editor = makeEditor(source);

--- a/packages/vue/src/viewer/composables/table-mutations.test.ts
+++ b/packages/vue/src/viewer/composables/table-mutations.test.ts
@@ -85,6 +85,22 @@ describe('table-mutations', () => {
 		expect(split!.rows[0].cells[1].hMerge).toBeUndefined();
 	});
 
+	it('keeps the anchor runs and clears absorbed runs through merge-down then split', () => {
+		const table = makeTableData(2, 2);
+		const anchorRuns = [{ text: 'r0c0', bold: true }];
+		table.rows[0].cells[0].textRuns = anchorRuns;
+		table.rows[1].cells[0].textRuns = [{ text: 'r1c0', italic: true }];
+
+		const merged = applyMergeDown(table, 0, 0)!;
+		expect(merged.rows[0].cells[0].textRuns).toBe(anchorRuns);
+		expect(merged.rows[1].cells[0].textRuns).toBeUndefined();
+
+		const split = applySplitCell(merged, 0, 0)!;
+		expect(split.rows[0].cells[0].textRuns).toBe(anchorRuns);
+		expect(split.rows[1].cells[0]).toMatchObject({ text: '' });
+		expect(split.rows[1].cells[0].textRuns).toBeUndefined();
+	});
+
 	it('returns null when splitting an unmerged cell', () => {
 		expect(applySplitCell(makeTableData(2, 2), 0, 0)).toBeNull();
 	});


### PR DESCRIPTION
## What does this change?

Clearing a cell during a cursor merge now also clears the formatted runs describing its old text. Previously Merge Right or Merge Down emptied the absorbed cell's plain text but retained its textRuns. Splitting it again could display the removed text until the file was saved and reloaded.

This applies the existing withCellText helper at the two cursor-merge branches that already clear text. The anchor text and formatting, merge geometry, existing continuation cells, and split policy are unchanged.

Christopher introduced withCellText in 952063b7 for this same stale-content invariant in plain edits and rectangular merges. The cursor helpers had been moved to shared earlier and still bypassed it.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

The cursor helper is used by Vue, Angular and Svelte context menus and inspectors, and React's inspector. Current-main browser reproduction confirms the removed rich text reappearing in Vue and Svelte. Existing binding tests also fail before the fix in React's programmatic inspector and Angular's helper/component boundary.

The fixed browser matrix passes in React, Vue, Angular, Svelte and Vanilla. React context menus and Vanilla use the rectangular merge helper and are controls, not proof of the cursor path. The React programmatic inspector is covered through its actual component buttons. Angular's before-fix browser app had a local build setup failure; its before-fix component tests and after-fix browser flows were both checked.

The React loaded-file inspector has a separate pre-existing raw-XML synchronization defect: it does not repaint merge geometry. This change does not claim to repair that unrelated state boundary; its programmatic-table path renders from the corrected model.

## Testing

- Current-main shared baseline: 4 expected failures, 20 passes. Covers right/down, merge then split, horizontal span absorption, a vertically spanning neighbor, rich anchor retention, cell style preservation, no-op, and source immutability.
- Existing affected-binding regressions reproduce the stale-run failure.
- Full shared suite: 8,876 passed, 3 skipped. Focused shared cursor/edit/block tests: 62 passed.
- React inspector component: 6 passed; Vue: 12 passed; Angular helper and component boundary: 52 passed; Svelte context dispatch: 10 passed.
- Shared, React and Vue typechecks passed. Svelte: 0 errors, 5 existing warnings.
- Independent code review approved the two-path change.
- Framework-neutral browser matrix: 10 passed across all five bindings, covering both merge directions, split, undo/redo and save/reload. The absorbed cell remains empty after split and after reload.
- Changed-file formatting, lint, diff checks and E2E neutrality passed.

## Conventional Commits

- [x] Conventional commit; personal-account signed commit required before publication.
