### PR TITLE
fix: keep split available for a single merged table cell

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -222,6 +222,31 @@ async function fractionalTableDeck(): Promise<DeckPayload> {
 	};
 }
 
+/** Derive a vertical two-cell merge from PowerPoint's public table fixture. */
+async function verticallyMergedTableDeck(): Promise<DeckPayload> {
+	const zip = await JSZip.loadAsync(await readFile(fixturePath));
+	const slidePath = 'ppt/slides/slide4.xml';
+	const slide = zip.file(slidePath);
+	if (!slide) {
+		throw new Error(`${slidePath} is missing from the table styling fixture`);
+	}
+	const xml = await slide.async('string');
+	const rows = [...xml.matchAll(/<a:tr\b[^>]*>.*?<\/a:tr>/gsu)].map((match) => match[0]);
+	const first = rows[0];
+	const second = rows[1];
+	if (!first?.includes('<a:tc>') || !second?.includes('<a:tc>')) {
+		throw new Error('slide 4 is missing the expected first two table rows');
+	}
+	const patchedFirst = first.replace('<a:tc>', '<a:tc rowSpan="2">');
+	const patchedSecond = second.replace('<a:tc>', '<a:tc vMerge="1">');
+	zip.file(slidePath, xml.replace(first, patchedFirst).replace(second, patchedSecond));
+	return {
+		name: 'table-vertical-merge.pptx',
+		mimeType: PPTX_MIME,
+		buffer: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),
+	};
+}
+
 interface RawTableRun {
 	text: string;
 	xml: string;
@@ -601,5 +626,55 @@ test.describe('table styling', () => {
 		await page.waitForTimeout(400);
 
 		expect(await menuLabelsOn(page, far)).toContain('merge selected cells');
+	});
+
+	test('keeps Split Cell available when one merged cell is selected', async ({ page }) => {
+		const deck = await verticallyMergedTableDeck();
+		await loadDeck(page, deck);
+		await gotoSlide(page, 4);
+		const anchor = canvasCell(page, 'R1C1');
+
+		// Selecting the same visible cell, including a Shift-click on it, must not
+		// turn its hidden merge continuation into a second user-selected cell.
+		await selectTableCell(page, anchor);
+		await anchor.click({ modifiers: ['Shift'] });
+		const selectedMenu = await openMenuOn(page, anchor);
+		expect(selectedMenu.labels).toContain('split cell');
+		expect(selectedMenu.labels).not.toContain('merge selected cells');
+
+		await chooseCommand(page, 'Split Cell');
+		await expect(anchor).not.toHaveAttribute('rowspan', '2');
+		await expect(canvasCell(page, 'R2C1')).toHaveCount(1);
+
+		const undo = page.getByRole('button', { name: /^undo/iu }).first();
+		const redo = page.getByRole('button', { name: /^redo/iu }).first();
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expect(canvasCell(page, 'R1C1')).toHaveAttribute('rowspan', '2');
+		await expect(canvasCell(page, 'R2C1')).toHaveCount(0);
+		await expect(redo).toBeEnabled();
+		await redo.click();
+		await expect(canvasCell(page, 'R1C1')).not.toHaveAttribute('rowspan', '2');
+		await expect(canvasCell(page, 'R2C1')).toHaveCount(1);
+
+		const download = await savePptxViaBackstage(page);
+		const savedPath = await download.path();
+		expect(savedPath, 'the browser should retain the downloaded PPTX').not.toBeNull();
+		await loadDeck(page, savedPath!);
+		await gotoSlide(page, 4);
+		await expect(canvasCell(page, 'R1C1')).not.toHaveAttribute('rowspan', '2');
+		await expect(canvasCell(page, 'R2C1')).toHaveCount(1);
+	});
+
+	test('still treats a merged cell plus a visible neighbour as a block', async ({ page }) => {
+		await loadDeck(page, await verticallyMergedTableDeck());
+		await gotoSlide(page, 4);
+		const anchor = canvasCell(page, 'R1C1');
+		const neighbour = canvasCell(page, 'R1C2');
+		await selectTableCell(page, anchor);
+		await neighbour.click({ modifiers: ['Shift'] });
+		const menu = await openMenuOn(page, neighbour);
+		expect(menu.labels).toContain('merge selected cells');
+		expect(menu.labels).not.toContain('split cell');
 	});
 });

--- a/packages/angular/src/viewer/editor-context-menu-context.ts
+++ b/packages/angular/src/viewer/editor-context-menu-context.ts
@@ -15,6 +15,7 @@
 import type { TablePptxElement } from 'pptx-viewer-core';
 
 import type { ContextMenuTableContext } from '../internal/shared';
+import { hasMultipleSelectedTableCells } from '../internal/shared';
 import type { TableCellSelection } from './table-selection.service';
 
 /**
@@ -35,7 +36,10 @@ export function tableMenuContext(
 	selection: TableCellSelection,
 ): ContextMenuTableContext {
 	return {
-		hasMultiCellSelection: (selection.selectedCells?.length ?? 0) >= 2,
+		hasMultiCellSelection: hasMultipleSelectedTableCells(
+			selection.selectedCells,
+			element.tableData,
+		),
 		isMergedCell: isMergedTableCell(element, selection.rowIndex, selection.columnIndex),
 	};
 }

--- a/packages/angular/src/viewer/editor-context-menu-dispatch.test.ts
+++ b/packages/angular/src/viewer/editor-context-menu-dispatch.test.ts
@@ -309,6 +309,30 @@ describe('tableMenuContext', () => {
 		expect(tableMenuContext(makeTable(), selection).hasMultiCellSelection).toBeTruthy();
 	});
 
+	it('does not count a merged anchor and its hidden continuation as two visible cells', () => {
+		const table = makeTable();
+		table.tableData!.rows[0].cells[0] = { text: 'merged', gridSpan: 2 };
+		table.tableData!.rows[0].cells[1] = { text: '', hMerge: true };
+		const oneVisibleCell: TableCellSelection = {
+			...selectionAt(0, 0),
+			selectedCells: [
+				{ row: 0, col: 0 },
+				{ row: 0, col: 1 },
+			],
+		};
+
+		expect(tableMenuContext(table, oneVisibleCell)).toStrictEqual({
+			hasMultiCellSelection: false,
+			isMergedCell: true,
+		});
+
+		const withVisibleNeighbour: TableCellSelection = {
+			...oneVisibleCell,
+			selectedCells: [...oneVisibleCell.selectedCells!, { row: 0, col: 2 }],
+		};
+		expect(tableMenuContext(table, withVisibleNeighbour).hasMultiCellSelection).toBeTruthy();
+	});
+
 	it('treats a missing cell as unmerged rather than throwing', () => {
 		expect(isMergedTableCell(makeTable(), 9, 9)).toBeFalsy();
 	});

--- a/packages/react/src/viewer/components/context-menu-dispatch.test.ts
+++ b/packages/react/src/viewer/components/context-menu-dispatch.test.ts
@@ -6,9 +6,10 @@
  * eating the next click (live-verified with the "comment" entry, suspected for
  * ai-ask/ai-fix and the z-order commands).
  */
+import type { TablePptxElement } from 'pptx-viewer-core';
 import { describe, expect, it, vi } from 'vitest';
 
-import { contextMenuHandlers } from './context-menu-dispatch';
+import { contextMenuContext, contextMenuHandlers } from './context-menu-dispatch';
 import type { ContextMenuProps } from './context-menu-types';
 
 function makeProps(): ContextMenuProps & { onClose: ReturnType<typeof vi.fn> } {
@@ -69,5 +70,50 @@ describe('contextMenuHandlers', () => {
 		const handlers = contextMenuHandlers(props);
 		expect(handlers['ai-ask']).toBeUndefined();
 		expect(handlers['ai-fix']).toBeUndefined();
+	});
+});
+
+describe('merged table cell menu context', () => {
+	it('does not count a hidden merge continuation as a second selected cell', () => {
+		const props = makeProps();
+		props.selectedElement = {
+			id: 'table',
+			type: 'table',
+			x: 0,
+			y: 0,
+			width: 200,
+			height: 50,
+			tableData: {
+				columnWidths: [0.3, 0.3, 0.4],
+				rows: [
+					{
+						cells: [
+							{ text: 'Merged', gridSpan: 2 },
+							{ text: '', hMerge: true },
+							{ text: 'Neighbor' },
+						],
+					},
+				],
+			},
+		} satisfies TablePptxElement;
+		props.tableEditorState = {
+			rowIndex: 0,
+			columnIndex: 0,
+			selectedCells: [
+				{ row: 0, col: 0 },
+				{ row: 0, col: 1 },
+			],
+		};
+
+		expect(contextMenuContext(props).table).toStrictEqual({
+			hasMultiCellSelection: false,
+			isMergedCell: true,
+		});
+
+		props.tableEditorState.selectedCells.push({ row: 0, col: 2 });
+		expect(contextMenuContext(props).table).toStrictEqual({
+			hasMultiCellSelection: true,
+			isMergedCell: true,
+		});
 	});
 });

--- a/packages/react/src/viewer/components/context-menu-dispatch.ts
+++ b/packages/react/src/viewer/components/context-menu-dispatch.ts
@@ -1,5 +1,6 @@
 import type { TablePptxElement } from 'pptx-viewer-core';
 import type { ContextMenuCommandId, ContextMenuContext } from 'pptx-viewer-shared';
+import { hasMultipleSelectedTableCells } from 'pptx-viewer-shared';
 
 import type { ContextMenuProps } from './context-menu-types';
 
@@ -21,11 +22,10 @@ function tableCell(props: ContextMenuProps): ContextMenuContext['table'] {
 	if (selectedElement?.type !== 'table' || tableEditorState === null) {
 		return null;
 	}
-	const rows = (selectedElement as TablePptxElement).tableData?.rows;
-	const cell = rows?.[tableEditorState.rowIndex]?.cells[tableEditorState.columnIndex];
+	const tableData = (selectedElement as TablePptxElement).tableData;
+	const cell = tableData?.rows[tableEditorState.rowIndex]?.cells[tableEditorState.columnIndex];
 	return {
-		hasMultiCellSelection:
-			Array.isArray(tableEditorState.selectedCells) && tableEditorState.selectedCells.length >= 2,
+		hasMultiCellSelection: hasMultipleSelectedTableCells(tableEditorState.selectedCells, tableData),
 		isMergedCell: Boolean(cell && ((cell.gridSpan ?? 1) > 1 || (cell.rowSpan ?? 1) > 1)),
 	};
 }

--- a/packages/shared/src/render/context-menu-commands.test.ts
+++ b/packages/shared/src/render/context-menu-commands.test.ts
@@ -1,11 +1,138 @@
+import type { PptxTableData } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import type { ContextMenuCommandId } from './context-menu-commands';
-import { buildContextMenuEntries, contextMenuLabelKey } from './context-menu-commands';
+import {
+	buildContextMenuEntries,
+	contextMenuLabelKey,
+	hasMultipleSelectedTableCells,
+} from './context-menu-commands';
 
 function ids(...args: Parameters<typeof buildContextMenuEntries>): ContextMenuCommandId[] {
 	return buildContextMenuEntries(...args).map((item) => item.id);
 }
+
+describe('hasMultipleSelectedTableCells', () => {
+	const table: PptxTableData = {
+		columnWidths: [1 / 3, 1 / 3, 1 / 3],
+		rows: [
+			{
+				cells: [
+					{ text: 'Merged', gridSpan: 2, rowSpan: 2 },
+					{ text: '', hMerge: true },
+					{ text: 'Neighbor' },
+				],
+			},
+			{
+				cells: [
+					{ text: '', vMerge: true },
+					{ text: '', hMerge: true, vMerge: true },
+					{ text: 'Other' },
+				],
+			},
+			{
+				cells: [
+					{ text: 'Second merge', gridSpan: 2 },
+					{ text: '', hMerge: true },
+					{ text: 'Last' },
+				],
+			},
+		],
+	};
+
+	it('counts a whole merged region as one visible selected cell without changing the range', () => {
+		const cells = [
+			{ row: 0, col: 0 },
+			{ row: 0, col: 1 },
+			{ row: 1, col: 0 },
+			{ row: 1, col: 1 },
+		];
+		const original = structuredClone({ table, cells });
+		expect(hasMultipleSelectedTableCells(cells, table)).toBeFalsy();
+		expect({ table, cells }).toStrictEqual(original);
+	});
+
+	it('recognizes a merged anchor plus a visible neighbor and two distinct merged anchors', () => {
+		expect(
+			hasMultipleSelectedTableCells(
+				[
+					{ row: 0, col: 0 },
+					{ row: 0, col: 1 },
+					{ row: 0, col: 2 },
+				],
+				table,
+			),
+		).toBeTruthy();
+		expect(
+			hasMultipleSelectedTableCells(
+				[
+					{ row: 0, col: 0 },
+					{ row: 2, col: 0 },
+				],
+				table,
+			),
+		).toBeTruthy();
+		expect(
+			hasMultipleSelectedTableCells(
+				[
+					{ row: 0, col: 2 },
+					{ row: 1, col: 2 },
+				],
+				table,
+			),
+		).toBeTruthy();
+	});
+
+	it('ignores duplicate coordinates, missing cells and hidden continuations', () => {
+		expect(
+			hasMultipleSelectedTableCells(
+				[
+					{ row: 0, col: 0 },
+					{ row: 0, col: 0 },
+				],
+				table,
+			),
+		).toBeFalsy();
+		expect(
+			hasMultipleSelectedTableCells(
+				[
+					{ row: 0, col: 0 },
+					{ row: 9, col: 9 },
+					{ row: 0, col: 1 },
+				],
+				table,
+			),
+		).toBeFalsy();
+		expect(
+			hasMultipleSelectedTableCells(
+				[
+					{ row: 0, col: 1 },
+					{ row: 1, col: 0 },
+					{ row: 1, col: 1 },
+				],
+				table,
+			),
+		).toBeFalsy();
+		expect(hasMultipleSelectedTableCells([], table)).toBeFalsy();
+		expect(hasMultipleSelectedTableCells(undefined, table)).toBeFalsy();
+	});
+
+	it('retains coordinate-based selection when no table model is available', () => {
+		expect(
+			hasMultipleSelectedTableCells([
+				{ row: 0, col: 0 },
+				{ row: 0, col: 1 },
+			]),
+		).toBeTruthy();
+		expect(
+			hasMultipleSelectedTableCells([
+				{ row: 0, col: 0 },
+				{ row: 0, col: 0 },
+			]),
+		).toBeFalsy();
+		expect(hasMultipleSelectedTableCells(undefined)).toBeFalsy();
+	});
+});
 
 describe('buildContextMenuEntries', () => {
 	/**

--- a/packages/shared/src/render/context-menu-commands.ts
+++ b/packages/shared/src/render/context-menu-commands.ts
@@ -20,6 +20,32 @@
  *
  * @module render/context-menu-commands
  */
+import type { PptxTableData } from 'pptx-viewer-core';
+
+import type { CellCoord } from './table-merge';
+
+/**
+ * A merge-aware range includes hidden continuation cells. Count visible
+ * anchors, not those logical slots, when choosing between Merge and Split.
+ * Raw-only tables retain coordinate-based selection when no model is available.
+ */
+export function hasMultipleSelectedTableCells(
+	cells: readonly CellCoord[] | undefined,
+	tableData?: PptxTableData,
+): boolean {
+	const selected = new Set<string>();
+	for (const { row, col } of cells ?? []) {
+		const cell = tableData?.rows[row]?.cells[col];
+		if (tableData && (!cell || cell.hMerge || cell.vMerge)) {
+			continue;
+		}
+		selected.add(`${row},${col}`);
+		if (selected.size > 1) {
+			return true;
+		}
+	}
+	return false;
+}
 
 /** Every command a canvas context menu can offer, in no particular order. */
 export type ContextMenuCommandId =
@@ -64,7 +90,7 @@ export interface ContextMenuEntry {
 
 /** The table cell the menu was opened on, when it was opened on one. */
 export interface ContextMenuTableContext {
-	/** Two or more cells are selected, so the merge is a block merge. */
+	/** Two or more visible cells are selected, so the merge is a block merge. */
 	hasMultiCellSelection: boolean;
 	/** The cell already spans, so it can be split but not merged again. */
 	isMergedCell: boolean;

--- a/packages/svelte/src/viewer/editor/context-menu-dispatch.ts
+++ b/packages/svelte/src/viewer/editor/context-menu-dispatch.ts
@@ -7,6 +7,7 @@ import {
 	computeMergeCellDown,
 	computeMergeCellRight,
 	computeSplitCell,
+	hasMultipleSelectedTableCells,
 	insertTableElementColumn,
 	insertTableElementRow,
 	mergeCells,
@@ -113,7 +114,7 @@ export function buildEditorContextMenuEntries(deps: ContextMenuDispatchDeps): Co
 		table:
 			tableData && cell
 				? {
-						hasMultiCellSelection: selectedCells.length > 1,
+						hasMultiCellSelection: hasMultipleSelectedTableCells(selectedCells, tableData),
 						isMergedCell: isMergedCell(tableData, cell),
 					}
 				: null,

--- a/packages/svelte/src/viewer/editor/table-cell-selection.svelte.test.ts
+++ b/packages/svelte/src/viewer/editor/table-cell-selection.svelte.test.ts
@@ -81,6 +81,26 @@ function modelOf(editor: EditorState): PptxTableData {
 	return (element as { tableData: PptxTableData }).tableData;
 }
 
+type ExistingMerge = 'horizontal' | 'vertical' | 'rectangle';
+
+/** A valid pre-existing merge anchored at (0, 0), plus visible neighbours. */
+function tableWithMerge(kind: ExistingMerge): PptxTableData {
+	const data = tableData();
+	const anchor = data.rows[0].cells[0];
+	if (kind === 'horizontal' || kind === 'rectangle') {
+		anchor.gridSpan = 2;
+		data.rows[0].cells[1] = { text: '', hMerge: true };
+	}
+	if (kind === 'vertical' || kind === 'rectangle') {
+		anchor.rowSpan = 2;
+		data.rows[1].cells[0] = { text: '', vMerge: true };
+	}
+	if (kind === 'rectangle') {
+		data.rows[1].cells[1] = { text: '', hMerge: true, vMerge: true };
+	}
+	return data;
+}
+
 describe('table cell range', () => {
 	it('a plain click anchors a single cell', () => {
 		const editor = makeEditor();
@@ -124,6 +144,41 @@ describe('table cell range', () => {
 });
 
 describe('block merge through the context menu', () => {
+	it.each<ExistingMerge>(['horizontal', 'vertical', 'rectangle'])(
+		'plain-clicking one %s merged cell offers Split Cell, not Merge Selected Cells',
+		(kind) => {
+			const editor = makeEditor(tableElement(tableWithMerge(kind)));
+			const cell = { rowIndex: 0, columnIndex: 0 };
+
+			applyTableCellPointer(editor, 'tbl', cellNode(0, 0), false);
+
+			// The merge-aware rectangle must still cover the anchor's full span so
+			// highlighting and a later Shift-click cannot select half a merge.
+			expect(editor.tableCells.cellsFor('tbl').length).toBeGreaterThan(1);
+			const entries = buildEditorContextMenuEntries({ editor, cell }).map((entry) => entry.id);
+			expect(entries).toContain('table-split');
+			expect(entries).not.toContain('table-merge-selected');
+		},
+	);
+
+	it('still offers Merge Selected Cells for a merged cell plus a visible neighbour', () => {
+		const editor = makeEditor(tableElement(tableWithMerge('horizontal')));
+		const cell = { rowIndex: 0, columnIndex: 0 };
+
+		applyTableCellPointer(editor, 'tbl', cellNode(0, 0), false);
+		const consumed = applyTableCellPointer(editor, 'tbl', cellNode(0, 2), true);
+
+		expect(consumed).toBeTruthy();
+		expect(editor.tableCells.cellsFor('tbl')).toStrictEqual([
+			{ row: 0, col: 0 },
+			{ row: 0, col: 1 },
+			{ row: 0, col: 2 },
+		]);
+		const entries = buildEditorContextMenuEntries({ editor, cell }).map((entry) => entry.id);
+		expect(entries).toContain('table-merge-selected');
+		expect(entries).not.toContain('table-split');
+	});
+
 	it('offers table-merge-selected only once the range covers a block', () => {
 		const editor = makeEditor();
 		const cell = { rowIndex: 0, columnIndex: 0 };

--- a/packages/vanilla/src/viewer/ui/element-context-menu-commands.ts
+++ b/packages/vanilla/src/viewer/ui/element-context-menu-commands.ts
@@ -14,6 +14,7 @@
  */
 import type { PptxElement } from 'pptx-viewer-core';
 import type { ContextMenuCommandId, ContextMenuTableContext } from 'pptx-viewer-shared';
+import { hasMultipleSelectedTableCells } from 'pptx-viewer-shared';
 
 import type { EditActions } from '../editor';
 import type { TableCellPosition } from '../editor/table-editor-mutations';
@@ -73,7 +74,10 @@ export function resolveTableTarget(
 	return {
 		cell,
 		context: {
-			hasMultiCellSelection: state.selectedTableCells.length > 1,
+			hasMultiCellSelection: hasMultipleSelectedTableCells(
+				state.selectedTableCells.map(({ row, column }) => ({ row, col: column })),
+				element.tableData,
+			),
 			isMergedCell: (anchor?.gridSpan ?? 1) > 1 || (anchor?.rowSpan ?? 1) > 1,
 		},
 	};

--- a/packages/vanilla/src/viewer/ui/element-context-menu.test.ts
+++ b/packages/vanilla/src/viewer/ui/element-context-menu.test.ts
@@ -310,6 +310,43 @@ describe('mountElementContextMenu', () => {
 		context.destroy();
 	});
 
+	it('offers Split Cell when the selected range contains only one visible merged cell', () => {
+		const slide = tableSlide();
+		const element = slide.elements[0];
+		if (element.type !== 'table' || !element.tableData) {
+			throw new Error('expected the table fixture');
+		}
+		element.tableData.rows[0].cells[0].gridSpan = 2;
+		element.tableData.rows[0].cells[1] = { text: '', hMerge: true };
+		const context = harness(slide, {
+			state: {
+				selectedElementId: element.id,
+				selectedElementIds: [element.id],
+				selectedTableCell: { row: 0, column: 0 },
+				selectedTableCells: [
+					{ row: 0, column: 0 },
+					{ row: 0, column: 1 },
+				],
+			},
+			decorate(node) {
+				const table = document.createElement('table');
+				const cell = table.insertRow().insertCell();
+				cell.dataset.rowIndex = '0';
+				cell.dataset.cellIndex = '0';
+				cell.colSpan = 2;
+				node.appendChild(table);
+				return cell;
+			},
+		});
+
+		rightClick(context.target);
+		expect(labels()).toContain('Split Cell');
+		expect(labels().map((label) => label.toLowerCase())).not.toContain('merge selected cells');
+		clickCommand('Split Cell');
+		expect(context.actions.splitTableCell).toHaveBeenCalledWith({ row: 0, column: 0 });
+		context.destroy();
+	});
+
 	it('folds the AI entries in only when the host configured ai', () => {
 		const askAboutSelection = vi.fn();
 		const context = harness(shapeSlide(), {

--- a/packages/vue/src/viewer/composables/useContextMenu.commands.test.ts
+++ b/packages/vue/src/viewer/composables/useContextMenu.commands.test.ts
@@ -72,6 +72,24 @@ const TABLE = {
 	},
 } as TablePptxElement;
 
+function tableWithHorizontalMerge(): TablePptxElement {
+	return {
+		...TABLE,
+		tableData: {
+			columnWidths: [1 / 3, 1 / 3, 1 / 3],
+			rows: [
+				{
+					cells: [
+						{ text: 'merged', gridSpan: 2 },
+						{ text: '', hMerge: true },
+						{ text: 'neighbour' },
+					],
+				},
+			],
+		},
+	};
+}
+
 /**
  * `<div data-element-id="group-1"><div data-element-id="child-1"><span/></div></div>`,
  * which is how every binding renders a `p:grpSp`: the child's element node is a
@@ -211,6 +229,36 @@ describe('useContextMenu command set', () => {
 			tableData: { rows: expect.any(Array) },
 			rawXml: expect.any(Object),
 		});
+	});
+
+	it('distinguishes one merged cell from a merged cell plus a visible neighbour', () => {
+		const table = tableWithHorizontalMerge();
+		const selectedCells = [
+			{ row: 0, col: 0 },
+			{ row: 0, col: 1 },
+		];
+		const tableSelection = ref({
+			elementId: table.id,
+			rowIndex: 0,
+			columnIndex: 0,
+			selectedCells,
+		});
+		const menu = setup({
+			findActiveElement: (id) => (id === table.id ? table : undefined),
+			tableSelection,
+			selectedElementIds: ref<string[]>([table.id]),
+		});
+		menu.contextMenu.value = { open: true, x: 0, y: 0, elementId: table.id };
+
+		expect(commandIds(menu)).toContain('table-split');
+		expect(commandIds(menu)).not.toContain('table-merge-selected');
+
+		tableSelection.value = {
+			...tableSelection.value,
+			selectedCells: [...selectedCells, { row: 0, col: 2 }],
+		};
+		expect(commandIds(menu)).toContain('table-merge-selected');
+		expect(commandIds(menu)).not.toContain('table-split');
 	});
 });
 

--- a/packages/vue/src/viewer/composables/useContextMenu.ts
+++ b/packages/vue/src/viewer/composables/useContextMenu.ts
@@ -1,6 +1,7 @@
 import type { PptxElement, PptxTableData, TablePptxElement } from 'pptx-viewer-core';
 import {
 	buildContextMenuEntries,
+	hasMultipleSelectedTableCells,
 	resolveContextMenuElementId,
 	resolveTopLevelElementId,
 } from 'pptx-viewer-shared';
@@ -113,11 +114,6 @@ export function useContextMenu(input: UseContextMenuInput): UseContextMenuResult
 		y: 0,
 		elementId: null,
 	});
-	/**
-	 * The table element under the context menu, when it is a table whose selected
-	 * cell is known: gates the row/column/merge entries. Mirrors React's ContextMenu
-	 * `isTable` / `hasMultiCellSelection` / `isMergedCell` derivation.
-	 */
 	/** The element the menu was opened on, whatever its type. */
 	const contextElement = computed(() => {
 		const id = contextMenu.value.elementId;
@@ -137,7 +133,7 @@ export function useContextMenu(input: UseContextMenuInput): UseContextMenuResult
 		}
 		const cell = el.tableData.rows[sel.rowIndex]?.cells[sel.columnIndex];
 		const isMerged = Boolean(cell && ((cell.gridSpan ?? 1) > 1 || (cell.rowSpan ?? 1) > 1));
-		const hasMulti = Array.isArray(sel.selectedCells) && sel.selectedCells.length >= 2;
+		const hasMulti = hasMultipleSelectedTableCells(sel.selectedCells, el.tableData);
 		return { el, sel, isMerged, hasMulti };
 	});
 


### PR DESCRIPTION
## What does this change?

Keep Split Cell available when a selection contains one visible merged cell. Merge-aware selections include the hidden continuation coordinates inside a span; counting those coordinates as separate cells made the context menu offer Merge Selected Cells instead of Split Cell.

The browser baseline reproduces this in Svelte after selecting a vertically merged cell. The same logical-coordinate classification is used by all five bindings, and existing boundary tests reproduce it in each. Shift-selecting the same merged cell can produce a span-expanded range even in bindings whose normal click stores only the anchor.

One small shared helper now counts distinct visible anchors, excluding hMerge/vMerge continuations. All five menu adapters use it. If no table model is available, it retains coordinate-based classification for raw-only consumers.

The author's merge-aware range expansion and the shared menu's priority for a true multi-cell block are unchanged. A merged cell plus a visible neighbor, or two distinct merged cells, still offers Merge Selected Cells. No selection state, command implementation or serialization behavior changes.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

React, Vue, Angular, Svelte and Vanilla menu adapters are all updated, with regressions in their existing test files. React and Angular tests check the actual menu context; Vue checks the reactive menu; Svelte drives real cell-selection events; Vanilla mounts the menu and invokes Split.

All five bindings pass the framework-neutral browser matrix: select one vertically merged cell, Shift-click it, invoke Split, undo/redo, and save/reload. A real merged-cell-plus-visible-neighbor selection still offers Merge Selected Cells. The before-fix browser reproduction was Svelte; the other four have before-fix context-boundary failures and after-fix browser coverage.

## Testing

- Before fix: expected failures in all five existing binding suites. Svelte covers horizontal, vertical and rectangular merges; controls cover a merged cell plus a visible neighbor.
- Shared tests cover whole merged regions, visible neighbors, multiple anchors, duplicates, invalid coordinates, hidden-only selections, missing-model fallback and immutability.
- Full shared suite: 8,874 passed, 3 skipped. Shared typecheck passed.
- Independent source/history and final integration reviews approved the focused change.
- Focused binding tests: React 12, Vue 11, Angular 33, Svelte 13, Vanilla 9 passed.
- All affected package typechecks passed. Svelte reports 5 existing accessibility warnings and 0 errors.
- Browser matrix: 10 passed across all five bindings, with no skips or flaky cases.
- Changed-file formatting/lint, diff checks and framework-neutrality contract passed.

## Conventional Commits

- [x] Conventional commit; signed personal-account commit required before publication.
