### PR TITLE
fix: read attributed table text without object coercion

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -51,6 +51,7 @@ import {
 	menuIsOpen,
 	openMenuAt,
 	openMenuOn,
+	selectTableCell,
 } from './support/context-menu';
 import { resetTabSession } from './support/deck';
 
@@ -248,6 +249,27 @@ async function verticallyMergedTableDeck(): Promise<DeckPayload> {
 	zip.file(slidePath, xml.replace(first, patchedFirst).replace(second, patchedSecond));
 	return {
 		name: 'table-vertical-merge.pptx',
+		mimeType: PPTX_MIME,
+		buffer: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),
+	};
+}
+
+/** Add the whitespace attribute that makes fast-xml-parser expose `a:t` as an object. */
+async function attributedTableTextDeck(): Promise<DeckPayload> {
+	const zip = await JSZip.loadAsync(await readFile(fixturePath));
+	const slidePath = 'ppt/slides/slide4.xml';
+	const slide = zip.file(slidePath);
+	if (!slide) {
+		throw new Error(`${slidePath} is missing from the table styling fixture`);
+	}
+	const xml = await slide.async('string');
+	const authoredRun = '<a:t>Revenue </a:t>';
+	if (!xml.includes(authoredRun)) {
+		throw new Error('the expected Revenue run is missing from slide 4');
+	}
+	zip.file(slidePath, xml.replace(authoredRun, '<a:t xml:space="preserve">Revenue </a:t>'));
+	return {
+		name: 'table-attributed-text.pptx',
 		mimeType: PPTX_MIME,
 		buffer: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),
 	};
@@ -628,6 +650,69 @@ test.describe('table styling', () => {
 		const reloadedCell = reloaded.cells.find((candidate) => candidate.text === 'Fractional cell');
 		expect(reloadedCell, 'the saved edit should survive reloading').toBeTruthy();
 		expect(reloadedCell!.fontSize).toBeCloseTo(14, 2);
+	});
+
+	test('renders attributed table text and preserves it through save', async ({ page }) => {
+		await loadDeck(page, await attributedTableTextDeck());
+		await gotoSlide(page, 4);
+		let cell = canvasCell(page, 'Revenue grew 42%');
+		await expect(cell).toBeVisible();
+		expect(await cell.locator('span').allTextContents()).toEqual(['Revenue ', 'grew 42%']);
+
+		const cellBox = await cell.boundingBox();
+		expect(cellBox, 'the attributed table cell should have a layout box').not.toBeNull();
+		await page.mouse.dblclick(cellBox!.x + cellBox!.width / 2, cellBox!.y + cellBox!.height / 2);
+		const input = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('td input')
+			.first();
+		await expect(input).toHaveValue('Revenue grew 42%');
+		await input.press('Escape');
+
+		const noOpDownload = await savePptxViaBackstage(page);
+		const noOpPath = await noOpDownload.path();
+		expect(noOpPath, 'the browser should retain the downloaded PPTX').not.toBeNull();
+		const noOpZip = await JSZip.loadAsync(await readFile(noOpPath!));
+		const noOpXml = await noOpZip.file('ppt/slides/slide4.xml')?.async('string');
+		expect(noOpXml).toContain('<a:t xml:space="preserve">Revenue </a:t>');
+
+		await loadDeck(page, noOpPath!);
+		await gotoSlide(page, 4);
+		cell = canvasCell(page, 'Revenue grew 42%');
+		await expect(cell).toBeVisible();
+		expect(await cell.locator('span').allTextContents()).toEqual(['Revenue ', 'grew 42%']);
+
+		const reloadedBox = await cell.boundingBox();
+		expect(reloadedBox, 'the reloaded table cell should have a layout box').not.toBeNull();
+		await page.mouse.dblclick(
+			reloadedBox!.x + reloadedBox!.width / 2,
+			reloadedBox!.y + reloadedBox!.height / 2,
+		);
+		const reloadedInput = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('td input')
+			.first();
+		await expect(reloadedInput).toHaveValue('Revenue grew 42%');
+		await reloadedInput.fill('Edited attributed cell');
+		await reloadedInput.press('Enter');
+		await expect(canvasCell(page, 'Edited attributed cell')).toBeVisible();
+		const undo = page.getByRole('button', { name: 'Undo' });
+		const redo = page.getByRole('button', { name: 'Redo' });
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expect(canvasCell(page, 'Revenue grew 42%')).toBeVisible();
+		await expect(redo).toBeEnabled();
+		await redo.click();
+		await expect(canvasCell(page, 'Edited attributed cell')).toBeVisible();
+
+		const editDownload = await savePptxViaBackstage(page);
+		const editPath = await editDownload.path();
+		expect(editPath, 'the browser should retain the edited PPTX').not.toBeNull();
+		await loadDeck(page, editPath!);
+		await gotoSlide(page, 4);
+		await expect(canvasCell(page, 'Edited attributed cell')).toBeVisible();
 	});
 
 	test('keeps rich cell runs aligned after inserting a middle row', async ({ page }) => {

--- a/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
@@ -40,6 +40,33 @@ async function buildDeckWithRichTableCell(): Promise<Uint8Array> {
 	return zip.generateAsync({ type: 'uint8array' });
 }
 
+const ATTRIBUTED_CELL_BODY =
+	'<a:txBody><a:bodyPr/><a:lstStyle/><a:p>' +
+	'<a:r><a:rPr lang="en-US" b="1"/><a:t xml:space="preserve"> Lead </a:t></a:r>' +
+	'<a:fld id="{AAAA0000-0000-4000-A000-000000000001}" type="slidenum"><a:rPr/><a:t xml:space="preserve"> Field </a:t></a:fld>' +
+	'<a:r><a:rPr lang="en-US" i="1"/><a:t xml:space="preserve"> Tail </a:t></a:r>' +
+	'<a:endParaRPr lang="en-US"/></a:p></a:txBody>';
+
+async function buildDeckWithAttributedTableCell(): Promise<Uint8Array> {
+	const { handler, data, createSlide } = await PresentationBuilder.create();
+	data.slides.push(
+		createSlide('Blank')
+			.addTable(
+				{ rows: [{ cells: [{ text: 'AttributedFixture' }] }] },
+				{ x: 20, y: 20, width: 400, height: 80 },
+			)
+			.build(),
+	);
+	const zip = await JSZip.loadAsync(await handler.save(data.slides));
+	const path = 'ppt/slides/slide1.xml';
+	const xml = await zip.file(path)!.async('string');
+	const fixtureBody =
+		/<a:txBody>(?:(?!<\/a:txBody>)[\s\S])*?<a:t>AttributedFixture<\/a:t>(?:(?!<\/a:txBody>)[\s\S])*?<\/a:txBody>/;
+	expect(xml, 'fixture precondition: attributed-cell marker body').toMatch(fixtureBody);
+	zip.file(path, xml.replace(fixtureBody, ATTRIBUTED_CELL_BODY));
+	return zip.generateAsync({ type: 'uint8array' });
+}
+
 /**
  * Regression test for SDK-created tables being silently dropped on save.
  *
@@ -50,6 +77,77 @@ async function buildDeckWithRichTableCell(): Promise<Uint8Array> {
  * `SAVE_ELEMENT_SKIPPED` warning. The saved slide had an empty `p:spTree`.
  */
 describe('sDK-created table survives save round-trip', () => {
+	it('preserves attributed rich text after a non-text table edit', async () => {
+		let handler = new PptxHandler();
+		let loaded = await handler.load(
+			(await buildDeckWithAttributedTableCell()).buffer as ArrayBuffer,
+		);
+		let table = loaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		const cell = table.tableData!.rows[0].cells[0];
+
+		// Keep the established flat-cell policy (runs first, then fields), while
+		// the rich run model retains the authored run/field/run order.
+		expect(cell.text).toBe(' Lead  Tail  Field ');
+		expect(cell.textRuns).toStrictEqual([
+			{ text: ' Lead ', bold: true },
+			{ text: ' Field ', isField: true },
+			{ text: ' Tail ', italic: true },
+		]);
+
+		table.x += 1;
+		const saved = await handler.save(loaded.slides);
+		const zip = await JSZip.loadAsync(saved);
+		const slideXml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+		const lead = slideXml.indexOf('<a:t xml:space="preserve"> Lead </a:t>');
+		const field = slideXml.indexOf('<a:t xml:space="preserve"> Field </a:t>');
+		const tail = slideXml.indexOf('<a:t xml:space="preserve"> Tail </a:t>');
+		expect(lead).toBeGreaterThan(-1);
+		expect(field).toBeGreaterThan(lead);
+		expect(tail).toBeGreaterThan(field);
+
+		handler = new PptxHandler();
+		loaded = await handler.load(saved.buffer as ArrayBuffer);
+		table = loaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		expect(table.tableData!.rows[0].cells[0]).toMatchObject({
+			text: ' Lead  Tail  Field ',
+			textRuns: [
+				{ text: ' Lead ', bold: true },
+				{ text: ' Field ', isField: true },
+				{ text: ' Tail ', italic: true },
+			],
+		});
+	});
+
+	it('still replaces attributed rich text after a genuine cell edit', async () => {
+		const handler = new PptxHandler();
+		const loaded = await handler.load(
+			(await buildDeckWithAttributedTableCell()).buffer as ArrayBuffer,
+		);
+		const table = loaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		const cell = table.tableData!.rows[0].cells[0];
+		cell.text = 'Edited table text';
+		delete cell.textRuns;
+
+		const saved = await handler.save(loaded.slides);
+		const reloaded = await new PptxHandler().load(saved.buffer as ArrayBuffer);
+		const reloadedTable = reloaded.slides[0].elements.find(
+			(element) => element.type === 'table',
+		) as TablePptxElement;
+		expect(reloadedTable.tableData!.rows[0].cells[0].text).toBe('Edited table text');
+		const zip = await JSZip.loadAsync(saved);
+		const slideXml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+		expect(slideXml).toContain('<a:t>Edited table text</a:t>');
+		expect(slideXml).not.toContain(' Lead ');
+		expect(slideXml).not.toContain(' Field ');
+		expect(slideXml).not.toContain(' Tail ');
+	});
+
 	it.each(
 		(['row', 'column'] as const).flatMap((axis) =>
 			(['insert', 'delete'] as const).flatMap((action) =>

--- a/packages/core/src/core/core/builders/PptxTableDataParser.ts
+++ b/packages/core/src/core/core/builders/PptxTableDataParser.ts
@@ -5,6 +5,7 @@ import type {
 	PptxTableRow,
 	XmlObject,
 } from '../../types';
+import { xmlText } from '../../utils';
 import { parseTableEffectChain } from '../runtime/table-style-effect-parse';
 import { parseTablePropertiesFill } from '../runtime/table-style-fill-parse';
 import { applyCell3DStyle } from './table-cell-3d-helpers';
@@ -251,10 +252,10 @@ export class PptxTableDataParser implements IPptxTableDataParser {
 			let lineText = '';
 
 			for (const run of runs) {
-				lineText += String(run?.['a:t'] ?? '');
+				lineText += xmlText(run?.['a:t']) ?? '';
 			}
 			for (const field of fields) {
-				lineText += String(field?.['a:t'] ?? '');
+				lineText += xmlText(field?.['a:t']) ?? '';
 			}
 			lines.push(lineText);
 		}

--- a/packages/core/src/core/core/builders/table-cell-runs.test.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.test.ts
@@ -38,6 +38,26 @@ function parseCell(xml: string): XmlObject {
 }
 
 describe('extractTableCellTextRuns', () => {
+	it('reads attributed runs and fields without losing whitespace or inline order', () => {
+		const cell = parseCell(
+			'<a:tc><a:txBody><a:p>' +
+				'<a:r><a:t xml:space="preserve"> Rich </a:t></a:r>' +
+				'<a:fld><a:t xml:space="preserve"> 1 </a:t></a:fld><a:br/>' +
+				'<a:r><a:t xml:space="preserve">  </a:t></a:r>' +
+				'<a:r><a:t xml:space="preserve"/></a:r>' +
+				'</a:p></a:txBody></a:tc>',
+		);
+		const before = structuredClone(cell);
+		expect(extractTableCellTextRuns(cell, context)).toStrictEqual([
+			{ text: ' Rich ' },
+			{ text: ' 1 ', isField: true },
+			{ text: '', isLineBreak: true },
+			{ text: '  ' },
+			{ text: '' },
+		]);
+		expect(cell).toStrictEqual(before);
+	});
+
 	it('preserves a paragraph containing only a soft break', () => {
 		const cell = parseCell('<a:tc><a:txBody><a:bodyPr/><a:p><a:br/></a:p></a:txBody></a:tc>');
 		expect(extractTableCellTextRuns(cell, context)).toStrictEqual([

--- a/packages/core/src/core/core/builders/table-cell-runs.ts
+++ b/packages/core/src/core/core/builders/table-cell-runs.ts
@@ -21,6 +21,7 @@
  * @module table-cell-runs
  */
 import type { PptxTableCellTextRun, XmlObject } from '../../types';
+import { xmlText } from '../../utils';
 import { paragraphContentEntries } from '../runtime/paragraph-sibling-order';
 
 /** Content children of an `a:p` that contribute to a cell's rendered text. */
@@ -113,7 +114,7 @@ export function extractTableCellTextRuns(
 				continue;
 			}
 			const node = item as XmlObject | undefined;
-			const run: PptxTableCellTextRun = { text: String(node?.['a:t'] ?? '') };
+			const run: PptxTableCellTextRun = { text: xmlText(node?.['a:t']) ?? '' };
 			if (tag === 'a:fld') {
 				run.isField = true;
 			}

--- a/packages/core/src/core/core/runtime/table-cell-text-xml.ts
+++ b/packages/core/src/core/core/runtime/table-cell-text-xml.ts
@@ -1,4 +1,5 @@
 import type { XmlObject } from '../../types';
+import { xmlText } from '../../utils';
 import { ensureArray as toArray } from './table-structural-helpers';
 
 type EnsureArray = (value: unknown) => XmlObject[];
@@ -26,10 +27,10 @@ export function flattenCellTxBodyText(
 		const fields = ensureArray((paragraph as XmlObject)?.['a:fld']);
 		let lineText = '';
 		for (const run of runs) {
-			lineText += String((run as XmlObject)?.['a:t'] ?? '');
+			lineText += xmlText((run as XmlObject)?.['a:t']) ?? '';
 		}
 		for (const field of fields) {
-			lineText += String((field as XmlObject)?.['a:t'] ?? '');
+			lineText += xmlText((field as XmlObject)?.['a:t']) ?? '';
 		}
 		lines.push(lineText);
 	}

--- a/packages/core/src/core/core/runtime/table-paragraph-save-order.test.ts
+++ b/packages/core/src/core/core/runtime/table-paragraph-save-order.test.ts
@@ -28,6 +28,24 @@ function fixture() {
 }
 
 describe('table paragraph save order', () => {
+	it('matches attributed text on cloned XML and preserves its nodes and order', () => {
+		const { cell, paragraph } = fixture();
+		for (const node of [...(paragraph['a:r'] as XmlObject[]), paragraph['a:fld'] as XmlObject]) {
+			node['a:t'] = { '#text': node['a:t'], '@_xml:space': 'preserve' };
+		}
+		const cloned = structuredClone(cell);
+		const before = structuredClone(cloned);
+		recordTableParagraphOrder(cloned, runs);
+		const ordered = withOrderedTableParagraphs(cloned);
+		expect(ordered).not.toBe(cloned);
+		expect(cloned).toStrictEqual(before);
+		const xml = new PptxRuntimeDependencyFactory().createBuilder().build(ordered);
+		expect(xml.match(/xml:space="preserve"/g)).toHaveLength(3);
+		expect(xml.indexOf('Page ')).toBeLessThan(xml.indexOf('slidenum'));
+		expect(xml.indexOf('slidenum')).toBeLessThan(xml.indexOf('<a:br'));
+		expect(xml.indexOf('<a:br')).toBeLessThan(xml.indexOf('of 10'));
+	});
+
 	it('uses the actual cached parse for untouched tables, without changing other paragraphs', () => {
 		const factory = new PptxRuntimeDependencyFactory();
 		const xml =

--- a/packages/core/src/core/core/runtime/table-paragraph-save-order.ts
+++ b/packages/core/src/core/core/runtime/table-paragraph-save-order.ts
@@ -1,4 +1,5 @@
 import type { PptxTableCellTextRun, XmlObject } from '../../types';
+import { xmlText } from '../../utils';
 import { assignOrderedXmlChildren, setOwnXmlProperty } from './ordered-xml-children';
 import { paragraphContentEntries } from './paragraph-sibling-order';
 import { ensureItems, isGroupedByTag, isXmlObject } from './xml-child-scan';
@@ -41,7 +42,7 @@ function matchesParagraph(paragraph: XmlObject, runs: readonly PptxTableCellText
 		if (node === undefined) {
 			return false;
 		}
-		if (tag !== 'a:br' && (!isXmlObject(node) || String(node['a:t'] ?? '') !== run.text)) {
+		if (tag !== 'a:br' && (!isXmlObject(node) || (xmlText(node['a:t']) ?? '') !== run.text)) {
 			return false;
 		}
 		consumed.set(tag, index + 1);

--- a/packages/core/src/core/utils/xml-access.test.ts
+++ b/packages/core/src/core/utils/xml-access.test.ts
@@ -140,6 +140,21 @@ describe('xml-access', () => {
 			expect(xmlText({ '#text': 16 })).toBe('16');
 		});
 
+		it.each([0, 42, false, true])('coerces primitive text %s consistently', (value) => {
+			expect(xmlText(value)).toBe(String(value));
+			expect(xmlText({ '#text': value })).toBe(String(value));
+		});
+
+		it('preserves exact text independently of attributes', () => {
+			expect(xmlText({ '#text': ' Rich ', '@_xml:space': 'preserve' })).toBe(' Rich ');
+			expect(xmlText({ '#text': '  ', '@_xml:space': 'preserve' })).toBe('  ');
+		});
+
+		it.each([null, [], Symbol('text'), 1n, { '@_xml:space': 'preserve' }, { '#text': {} }])(
+			'does not stringify unsupported text nodes',
+			(value) => expect(xmlText(value)).toBeUndefined(),
+		);
+
 		it('returns undefined when missing', () => {
 			expect(xmlText({})).toBeUndefined();
 			expect(xmlText(undefined)).toBeUndefined();

--- a/packages/core/src/core/utils/xml-access.ts
+++ b/packages/core/src/core/utils/xml-access.ts
@@ -257,14 +257,12 @@ export function xmlAttrBool(node: unknown, name: string): boolean | undefined {
 
 /**
  * Read the text content of an element (`#text` key) or the element itself if
- * fast-xml-parser collapsed it to a bare string.
+ * fast-xml-parser collapsed it to a bare value. Alternate parser configurations
+ * may produce numbers or booleans, which use the same coercion as attributes.
  */
 export function xmlText(node: unknown): string | undefined {
-	if (typeof node === 'string') {
-		return node;
-	}
 	if (!isXmlObject(node)) {
-		return undefined;
+		return coerceString(node);
 	}
 	return coerceString(node[TEXT_KEY]);
 }

--- a/packages/react/src/viewer/utils/table-cell-style.test.tsx
+++ b/packages/react/src/viewer/utils/table-cell-style.test.tsx
@@ -75,6 +75,29 @@ describe('extractCellText', () => {
 		expect(extractCellText(cellXml)).toBe('Text 123');
 	});
 
+	it('extracts attributed run and field text with boundary spaces', () => {
+		const cellXml = {
+			'a:txBody': {
+				'a:p': {
+					'a:r': { 'a:t': { '#text': ' Run ', '@_xml:space': 'preserve' } },
+					'a:fld': { 'a:t': { '#text': ' Field ', '@_xml:space': 'preserve' } },
+				},
+			},
+		};
+		expect(extractCellText(cellXml)).toBe(' Run  Field ');
+	});
+
+	it('treats an attributed text node without #text as empty', () => {
+		const cellXml = {
+			'a:txBody': {
+				'a:p': {
+					'a:r': { 'a:t': { '@_xml:space': 'preserve' } },
+				},
+			},
+		};
+		expect(extractCellText(cellXml)).toBe('');
+	});
+
 	it('converts non-string text values to string', () => {
 		const cellXml = {
 			'a:txBody': {

--- a/packages/react/src/viewer/utils/table-cell-style.tsx
+++ b/packages/react/src/viewer/utils/table-cell-style.tsx
@@ -1,4 +1,5 @@
 import type { XmlObject } from 'pptx-viewer-core';
+import { xmlText } from 'pptx-viewer-core';
 import React from 'react';
 
 import { colorWithOpacity } from './color';
@@ -25,22 +26,12 @@ export function extractCellText(cellXml: XmlObject | undefined): string {
 		const textParts: string[] = [];
 		const runs = ensureArrayValue(paragraph['a:r'] as XmlObject | XmlObject[] | undefined);
 		runs.forEach((run) => {
-			const value = run['a:t'];
-			if (typeof value === 'string') {
-				textParts.push(value);
-			} else if (value !== undefined) {
-				textParts.push(String(value));
-			}
+			textParts.push(xmlText(run['a:t']) ?? '');
 		});
 
 		const fields = ensureArrayValue(paragraph['a:fld'] as XmlObject | XmlObject[] | undefined);
 		fields.forEach((field) => {
-			const value = field['a:t'];
-			if (typeof value === 'string') {
-				textParts.push(value);
-			} else if (value !== undefined) {
-				textParts.push(String(value));
-			}
+			textParts.push(xmlText(field['a:t']) ?? '');
 		});
 
 		paragraphTexts.push(textParts.join(''));


### PR DESCRIPTION
## What does this change?

Table text such as `<a:t xml:space="preserve">Revenue </a:t>` is parsed as an object containing `#text` and attributes. The table paths currently call `String` on that object, so an ordinary loaded cell and its inline editor display `[object Object]` instead of the text.

- Use the existing `xmlText` accessor in table flat-text parsing, rich-run parsing, save equality, save-order matching, and React's raw-XML text fallback.
- Preserve the existing runs-then-fields flat-text policy from #68 and the authored rich-run order. Matching load and save normalization keeps unchanged rich XML intact.
- Let `xmlText` apply its existing primitive coercion policy to bare numbers/booleans too, preserving alternate-parser compatibility and React's existing numeric-text behavior.

This follows #107's accepted treatment of attributed shape text. It does not change paragraph ordering, styling, whitespace, or how genuinely edited text is rebuilt.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

Reproduced the same loaded-text and inline-editor corruption in actual Chromium against React, Vue, Angular, Svelte, and Vanilla on main `9623e258`. All five consume the core table model; React additionally reads raw cell XML. The core correction therefore serves all five, with the additional React fallback correction here.

| Binding | Affected? | Fix |
| --- | --- | --- |
| React | Yes | Core normalization and raw-XML fallback |
| Vue | Yes | Core normalization |
| Angular | Yes | Core normalization |
| Svelte | Yes | Core normalization |
| Vanilla | Yes | Core normalization |

## Testing

- Added regressions to existing test files for attributed runs/fields, exact boundary spaces, empty attributed nodes, primitive compatibility, cloned-XML ordering, source immutability, and actual PPTX save/reload after non-text and genuine text edits.
- Before the fix: six focused core assertions failed, one SDK roundtrip case failed, and two React cases failed. The genuine-edit control passed before and after.
- Independent code review approved the production scope and compatibility with #68 and #107.
- Final core suite: 14,270 passed, 231 skipped. Shared suite: 8,870 passed, 3 skipped. React utility tests: 39 passed. Core and React type checks, changed-file formatting/lint, and the E2E neutrality check passed.
- Framework-neutral Chromium regression passed 5/5: React, Vue, Angular, Svelte, and Vanilla. Checks cover displayed run text, initial editing value, unchanged save/reload retaining the attributed XML and rich spans, actual edit, undo/redo, and edited save/reload.
- Independent browser review reproduced the pre-fix behavior and approved the fixed flow. No native PowerPoint fidelity claim is made; these are library/browser and PPTX XML roundtrip checks.

## Checks run locally

The package-level suites and checks listed above were run with Node 22; this was not a full all-package test or full E2E sweep. The added E2E case ran against every demo project.

## Conventional Commits

- [x] Commit message follows Conventional Commits.
