### PR TITLE
fix(core): read attributed chart axis titles

### DIFF
--- a/e2e/chart-title-runs.spec.ts
+++ b/e2e/chart-title-runs.spec.ts
@@ -22,20 +22,40 @@
  *
  * Run: bunx playwright test chart-title-runs
  */
+import { readFile } from 'node:fs/promises';
+
 import { test, expect } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import JSZip from 'jszip';
 
 import {
 	CHART_TITLE_RUN_1,
 	CHART_TITLE_RUN_2,
 	EDITED_TITLE,
 } from './fixtures/generate-chart-title-runs-fixture';
-import { fixture, inspector, loadDeck, selectElement } from './support/deck';
+import { savePptxViaBackstage } from './save-pptx';
+import {
+	fixture,
+	inspector,
+	loadDeck,
+	resetTabSession,
+	selectElement,
+	slideStage,
+	thumbnail,
+} from './support/deck';
 
 const CHART_FIXTURE = fixture('chart-title-runs.pptx');
 const ENTERED_TITLE = 'Committed with Enter';
 const CANCELLED_TITLE = 'Must not commit';
 const BLURRED_TITLE = 'Committed on blur';
+const CHART_GALLERY_FIXTURE = fixture('chart-gallery.pptx');
+const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
+interface DeckPayload {
+	name: string;
+	mimeType: string;
+	buffer: Buffer;
+}
 
 interface TitleTspan {
 	text: string;
@@ -112,6 +132,97 @@ function collectRuntimeErrors(page: Page): string[] {
 		}
 	});
 	return errors;
+}
+
+const classicAxisTitle =
+	'<c:title><c:tx><c:rich><a:bodyPr/><a:p><a:r><a:t xml:space="preserve">Quarter Axis</a:t></a:r></a:p></c:rich></c:tx><c:overlay val="0"/></c:title>';
+const chartExAxisTitle =
+	'<cx:title><cx:tx><cx:rich><a:bodyPr/><a:p><a:r><a:t xml:space="preserve">Histogram Axis</a:t></a:r></a:p></cx:rich></cx:tx></cx:title>';
+
+/** Add schema-valid attributed classic and ChartEx axis titles to the public gallery in memory. */
+async function attributedAxisDeck(): Promise<DeckPayload> {
+	const zip = await JSZip.loadAsync(await readFile(CHART_GALLERY_FIXTURE));
+	const classicPart = zip.file('ppt/charts/chart1.xml');
+	const chartExPart = zip.file('ppt/charts/chart13.xml');
+	if (!classicPart || !chartExPart) {
+		throw new Error('the chart gallery is missing its classic or ChartEx part');
+	}
+
+	const classicXml = await classicPart.async('string');
+	const classicAnchor = '<c:axPos val="b"/>';
+	if (!classicXml.includes(classicAnchor)) {
+		throw new Error('the classic category-axis insertion point is missing');
+	}
+	zip.file(
+		'ppt/charts/chart1.xml',
+		classicXml.replace(classicAnchor, `${classicAnchor}${classicAxisTitle}`),
+	);
+
+	const chartExXml = await chartExPart.async('string');
+	const dataId = '<cx:dataId val="0"/>';
+	const plotRegionEnd = '</cx:plotAreaRegion>';
+	if (!chartExXml.includes(dataId) || !chartExXml.includes(plotRegionEnd)) {
+		throw new Error('the ChartEx axis insertion points are missing');
+	}
+	const withAxisReferences = chartExXml.replace(
+		dataId,
+		`${dataId}<cx:axisId>71001</cx:axisId><cx:axisId>71002</cx:axisId>`,
+	);
+	const axes = `<cx:axis id="71001"><cx:catScaling/>${chartExAxisTitle}<cx:tickLabels/></cx:axis><cx:axis id="71002"><cx:valScaling/><cx:tickLabels/></cx:axis>`;
+	zip.file(
+		'ppt/charts/chart13.xml',
+		withAxisReferences.replace(plotRegionEnd, `${plotRegionEnd}${axes}`),
+	);
+
+	return {
+		name: 'chart-attributed-axis-titles.pptx',
+		mimeType: PPTX_MIME,
+		buffer: Buffer.from(await zip.generateAsync({ type: 'uint8array' })),
+	};
+}
+
+async function loadAxisDeck(page: Page, deck: DeckPayload | string): Promise<void> {
+	await resetTabSession(page);
+	await page.goto('/');
+	await page.locator('#file-input').setInputFiles(deck);
+	await slideStage(page).waitFor();
+	await page.locator('[data-pptx-viewport] [data-element-id]').first().waitFor();
+}
+
+async function axisChart(page: Page, slideNumber: number): Promise<Locator> {
+	await thumbnail(page, slideNumber).click();
+	const chart = slideStage(page).locator('[aria-roledescription="chart"]').first();
+	await chart.waitFor();
+	await selectElement(page, chart);
+	await expect(inspector(page)).toBeVisible();
+	return chart;
+}
+
+async function visibleInputValues(page: Page): Promise<string[]> {
+	return inspector(page)
+		.locator('input:visible')
+		.evaluateAll((inputs) => inputs.map((input) => input.value));
+}
+
+async function visibleInputWithValue(page: Page, value: string): Promise<Locator> {
+	const inputs = inspector(page).locator('input:visible');
+	for (let index = 0; index < (await inputs.count()); index += 1) {
+		const input = inputs.nth(index);
+		if ((await input.inputValue()) === value) {
+			return input;
+		}
+	}
+	throw new Error(`no visible input has value ${JSON.stringify(value)}`);
+}
+
+async function svgTextCount(chart: Locator, value: string): Promise<number> {
+	const texts = await chart.locator('svg text').allTextContents();
+	return texts.filter((text) => text.trim() === value).length;
+}
+
+async function savedChartXml(path: string, part: string): Promise<string> {
+	const zip = await JSZip.loadAsync(await readFile(path));
+	return (await zip.file(part)?.async('string')) ?? '';
 }
 
 test.describe('chart title rich text (multi-run titles)', () => {
@@ -242,5 +353,66 @@ test.describe('chart title rich text (multi-run titles)', () => {
 			.poll(() => normalizedTitleText(target))
 			.toBe(`${CHART_TITLE_RUN_1}${CHART_TITLE_RUN_2}`);
 		expect(runtimeErrors).toStrictEqual([]);
+	});
+});
+
+test.describe('attributed chart-axis titles', () => {
+	test('renders, inspects, and safely saves attributed axis text', async ({ page }) => {
+		const deck = await attributedAxisDeck();
+		await loadAxisDeck(page, deck);
+
+		let classicChart = await axisChart(page, 1);
+		await expect.poll(() => svgTextCount(classicChart, 'Quarter Axis')).toBe(1);
+		await expect.poll(() => visibleInputValues(page)).toContain('Quarter Axis');
+
+		// ChartEx histogram currently exposes axis titles in the inspector but does
+		// not paint them on the chart surface, so the inspector is the UI contract.
+		await axisChart(page, 13);
+		await expect.poll(() => visibleInputValues(page)).toContain('Histogram Axis');
+
+		const noOpDownload = await savePptxViaBackstage(page);
+		const noOpPath = await noOpDownload.path();
+		expect(noOpPath, 'the browser should retain the no-op PPTX').not.toBeNull();
+		const noOpClassicXml = await savedChartXml(noOpPath!, 'ppt/charts/chart1.xml');
+		const noOpChartExXml = await savedChartXml(noOpPath!, 'ppt/charts/chart13.xml');
+		expect(noOpClassicXml).toContain('<a:t xml:space="preserve">Quarter Axis</a:t>');
+		expect(noOpChartExXml).toContain('<a:t xml:space="preserve">Histogram Axis</a:t>');
+		expect(noOpClassicXml).not.toContain('[object Object]');
+		expect(noOpChartExXml).not.toContain('[object Object]');
+
+		await loadAxisDeck(page, noOpPath!);
+		classicChart = await axisChart(page, 1);
+		await expect.poll(() => svgTextCount(classicChart, 'Quarter Axis')).toBe(1);
+		await expect.poll(() => visibleInputValues(page)).toContain('Quarter Axis');
+		await axisChart(page, 13);
+		await expect.poll(() => visibleInputValues(page)).toContain('Histogram Axis');
+
+		// Exercise the classic axis title's real edit and history path before
+		// saving the dirty chart and reloading the result.
+		classicChart = await axisChart(page, 1);
+		const axisTitle = await visibleInputWithValue(page, 'Quarter Axis');
+		await axisTitle.fill('Edited Axis');
+		await axisTitle.press('Tab');
+		await expect.poll(() => svgTextCount(classicChart, 'Edited Axis')).toBe(1);
+		const undo = page.getByRole('button', { name: 'Undo' });
+		const redo = page.getByRole('button', { name: 'Redo' });
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expect.poll(() => svgTextCount(classicChart, 'Quarter Axis')).toBe(1);
+		await expect(redo).toBeEnabled();
+		await redo.click();
+		await expect.poll(() => svgTextCount(classicChart, 'Edited Axis')).toBe(1);
+
+		const dirtyDownload = await savePptxViaBackstage(page);
+		const dirtyPath = await dirtyDownload.path();
+		expect(dirtyPath, 'the browser should retain the dirty PPTX').not.toBeNull();
+		const dirtyClassicXml = await savedChartXml(dirtyPath!, 'ppt/charts/chart1.xml');
+		expect(dirtyClassicXml).toContain('>Edited Axis</a:t>');
+		expect(dirtyClassicXml).not.toContain('[object Object]');
+
+		await loadAxisDeck(page, dirtyPath!);
+		classicChart = await axisChart(page, 1);
+		await expect.poll(() => svgTextCount(classicChart, 'Edited Axis')).toBe(1);
+		await expect.poll(() => visibleInputValues(page)).toContain('Edited Axis');
 	});
 });

--- a/packages/core/src/__tests__/integration/chart-axis-label-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/chart-axis-label-roundtrip.test.ts
@@ -1,8 +1,12 @@
+import { XMLBuilder, XMLParser } from 'fast-xml-parser';
+import JSZip from 'jszip';
 import { describe, expect, it } from 'vitest';
 
 import { PresentationBuilder } from '../../core/builders/sdk/PresentationBuilder';
 import { PptxHandler } from '../../core/PptxHandler';
+import type { XmlObject } from '../../core/types';
 import type { ChartPptxElement } from '../../core/types/elements';
+import { applyChartAxisTitleToXml } from '../../core/utils/chart-axis-title-serializer';
 
 function chartFrom(slides: Awaited<ReturnType<PptxHandler['load']>>['slides']): ChartPptxElement {
 	const element = slides[0].elements.find((candidate) => candidate.type === 'chart');
@@ -12,7 +16,98 @@ function chartFrom(slides: Awaited<ReturnType<PptxHandler['load']>>['slides']): 
 	return element;
 }
 
+async function buildDeckWithAttributedAxisTitle(): Promise<ArrayBuffer> {
+	const { handler, data, createSlide } = await PresentationBuilder.create();
+	data.slides.push(
+		createSlide('Blank')
+			.addChart(
+				'bar',
+				{ categories: ['Q1', 'Q2'], series: [{ name: 'Revenue', values: [10, 20] }] },
+				{ x: 50, y: 50, width: 500, height: 300 },
+			)
+			.build(),
+	);
+	const zip = await JSZip.loadAsync(await handler.save(data.slides));
+	const path = 'ppt/charts/chart1.xml';
+	const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+	const document = parser.parse(await zip.file(path)!.async('string')) as XmlObject;
+	const chartSpace = document['c:chartSpace'] as XmlObject;
+	const chart = chartSpace['c:chart'] as XmlObject;
+	const plotArea = chart['c:plotArea'] as XmlObject;
+	const categoryAxis = plotArea['c:catAx'] as XmlObject;
+	const valueAxis = plotArea['c:valAx'] as XmlObject;
+	const getLocalName = (key: string) => key.split(':').at(-1)!;
+	applyChartAxisTitleToXml(categoryAxis, 'Category axis', getLocalName);
+	applyChartAxisTitleToXml(valueAxis, 'Value axis', getLocalName);
+	const valueAxisKeys = Object.keys(valueAxis).map(getLocalName);
+	expect(valueAxisKeys.indexOf('title')).toBeGreaterThan(valueAxisKeys.indexOf('axPos'));
+	expect(valueAxisKeys.indexOf('title')).toBeLessThan(valueAxisKeys.indexOf('crossAx'));
+
+	const valueTitle = valueAxis['c:title'] as XmlObject;
+	const valueRich = ((valueTitle['c:tx'] as XmlObject)['c:rich'] as XmlObject)['a:p'] as XmlObject;
+	const valueRun = valueRich['a:r'] as XmlObject;
+	expect(valueRun['a:t']).toBe('Value axis');
+	valueRun['a:t'] = { '@_xml:space': 'preserve', '#text': ' Value axis ' };
+	zip.file(
+		path,
+		new XMLBuilder({ ignoreAttributes: false, attributeNamePrefix: '@_' }).build(document),
+	);
+	return (await zip.generateAsync({ type: 'uint8array' })).buffer as ArrayBuffer;
+}
+
 describe('chartML axis label formatting round-trip', () => {
+	it('preserves an attributed axis title through an unrelated save', async () => {
+		let handler = new PptxHandler();
+		let loaded = await handler.load(await buildDeckWithAttributedAxisTitle());
+		let chart = chartFrom(loaded.slides);
+		const categoryAxis = chart.chartData!.axes?.find((axis) => axis.axisType === 'catAx');
+		const valueAxis = chart.chartData!.axes?.find((axis) => axis.axisType === 'valAx');
+		expect(categoryAxis?.titleText).toBe('Category axis');
+		expect(valueAxis?.titleText).toBe(' Value axis ');
+
+		chart.x += 1;
+		loaded.slides[0].isDirty = true;
+		const saved = await handler.save(loaded.slides);
+		const zip = await JSZip.loadAsync(saved);
+		const chartXml = await zip.file('ppt/charts/chart1.xml')!.async('string');
+		expect(chartXml).toContain('<a:t xml:space="preserve"> Value axis </a:t>');
+		expect(chartXml).toContain('<a:t>Category axis</a:t>');
+		expect(chartXml).not.toContain('[object Object]');
+
+		handler = new PptxHandler();
+		loaded = await handler.load(saved.buffer as ArrayBuffer);
+		chart = chartFrom(loaded.slides);
+		expect(chart.chartData!.axes?.find((axis) => axis.axisType === 'catAx')?.titleText).toBe(
+			'Category axis',
+		);
+		expect(chart.chartData!.axes?.find((axis) => axis.axisType === 'valAx')?.titleText).toBe(
+			' Value axis ',
+		);
+	});
+
+	it('still replaces an attributed axis title after a genuine title edit', async () => {
+		const handler = new PptxHandler();
+		const loaded = await handler.load(await buildDeckWithAttributedAxisTitle());
+		const valueAxis = chartFrom(loaded.slides).chartData!.axes?.find(
+			(axis) => axis.axisType === 'valAx',
+		);
+		expect(valueAxis).toBeDefined();
+		valueAxis!.titleText = 'Edited value axis';
+
+		loaded.slides[0].isDirty = true;
+		const saved = await handler.save(loaded.slides);
+		const reloaded = await new PptxHandler().load(saved.buffer as ArrayBuffer);
+		expect(
+			chartFrom(reloaded.slides).chartData!.axes?.find((axis) => axis.axisType === 'valAx')
+				?.titleText,
+		).toBe('Edited value axis');
+		const zip = await JSZip.loadAsync(saved);
+		const chartXml = await zip.file('ppt/charts/chart1.xml')!.async('string');
+		expect(chartXml).toContain('Edited value axis');
+		expect(chartXml).not.toContain(' Value axis ');
+		expect(chartXml).not.toContain('[object Object]');
+	});
+
 	it('generates, parses, edits, and dirty-saves category-axis label controls', async () => {
 		const { handler, data, createSlide } = await PresentationBuilder.create();
 		data.slides.push(

--- a/packages/core/src/core/utils/chart-axis-parser.test.ts
+++ b/packages/core/src/core/utils/chart-axis-parser.test.ts
@@ -50,6 +50,46 @@ const getLocalName = (key: string): string => {
 };
 
 describe('parseChartAxes', () => {
+	it.each(['catAx', 'valAx', 'dateAx', 'serAx'])(
+		'reads attributed title runs and fields on %s without changing whitespace',
+		(axisType) => {
+			const plotArea: XmlObject = {
+				[`c:${axisType}`]: {
+					'c:title': {
+						'c:tx': {
+							'c:rich': {
+								'a:p': [
+									{ 'a:r': { 'a:t': { '#text': ' Units ', '@_xml:space': 'preserve' } } },
+									{ 'a:fld': { 'a:t': { '#text': ' field ', '@_xml:space': 'preserve' } } },
+									{ 'a:r': { 'a:t': 'suffix' } },
+								],
+							},
+						},
+					},
+				},
+			};
+			const before = structuredClone(plotArea);
+			const [axis] = parseChartAxes(plotArea, xmlLookup, colorParser, getLocalName);
+			expect(axis.titleText).toBe(' Units  field suffix');
+			expect(plotArea).toStrictEqual(before);
+		},
+	);
+
+	it.each([
+		[{ '@_xml:space': 'preserve' }, ''],
+		[{ '#text': '  ', '@_xml:space': 'preserve' }, '  '],
+		[0, '0'],
+		[false, 'false'],
+		['Plain', 'Plain'],
+	] as const)('reads an axis title leaf without object coercion', (value, expected) => {
+		const plotArea = {
+			'c:valAx': { 'c:title': { 'c:tx': { 'c:rich': { 'a:p': { 'a:r': { 'a:t': value } } } } } },
+		};
+		expect(parseChartAxes(plotArea, xmlLookup, colorParser, getLocalName)[0].titleText).toBe(
+			expected,
+		);
+	});
+
 	it('should parse category and value axes', () => {
 		const plotArea: XmlObject = {
 			'c:catAx': {

--- a/packages/core/src/core/utils/chart-axis-parser.ts
+++ b/packages/core/src/core/utils/chart-axis-parser.ts
@@ -4,6 +4,7 @@ import { parseChartAxisLabelFormatting } from './chart-axis-label-formatting';
 import { parseChartAxisScaling } from './chart-axis-scaling';
 import { parseChartDateAxisUnits } from './chart-date-axis';
 import { parseShapeProps } from './chart-series-detail-parser';
+import { collectAllText } from './chart-title-xml-ops';
 
 export { upsertChartAxisChild } from './chart-axis-scaling';
 
@@ -83,7 +84,6 @@ function parseSingleAxis(
 		}
 	}
 
-	// Number format
 	const numFmtNode = xmlLookup.getChildByLocalName(axisNode, 'numFmt');
 	if (numFmtNode) {
 		const formatCode = String(numFmtNode['@_formatCode'] || '').trim();
@@ -95,11 +95,10 @@ function parseSingleAxis(
 		}
 	}
 
-	// Axis title
 	const titleNode = xmlLookup.getChildByLocalName(axisNode, 'title');
 	if (titleNode) {
 		const texts: string[] = [];
-		collectAxisTextValues(titleNode, texts);
+		collectAllText(titleNode, getLocalName, texts);
 		if (texts.length > 0) {
 			result.titleText = texts.join('');
 		}
@@ -298,26 +297,4 @@ export function parseChart3DSurfaces(
 	}
 
 	return result;
-}
-
-/** Recursively collect text values from axis title nodes. */
-function collectAxisTextValues(node: XmlObject, results: string[]): void {
-	if (node['a:t'] !== undefined) {
-		results.push(String(node['a:t']));
-	}
-	for (const key of Object.keys(node)) {
-		if (key.startsWith('@_')) {
-			continue;
-		}
-		const child = node[key];
-		if (Array.isArray(child)) {
-			for (const item of child) {
-				if (item && typeof item === 'object') {
-					collectAxisTextValues(item as XmlObject, results);
-				}
-			}
-		} else if (child && typeof child === 'object') {
-			collectAxisTextValues(child as XmlObject, results);
-		}
-	}
 }

--- a/packages/core/src/core/utils/chart-cx-axis-parser.test.ts
+++ b/packages/core/src/core/utils/chart-cx-axis-parser.test.ts
@@ -56,6 +56,27 @@ const xmlLookup = {
 };
 
 describe('parseCxAxes (C2-G7)', () => {
+	it('reads attributed axis and display-unit titles through the same title resolver', () => {
+		const rich = (text: string): XmlObject => ({
+			'cx:tx': {
+				'cx:rich': { 'a:p': { 'a:r': { 'a:t': { '#text': text, '@_xml:space': 'preserve' } } } },
+			},
+		});
+		const [axis] = parseCxAxes(
+			{
+				'cx:axis': {
+					'@_id': '1',
+					'cx:valScaling': {},
+					'cx:title': rich(' Units '),
+					'cx:units': { '@_unit': '1000', 'cx:unitsLabel': rich(' Thousands ') },
+				},
+			},
+			xmlLookup,
+		)!;
+		expect(axis.titleText).toBe(' Units ');
+		expect(axis.displayUnitsLabel?.text).toBe(' Thousands ');
+	});
+
 	it('returns undefined when the plotArea has no cx:axis siblings', () => {
 		expect(parseCxAxes({ 'cx:plotAreaRegion': {} }, xmlLookup)).toBeUndefined();
 	});
@@ -185,6 +206,39 @@ describe('parseCxAxes (C2-G7)', () => {
 });
 
 describe('resolveCxTitleText', () => {
+	it('reads attributed text while retaining the existing paragraph join policy', () => {
+		const title: XmlObject = {
+			'cx:tx': {
+				'cx:rich': {
+					'a:p': [
+						{ 'a:r': { 'a:t': { '#text': ' Units ', '@_xml:space': 'preserve' } } },
+						{ 'a:fld': { 'a:t': { '#text': ' field ', '@_xml:space': 'preserve' } } },
+						{ 'a:r': { 'a:t': 'suffix' } },
+					],
+				},
+			},
+		};
+		const before = structuredClone(title);
+		expect(resolveCxTitleText(title, xmlLookup)).toBe(' Units  field suffix');
+		expect(title).toStrictEqual(before);
+	});
+
+	it.each([
+		[{ '@_xml:space': 'preserve' }, ''],
+		[{ '#text': '  ', '@_xml:space': 'preserve' }, '  '],
+		[0, '0'],
+		[false, 'false'],
+		['', ''],
+	] as const)('prefers present rich text over a cached fallback', (value, expected) => {
+		const title = {
+			'cx:tx': {
+				'cx:rich': { 'a:p': { 'a:r': { 'a:t': value } } },
+				'cx:txData': { 'cx:v': 'Cached title' },
+			},
+		};
+		expect(resolveCxTitleText(title, xmlLookup)).toBe(expected);
+	});
+
 	it('returns undefined for a missing title node', () => {
 		expect(resolveCxTitleText(undefined, xmlLookup)).toBeUndefined();
 	});

--- a/packages/core/src/core/utils/chart-cx-axis-parser.ts
+++ b/packages/core/src/core/utils/chart-cx-axis-parser.ts
@@ -18,6 +18,7 @@
 import type { PptxChartAxisFormatting, PptxChartDisplayUnitsLabel, XmlObject } from '../types';
 import type { ColorParserLike, XmlLookupLike } from './chart-cx-parser';
 import { parseShapeProps } from './chart-series-detail-parser';
+import { collectAllText } from './chart-title-xml-ops';
 
 /** The subset of font fields a `cx:txPr`/`cx:unitsLabel` run reads onto. */
 interface CxFontTarget {
@@ -34,25 +35,6 @@ function safeInt(val: unknown): number | undefined {
 	return Number.isFinite(n) ? n : undefined;
 }
 
-/** Recursively collect `a:t` run text (mirrors the walker other cx: text readers use). */
-function collectRunText(node: XmlObject, out: string[]): void {
-	for (const [key, child] of Object.entries(node)) {
-		if (key.startsWith('@_')) {
-			continue;
-		}
-		if (key === 'a:t' || key.endsWith(':t')) {
-			out.push(String(child));
-			continue;
-		}
-		const items = Array.isArray(child) ? child : [child];
-		for (const item of items) {
-			if (item && typeof item === 'object') {
-				collectRunText(item as XmlObject, out);
-			}
-		}
-	}
-}
-
 /**
  * Resolve `cx:title` text: rich run text (`cx:tx/cx:rich`, `a:t` runs) when
  * present, otherwise the linked-cell cached string (`cx:tx/cx:txData/cx:v`),
@@ -66,7 +48,7 @@ export function resolveCxTitleText(
 		return undefined;
 	}
 	const texts: string[] = [];
-	collectRunText(titleNode, texts);
+	collectAllText(titleNode, (key) => key.split(':').at(-1) ?? key, texts);
 	if (texts.length > 0) {
 		return texts.join('');
 	}

--- a/packages/core/src/core/utils/chart-cx-parser.test.ts
+++ b/packages/core/src/core/utils/chart-cx-parser.test.ts
@@ -643,4 +643,28 @@ describe('parseCxChartSeries chartData (axes/title) wiring', () => {
 			'Q3 Sales',
 		);
 	});
+
+	it('reads an attributed chart title when a chartRoot is supplied', () => {
+		const plotArea: XmlObject = {
+			'cx:plotAreaRegion': {
+				'cx:series': { 'cx:data': { 'cx:numDim': { 'cx:lvl': { 'cx:pt': [{ 'cx:v': '1' }] } } } },
+			},
+		};
+		const chartRoot: XmlObject = {
+			'cx:title': {
+				'cx:tx': {
+					'cx:rich': {
+						'a:p': {
+							'a:r': {
+								'a:t': { '#text': ' Q3 Sales ', '@_xml:space': 'preserve' },
+							},
+						},
+					},
+				},
+			},
+		};
+		expect(parseCxChartSeries(plotArea, xmlLookup, undefined, chartRoot)?.chartData?.title).toBe(
+			' Q3 Sales ',
+		);
+	});
 });


### PR DESCRIPTION
## What does this change?

Valid attributed axis-title text, such as `<a:t xml:space="preserve"> Value axis </a:t>`, is currently converted to `[object Object]` by the classic and ChartEx text walkers. The wrong classic axis title can also be written back on a dirty save.

Reuse the existing `collectAllText` chart helper and remove the duplicate walkers. It already handles attributed text, exact whitespace, empty rich leaves, and primitive values. No new parsing abstraction or dependency on the table-text change is needed.

## Type of change

- [x] Bug fix (non-breaking)

## Scope and existing behavior

- Classic axis titles and ChartEx axis titles use the corrected readers.
- The existing ChartEx resolver also supplies main chart titles and units labels, so those receive the same correction and explicit tests.
- Existing paragraph joining and rich-text-versus-cached-text precedence stay unchanged. A present empty attributed run remains an empty rich title, not a request to use cached text.
- This does not add ChartEx axis-title edit persistence, which the current save path does not support. Classic multi-run axis-title save behavior is also separate; the dirty-save regression isolates a single attributed run.

## Testing

Independent source review approved the existing-helper approach and checked prior chart parity/title work. Thirteen intended parser/integration assertions failed before the change. The fixed focused run passed 74 tests.

- Core suite: 14,274 passed, 231 skipped.
- Shared suite: 8,870 passed, 3 skipped.
- Core type check, changed-file formatting/lint, and framework-neutral E2E contract check passed.
- Existing test files cover attributed runs/fields, whitespace-only and empty rich text, numeric/boolean controls, all four classic axis types, ChartEx title consumers, source immutability, unrelated dirty save, and genuine classic title edit/reload.

## Cross-binding parity

Actual browser checks found classic chart-axis corruption across React, Vue, Angular, Svelte, and Vanilla, all consuming the same parsed axis model. ChartEx title values were also corrupted in each inspector. The histogram renderer currently does not paint ChartEx axis titles; this parsing fix does not add that separate rendering capability.

| Binding | Classic axis display and inspector | ChartEx axis inspector |
| --- | --- | --- |
| React | Affected; core fix | Affected; core fix |
| Vue | Affected; core fix | Affected; core fix |
| Angular | Affected; core fix | Affected; core fix |
| Svelte | Affected; core fix | Affected; core fix |
| Vanilla | Affected; core fix | Affected; core fix |

The final framework-neutral browser case passed in all five bindings (5 passed, 0 failed, 0 flaky). It checks classic rendered titles and inspector values, ChartEx inspector values, no-op save/reload, actual classic axis-title editing, Undo/Redo, and dirty save/reload. These are Chromium and PPTX XML roundtrip checks, not native PowerPoint fidelity validation. Full core/shared suites and the selected all-five E2E case were run, not a full all-package/all-E2E sweep.

## Conventional Commits

- [x] Commit message follows Conventional Commits.
