### PR TITLE
fix(shared): render edited single-run chart titles

### DIFF
--- a/e2e/chart-title-runs.spec.ts
+++ b/e2e/chart-title-runs.spec.ts
@@ -22,10 +22,10 @@
  *
  * Run: bunx playwright test chart-title-runs
  */
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 
 import { test, expect } from '@playwright/test';
-import type { Locator, Page } from '@playwright/test';
+import type { Locator, Page, TestInfo } from '@playwright/test';
 import JSZip from 'jszip';
 
 import {
@@ -49,6 +49,13 @@ const ENTERED_TITLE = 'Committed with Enter';
 const CANCELLED_TITLE = 'Must not commit';
 const BLURRED_TITLE = 'Committed on blur';
 const CHART_GALLERY_FIXTURE = fixture('chart-gallery.pptx');
+const SINGLE_RUN_TITLE = 'Clustered Bar';
+const EDITED_SINGLE_RUN_TITLE = 'Edited Chart Title';
+const ON_CANVAS_TITLE = 'On-canvas Chart Title';
+const TITLE_RUN_XML = '<a:r><a:t>Clustered Bar</a:t></a:r>';
+const STYLED_TITLE_RUN_XML =
+	'<a:r><a:rPr lang="fr-FR" sz="1800" b="1"><a:solidFill><a:schemeClr val="accent5"/></a:solidFill><a:latin typeface="+mj-lt"/></a:rPr><a:t>Clustered Bar</a:t></a:r>';
+
 const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
 
 interface DeckPayload {
@@ -61,6 +68,8 @@ interface TitleTspan {
 	text: string;
 	fontWeight: string;
 	fontStyle: string;
+	fontSize: string;
+	fontFamily: string;
 	fill: string;
 }
 
@@ -78,6 +87,8 @@ async function titleTspans(page: Page): Promise<TitleTspan[]> {
 				text: (node.textContent ?? '').trim(),
 				fontWeight: style.fontWeight,
 				fontStyle: style.fontStyle,
+				fontSize: style.fontSize,
+				fontFamily: style.fontFamily,
 				fill: style.fill,
 			};
 		});
@@ -132,6 +143,26 @@ function collectRuntimeErrors(page: Page): string[] {
 		}
 	});
 	return errors;
+}
+
+async function styledSingleRunDeck(testInfo: TestInfo): Promise<string> {
+	const zip = await JSZip.loadAsync(await readFile(CHART_GALLERY_FIXTURE));
+	const chartPart = zip.file('ppt/charts/chart1.xml');
+	if (!chartPart) {
+		throw new Error('the chart gallery is missing chart1.xml');
+	}
+	const chartXml = await chartPart.async('string');
+	if (!chartXml.includes(TITLE_RUN_XML)) {
+		throw new Error('the chart gallery single-run title changed');
+	}
+	zip.file('ppt/charts/chart1.xml', chartXml.replace(TITLE_RUN_XML, STYLED_TITLE_RUN_XML));
+	const outputPath = testInfo.outputPath('styled-single-run-title.pptx');
+	await writeFile(outputPath, await zip.generateAsync({ type: 'uint8array' }));
+	return outputPath;
+}
+
+function chartTitleInput(page: Page) {
+	return inspector(page).getByLabel('Title', { exact: true }).locator('visible=true').first();
 }
 
 const classicAxisTitle =
@@ -220,7 +251,7 @@ async function svgTextCount(chart: Locator, value: string): Promise<number> {
 	return texts.filter((text) => text.trim() === value).length;
 }
 
-async function savedChartXml(path: string, part: string): Promise<string> {
+async function savedChartXml(path: string, part = 'ppt/charts/chart1.xml'): Promise<string> {
 	const zip = await JSZip.loadAsync(await readFile(path));
 	return (await zip.file(part)?.async('string')) ?? '';
 }
@@ -353,6 +384,145 @@ test.describe('chart title rich text (multi-run titles)', () => {
 			.poll(() => normalizedTitleText(target))
 			.toBe(`${CHART_TITLE_RUN_1}${CHART_TITLE_RUN_2}`);
 		expect(runtimeErrors).toStrictEqual([]);
+	});
+
+	test('editing a styled single-run title refreshes without rebuilding its run', async ({
+		page,
+	}, testInfo) => {
+		const deck = await styledSingleRunDeck(testInfo);
+		await loadDeck(page, deck);
+		const chart = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('[aria-roledescription="chart"]')
+			.first();
+		await chart.waitFor();
+		await selectElement(page, chart);
+		await expect(inspector(page)).toBeVisible();
+
+		const titleInput = chartTitleInput(page);
+		await expect(titleInput).toHaveValue(SINGLE_RUN_TITLE);
+		const [initialSpan] = await titleTspans(page);
+		expect(initialSpan.text).toBe(SINGLE_RUN_TITLE);
+		expect(Number(initialSpan.fontWeight)).toBeGreaterThanOrEqual(700);
+
+		await titleInput.fill(EDITED_SINGLE_RUN_TITLE);
+		await titleInput.press('Tab');
+		await expect(titleInput).toHaveValue(EDITED_SINGLE_RUN_TITLE);
+		await expect
+			.poll(async () => await titleTspans(page))
+			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+
+		const download = await savePptxViaBackstage(page);
+		const downloadPath = await download.path();
+		expect(downloadPath, 'the browser should retain the edited PPTX').not.toBeNull();
+		const chartXml = await savedChartXml(downloadPath!);
+		expect(chartXml).toContain(`<a:t>${EDITED_SINGLE_RUN_TITLE}</a:t>`);
+		expect(chartXml).toContain('lang="fr-FR"');
+		expect(chartXml).toContain('sz="1800"');
+		expect(chartXml).toContain('b="1"');
+		expect(chartXml).toMatch(/<a:schemeClr\b[^>]*\bval="accent5"/u);
+		expect(chartXml).toMatch(/<a:latin\b[^>]*\btypeface="\+mj-lt"/u);
+
+		await loadDeck(page, downloadPath!);
+		const reloadedChart = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('[aria-roledescription="chart"]')
+			.first();
+		await reloadedChart.waitFor();
+		await selectElement(page, reloadedChart);
+		await expect(chartTitleInput(page)).toHaveValue(EDITED_SINGLE_RUN_TITLE);
+		await expect
+			.poll(async () => await titleTspans(page))
+			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+	});
+
+	test('single-run title edits stay in sync through undo, redo, save, and reload', async ({
+		page,
+	}) => {
+		await loadDeck(page, CHART_GALLERY_FIXTURE);
+		const chart = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('[aria-roledescription="chart"]')
+			.first();
+		await chart.waitFor();
+		await selectElement(page, chart);
+		await expect(inspector(page)).toBeVisible();
+
+		const titleInput = chartTitleInput(page);
+		await expect(titleInput).toHaveValue(SINGLE_RUN_TITLE);
+		const [initialSpan] = await titleTspans(page);
+		expect(initialSpan.text).toBe(SINGLE_RUN_TITLE);
+
+		await titleInput.fill(EDITED_SINGLE_RUN_TITLE);
+		await titleInput.press('Tab');
+		await expect(titleInput).toHaveValue(EDITED_SINGLE_RUN_TITLE);
+		await expect
+			.poll(async () => await titleTspans(page))
+			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+
+		const undo = page.getByRole('button', { name: 'Undo' });
+		const redo = page.getByRole('button', { name: 'Redo' });
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await selectElement(page, chart);
+		await expect(chartTitleInput(page)).toHaveValue(SINGLE_RUN_TITLE);
+		await expect.poll(async () => await titleTspans(page)).toStrictEqual([initialSpan]);
+		await expect(redo).toBeEnabled();
+		await redo.click();
+		await selectElement(page, chart);
+		await expect(chartTitleInput(page)).toHaveValue(EDITED_SINGLE_RUN_TITLE);
+		await expect
+			.poll(async () => await titleTspans(page))
+			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+
+		const download = await savePptxViaBackstage(page);
+		const downloadPath = await download.path();
+		expect(downloadPath, 'the browser should retain the edited PPTX').not.toBeNull();
+		expect(await savedChartXml(downloadPath!)).toContain(`<a:t>${EDITED_SINGLE_RUN_TITLE}</a:t>`);
+
+		await loadDeck(page, downloadPath!);
+		const reloadedChart = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('[aria-roledescription="chart"]')
+			.first();
+		await reloadedChart.waitFor();
+		await selectElement(page, reloadedChart);
+		await expect(chartTitleInput(page)).toHaveValue(EDITED_SINGLE_RUN_TITLE);
+		await expect
+			.poll(async () => await titleTspans(page))
+			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+	});
+
+	test('editing a single-run title directly on the canvas refreshes immediately', async ({
+		page,
+	}) => {
+		await loadDeck(page, CHART_GALLERY_FIXTURE);
+		const chart = page
+			.locator('[aria-roledescription="slide"]')
+			.first()
+			.locator('[aria-roledescription="chart"]')
+			.first();
+		await chart.waitFor();
+		await selectElement(page, chart);
+		const title = chart.locator('[data-chart-part="title"]');
+		const titleBox = await title.boundingBox();
+		expect(titleBox, 'the rendered title should have a hit target').not.toBeNull();
+		await title.dblclick({
+			position: { x: Math.max(1, titleBox!.width / 8), y: titleBox!.height / 2 },
+		});
+
+		const inlineTitle = chart.locator('input:visible').first();
+		await expect(inlineTitle).toBeVisible();
+		await expect(inlineTitle).toHaveValue(SINGLE_RUN_TITLE);
+		await inlineTitle.fill(ON_CANVAS_TITLE);
+		await inlineTitle.press('Enter');
+		await expect
+			.poll(async () => (await titleTspans(page)).map((span) => span.text))
+			.toStrictEqual([ON_CANVAS_TITLE]);
 	});
 });
 

--- a/packages/angular/src/viewer/chart-title-runs.test.ts
+++ b/packages/angular/src/viewer/chart-title-runs.test.ts
@@ -47,6 +47,26 @@ describe('chartRendererComponent data source: chart title rich text (titleRunSpa
 		]);
 	});
 
+	it('uses an edited flat title as the text of its existing single styled run', () => {
+		const element = chartElement({
+			chartType: 'bar',
+			title: 'Annual Summary',
+			categories: ['Q1'],
+			series: [{ name: 'Revenue', values: [10] }],
+			style: { hasTitle: true },
+			titleRuns: [{ text: 'Old title', italic: true }],
+		});
+		expect(buildChartViewModel(element).titleRunSpans).toStrictEqual([
+			{
+				text: 'Annual Summary',
+				fontSize: 12,
+				fontWeight: 600,
+				fontStyle: 'italic',
+				fill: '#1e293b',
+			},
+		]);
+	});
+
 	it('leaves vm.titleRunSpans undefined when the title has no typed runs', () => {
 		const element = chartElement({
 			chartType: 'bar',

--- a/packages/core/src/__tests__/integration/chart-title-runs-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/chart-title-runs-roundtrip.test.ts
@@ -7,6 +7,7 @@
  * round-trips, and that the flat `title` path still works when `titleRuns`
  * is absent.
  */
+import JSZip from 'jszip';
 import { describe, it, expect, beforeAll } from 'vitest';
 
 import { PresentationBuilder } from '../../core/builders/sdk/PresentationBuilder';
@@ -40,6 +41,23 @@ async function buildSeed(): Promise<ArrayBuffer> {
 	return seed.buffer.slice(seed.byteOffset, seed.byteOffset + seed.byteLength) as ArrayBuffer;
 }
 
+async function buildStyledSingleRunSeed(): Promise<ArrayBuffer> {
+	const zip = await JSZip.loadAsync(await buildSeed());
+	const path = 'ppt/charts/chart1.xml';
+	const part = zip.file(path);
+	if (!part) {
+		throw new Error(`missing part ${path}`);
+	}
+	const xml = await part.async('string');
+	const plainRun = '<a:r><a:t>Q4 Sales</a:t></a:r>';
+	const styledRun =
+		'<a:r><a:rPr lang="en-AU" altLang="fr-FR" dirty="0"><a:solidFill><a:schemeClr val="accent2"><a:lumMod val="75000"/></a:schemeClr></a:solidFill><a:latin typeface="+mj-lt"/></a:rPr><a:t>Q4 Sales</a:t></a:r>';
+	expect(xml, 'styled-title fixture precondition').toContain(plainRun);
+	zip.file(path, xml.replace(plainRun, styledRun));
+	const bytes = await zip.generateAsync({ type: 'uint8array' });
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
 describe('chart title rich text (titleRuns): load -> edit -> save -> re-parse', () => {
 	it('parses a single-run authored title into a matching one-entry titleRuns', async () => {
 		const handler = new PptxHandler();
@@ -47,6 +65,35 @@ describe('chart title rich text (titleRuns): load -> edit -> save -> re-parse', 
 		const chart = findChart(data);
 		expect(chart.chartData?.title).toBe('Q4 Sales');
 		expect(chart.chartData?.titleRuns).toStrictEqual([{ text: 'Q4 Sales' }]);
+	});
+
+	it('keeps unmodeled single-run formatting when only the flat title is edited', async () => {
+		const handler = new PptxHandler();
+		const data = await handler.load(await buildStyledSingleRunSeed());
+		const chart = findChart(data);
+		expect(chart.chartData?.title).toBe('Q4 Sales');
+		expect(chart.chartData?.titleRuns?.map((run) => run.text)).toStrictEqual(['Q4 Sales']);
+
+		chart.chartData!.title = 'Annual Summary';
+		expect(chart.chartData!.titleRuns?.[0]?.text).toBe('Q4 Sales');
+		data.slides[0]!.isDirty = true;
+		const saved = await handler.save(data.slides);
+		const zip = await JSZip.loadAsync(saved);
+		const xml = await zip.file('ppt/charts/chart1.xml')!.async('string');
+		expect(xml).toContain('lang="en-AU"');
+		expect(xml).toContain('altLang="fr-FR"');
+		expect(xml).toContain('dirty="0"');
+		expect(xml).toContain('<a:schemeClr val="accent2"><a:lumMod val="75000">');
+		expect(xml).toContain('<a:latin typeface="+mj-lt">');
+		expect(xml).toContain('<a:t>Annual Summary</a:t>');
+		expect(xml).not.toContain('<a:t>Q4 Sales</a:t>');
+
+		const reloaded = await new PptxHandler().load(saved.buffer as ArrayBuffer);
+		const reloadedChart = findChart(reloaded);
+		expect(reloadedChart.chartData?.title).toBe('Annual Summary');
+		expect(reloadedChart.chartData?.titleRuns?.map((run) => run.text)).toStrictEqual([
+			'Annual Summary',
+		]);
 	});
 
 	describe('editing titleRuns to two differently-styled runs', () => {

--- a/packages/react/src/viewer/utils/chart-view-model-render.test.tsx
+++ b/packages/react/src/viewer/utils/chart-view-model-render.test.tsx
@@ -295,6 +295,25 @@ describe('renderChartViewModel: chart title rich text (titleRunSpans)', () => {
 		expect(html).toContain('font-style="italic"');
 	});
 
+	it('renders an edited flat title through its existing single styled run', () => {
+		const element = chartElement({
+			chartType: 'bar',
+			title: 'Annual Summary',
+			categories: ['Q1'],
+			series: [{ name: 'Revenue', values: [10] }],
+			style: { hasTitle: true },
+			titleRuns: [{ text: 'Old title', italic: true }],
+		});
+		const vm = buildChartViewModel(element);
+		expect(vm.titleRunSpans?.[0]).toMatchObject({
+			text: 'Annual Summary',
+			fontStyle: 'italic',
+		});
+		const html = renderToStaticMarkup(renderChartViewModel('c1', vm));
+		expect(html).toContain('>Annual Summary</tspan>');
+		expect(html).not.toContain('>Old title</tspan>');
+	});
+
 	it('falls back to a flat text node when the title has no typed runs', () => {
 		const element = chartElement({
 			chartType: 'bar',

--- a/packages/shared/src/render/chart-title-runs.test.ts
+++ b/packages/shared/src/render/chart-title-runs.test.ts
@@ -1,4 +1,5 @@
-import type { PptxChartData } from 'pptx-viewer-core';
+import type { ChartPptxElement, PptxChartData } from 'pptx-viewer-core';
+import { setChartTitle } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import { translationsEn } from '../i18n/translations-en';
@@ -46,6 +47,69 @@ describe('resolveChartTitleRunSpans', () => {
 		const spans = resolveChartTitleRunSpans(data);
 		expect(spans).toHaveLength(1);
 		expect(spans![0]).toMatchObject({ text: 'Sales Q1', fontStyle: 'italic' });
+	});
+
+	it('renders a title-only edit with the single run styling without mutating its saved metadata', () => {
+		const data = chart({
+			titleRuns: [{ text: 'Sales Q1', bold: true, italic: true, fontSize: 20, color: '#FF0000' }],
+			style: { titleFontFamily: 'Georgia' },
+		});
+		const original = structuredClone(data);
+		const edited = { ...data, ...collapseChartTitleRunsForEdit(data, 'Updated sales') };
+		expect(resolveChartTitleRunSpans(edited)).toStrictEqual([
+			{
+				text: 'Updated sales',
+				fontSize: 20 * (4 / 3),
+				fontWeight: 700,
+				fontStyle: 'italic',
+				fill: '#FF0000',
+				fontFamily: 'Georgia',
+			},
+		]);
+		expect(data).toStrictEqual(original);
+		expect(edited.titleRuns).toBe(data.titleRuns);
+	});
+
+	it.each([
+		['API title', 'API title'],
+		['', ''],
+		[undefined, 'Sales Q1'],
+	])('resolves a single run with flat title %s', (title, expected) => {
+		const data = chart({ title, titleRuns: [{ text: 'Sales Q1', italic: true }] });
+		expect(resolveChartTitleRunSpans(data)?.[0]).toMatchObject({
+			text: expected,
+			fontStyle: 'italic',
+		});
+	});
+
+	it('does not replace individual multi-run text with the flat first-run title', () => {
+		const data = chart({
+			title: 'Sales ',
+			titleRuns: [
+				{ text: 'Sales ', bold: true },
+				{ text: 'Q1', italic: true },
+			],
+		});
+		expect(resolveChartTitleRunSpans(data)?.map((run) => run.text)).toStrictEqual(['Sales ', 'Q1']);
+		expect(resolveChartTitleRunSpans(chart({ titleRuns: [] }))).toBeUndefined();
+	});
+
+	it('renders a public SDK title-only update without rewriting the single run', () => {
+		const element: ChartPptxElement = {
+			id: 'chart',
+			type: 'chart',
+			x: 0,
+			y: 0,
+			width: 500,
+			height: 300,
+			chartData: chart({ titleRuns: [{ text: 'Sales Q1', bold: true }] }),
+		};
+		setChartTitle(element, 'Annual sales');
+		expect(resolveChartTitleRunSpans(element.chartData)?.[0]).toMatchObject({
+			text: 'Annual sales',
+			fontWeight: 700,
+		});
+		expect(element.chartData?.titleRuns?.[0]?.text).toBe('Sales Q1');
 	});
 });
 

--- a/packages/shared/src/render/chart-title-runs.ts
+++ b/packages/shared/src/render/chart-title-runs.ts
@@ -52,7 +52,8 @@ export interface ChartTitleRunSpan {
  * run still resolves to a one-element array: this lets a per-run override
  * (e.g. italic on the title's only run) render even when
  * `resolveChartTitleTextStyle`'s coarser `chartData.style.titleFont*` cascade
- * does not carry it.
+ * does not carry it. Its text follows the flat title so single-run edits
+ * render immediately while core retains the original run for lossless save.
  */
 export function resolveChartTitleRunSpans(
 	chartData: PptxChartData | undefined,
@@ -63,7 +64,7 @@ export function resolveChartTitleRunSpans(
 	}
 	const base = resolveChartTitleTextStyle(chartData);
 	return runs.map((run) => ({
-		text: run.text,
+		text: runs.length === 1 ? (chartData?.title ?? run.text) : run.text,
 		fontSize: run.fontSize !== undefined ? chartFontPx(run.fontSize) : base.fontSize,
 		fontWeight: run.bold !== undefined ? (run.bold ? 700 : 400) : base.fontWeight,
 		...(run.italic ? { fontStyle: 'italic' as const } : {}),

--- a/packages/svelte/src/viewer/components/ChartView.chart-title-runs.test.ts
+++ b/packages/svelte/src/viewer/components/ChartView.chart-title-runs.test.ts
@@ -65,6 +65,23 @@ describe('chartView: chart title rich text (titleRunSpans)', () => {
 		expect(tspans[1].getAttribute('font-style')).toBe('italic');
 	});
 
+	it('renders an edited flat title through its existing single styled run', () => {
+		const target = render(
+			chartElement({
+				chartType: 'bar',
+				title: 'Annual Summary',
+				categories: ['Q1'],
+				series: [{ name: 'Revenue', values: [10] }],
+				style: { hasTitle: true },
+				titleRuns: [{ text: 'Old title', italic: true }],
+			}),
+		);
+		const tspans = Array.from(target.querySelectorAll('tspan'));
+		expect(tspans).toHaveLength(1);
+		expect(tspans[0].textContent).toBe('Annual Summary');
+		expect(tspans[0].getAttribute('font-style')).toBe('italic');
+	});
+
 	it('falls back to a flat text node when the title has no typed runs', () => {
 		const target = render(
 			chartElement({

--- a/packages/vanilla/src/viewer/render/elements/chart-svg.chart-title-runs.test.ts
+++ b/packages/vanilla/src/viewer/render/elements/chart-svg.chart-title-runs.test.ts
@@ -44,6 +44,22 @@ describe('renderChartViewModelSvg: chart title rich text (titleRunSpans)', () =>
 		expect(tspans[1].getAttribute('font-style')).toBe('italic');
 	});
 
+	it('renders an edited flat title through its existing single styled run', () => {
+		const element = chartElement({
+			chartType: 'bar',
+			title: 'Annual Summary',
+			categories: ['Q1'],
+			series: [{ name: 'Revenue', values: [10] }],
+			style: { hasTitle: true },
+			titleRuns: [{ text: 'Old title', italic: true }],
+		});
+		const svg = renderChartViewModelSvg(document, buildChartViewModel(element), 'none');
+		const tspans = Array.from(svg.querySelectorAll('tspan'));
+		expect(tspans).toHaveLength(1);
+		expect(tspans[0].textContent).toBe('Annual Summary');
+		expect(tspans[0].getAttribute('font-style')).toBe('italic');
+	});
+
 	it('falls back to a flat text node when the title has no typed runs', () => {
 		const element = chartElement({
 			chartType: 'bar',

--- a/packages/vue/src/viewer/components/chart/ChartViewModelSvg.test.ts
+++ b/packages/vue/src/viewer/components/chart/ChartViewModelSvg.test.ts
@@ -264,6 +264,22 @@ describe('chartViewModelSvg: chart title rich text (titleRunSpans)', () => {
 		expect(tspans[1].attributes('font-style')).toBe('italic');
 	});
 
+	it('renders an edited flat title through its existing single styled run', () => {
+		const element = chartElement({
+			chartType: 'bar',
+			title: 'Annual Summary',
+			categories: ['Q1'],
+			series: [{ name: 'Revenue', values: [10] }],
+			style: { hasTitle: true },
+			titleRuns: [{ text: 'Old title', italic: true }],
+		});
+		const wrapper = mountVm(buildChartViewModel(element));
+		const tspans = wrapper.findAll('tspan');
+		expect(tspans).toHaveLength(1);
+		expect(tspans[0].text()).toBe('Annual Summary');
+		expect(tspans[0].attributes('font-style')).toBe('italic');
+	});
+
 	it('falls back to a flat text node when the title has no typed runs', () => {
 		const element = chartElement({
 			chartType: 'bar',


### PR DESCRIPTION
## What does this change?

Editing a loaded single-run chart title updates the inspector but leaves the old title visible on the slide until save/reload. This reproduces in all five bindings.

Resolve the text of exactly one styled title run from the current flat `title`, falling back to the run text only when the flat title is undefined. Preserve the run's styling, no-run fallback, and existing multi-run rendering.

## Type of change

- [x] Bug fix (non-breaking)

## Why this fix?

The existing single-run edit helper deliberately updates only `title`: the core serializer uses that divergence from `titleRuns` to patch the original XML text in place, retaining unmodeled theme, font and language properties. Updating the typed run in the inspector instead would bypass that preservation path. The shared renderer simply needs to display the current text while keeping the existing run style.

The production change is one expression in the existing resolver plus a documentation clarification. No core writer or binding adapter behavior changes. Direct public `setChartTitle()` updates to single-run titles also use the corrected resolver.

## Scope

- Empty and undefined titles retain their distinct meanings.
- Existing zero-run and multi-run policies are unchanged. Direct SDK edits to a multi-run title are a separate case, not claimed fixed here.
- The raw-formatting roundtrip uses an ordinary text leaf; attributed main-title parsing is a separate issue.
- Existing save/history behavior can lose unmodeled run metadata when restoring a prior title after it has already been saved. This reproduces directly in core and is particularly visible in Svelte, which serializes every history commit. It is not introduced or fixed here; raw preservation is tested for a fresh title-only edit/save, separately from history text/rendering checks.

## Latest conflict refresh

Rebased onto `ae622d03` at `64d67121`. The production fix and all seven non-E2E regression files are unchanged; the resolved browser spec preserves both this PR's cases and merged PR #233's attributed-axis coverage.

Fresh dependency-ordered builds and independent code/browser reviews pass. The expanded five-binding Chromium matrix passes 45/45 with no failures, skips or flakes. Final focused and shared-suite results are recorded in the follow-up comment below.

## Original pre-rebase validation

Four shared regression assertions failed before the change, including a public SDK title update. Actual baseline browser checks confirmed the stale title in React, Vue, Angular, Svelte and Vanilla, while save/reload already produced the edited title.

- Full core: 14,256 passed, 231 skipped.
- Full shared: 8,876 passed, 3 skipped.
- Focused shared14 and core roundtrip6 passed.
- Existing renderer tests: React14, Vue12, Angular3, Svelte3, Vanilla3 passed.
- All five binding typechecks and shared typecheck passed; Svelte reports five existing warnings in unrelated files.
- Independent code review approved the minimal shared fix and preservation of the original save contract.

- Final framework-neutral browser run: 25 passed, 0 failed, 0 flaky across all five bindings. Includes existing multi-run controls, fresh styled edit/save/raw preservation/reload, separate Undo/Redo/save/reload, and normal on-canvas editing.
- Formatting/lint and E2E neutrality checks passed. The on-canvas check uses an unobstructed part of the title, without forced clicks. Vanilla still emits a separate existing inline-editor close error after a successful Enter commit; that lifecycle issue is not changed here.

## Cross-binding parity

All five bindings consume the same shared chart view model. Each has a regression in its existing title-render test file, plus the same framework-neutral browser spec. Angular's unit asserts the component's view-model input; its actual rendered template is covered in Chromium.

These checks cover browser rendering and PPTX XML roundtrips, not native PowerPoint fidelity. This PR does not claim a full all-package or all-E2E sweep.

## Conventional Commits

- [x] Commit message follows Conventional Commits.

