### PR TITLE
fix(core): avoid duplicating rich axis titles on save

### DIFF
--- a/e2e/chart-title-runs.spec.ts
+++ b/e2e/chart-title-runs.spec.ts
@@ -56,6 +56,11 @@ const TITLE_RUN_XML = '<a:r><a:t>Clustered Bar</a:t></a:r>';
 const STYLED_TITLE_RUN_XML =
 	'<a:r><a:rPr lang="fr-FR" sz="1800" b="1"><a:solidFill><a:schemeClr val="accent5"/></a:solidFill><a:latin typeface="+mj-lt"/></a:rPr><a:t>Clustered Bar</a:t></a:r>';
 
+const AXIS_TITLE = 'Quarterly Axis';
+const EDITED_AXIS_TITLE = 'Edited Axis';
+const AXIS_TITLE_XML =
+	'<c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:pPr algn="ctr"/><a:r><a:rPr lang="fr-FR" sz="1600" b="1"><a:solidFill><a:schemeClr val="accent3"/></a:solidFill><a:latin typeface="+mj-lt"/></a:rPr><a:t>Quarter</a:t></a:r><a:r><a:rPr lang="de-DE" sz="1400" i="1"><a:solidFill><a:srgbClr val="FF0000"/></a:solidFill><a:latin typeface="Arial"/></a:rPr><a:t>ly Axis</a:t></a:r><a:endParaRPr lang="en-US"/></a:p></c:rich></c:tx><c:layout/><c:overlay val="0"/></c:title>';
+
 const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
 
 interface DeckPayload {
@@ -126,6 +131,26 @@ async function expectAuthoredTitle(page: Page): Promise<void> {
 	await expect.poll(() => normalizedTitleText(chartLocator(page))).toBe('Sales Overview');
 }
 
+async function twoRunAxisDeck(testInfo: TestInfo): Promise<string> {
+	const zip = await JSZip.loadAsync(await readFile(CHART_GALLERY_FIXTURE));
+	const part = zip.file('ppt/charts/chart1.xml');
+	if (!part) {
+		throw new Error('the public chart gallery is missing chart1.xml');
+	}
+	const chartXml = await part.async('string');
+	const axisPosition = '<c:axPos val="b"/>';
+	if (!chartXml.includes(axisPosition)) {
+		throw new Error('the chart gallery category-axis insertion point changed');
+	}
+	zip.file(
+		'ppt/charts/chart1.xml',
+		chartXml.replace(axisPosition, `${axisPosition}${AXIS_TITLE_XML}`),
+	);
+	const outputPath = testInfo.outputPath('two-run-axis-title.pptx');
+	await writeFile(outputPath, await zip.generateAsync({ type: 'uint8array' }));
+	return outputPath;
+}
+
 function chartLocator(page: Page): Locator {
 	return page
 		.locator('[aria-roledescription="slide"]')
@@ -183,6 +208,45 @@ async function styledSingleRunDeck(testInfo: TestInfo): Promise<string> {
 
 function chartTitleInput(page: Page) {
 	return inspector(page).getByLabel('Title', { exact: true }).locator('visible=true').first();
+}
+
+async function openAxisDeck(page: Page, path: string): Promise<Locator> {
+	await loadDeck(page, path);
+	const chart = chartLocator(page);
+	await chart.waitFor();
+	await selectElement(page, chart);
+	await expect(inspector(page)).toBeVisible();
+	return chart;
+}
+
+async function renderedTextCount(chart: Locator, value: string): Promise<number> {
+	const values = await chart.locator('svg text').allTextContents();
+	return values.filter((text) => text.trim() === value).length;
+}
+
+function axisTitleSnapshot(xml: string) {
+	const categoryAxis = /<c:catAx>[\s\S]*?<\/c:catAx>/u.exec(xml)?.[0] ?? '';
+	const title = /<c:title>[\s\S]*?<\/c:title>/u.exec(categoryAxis)?.[0] ?? '';
+	return {
+		texts: [...title.matchAll(/<a:t(?:\s[^>]*)?>([\s\S]*?)<\/a:t>/gu)].map((match) => match[1]),
+		firstLang: title.includes('lang="fr-FR"'),
+		firstSize: title.includes('sz="1600"'),
+		firstBold: title.includes('b="1"'),
+		firstScheme: /<a:schemeClr\b[^>]*\bval="accent3"/u.test(title),
+		firstTypeface: /<a:latin\b[^>]*\btypeface="\+mj-lt"/u.test(title),
+		secondLang: title.includes('lang="de-DE"'),
+		secondItalic: title.includes('i="1"'),
+		secondRed: /<a:srgbClr\b[^>]*\bval="FF0000"/u.test(title),
+		paragraphDefaults: title.includes('<a:pPr algn="ctr"'),
+		endProperties: title.includes('<a:endParaRPr lang="en-US"'),
+	};
+}
+
+async function savePath(page: Page): Promise<string> {
+	const download = await savePptxViaBackstage(page);
+	const path = await download.path();
+	expect(path, 'the browser should retain the saved PPTX').not.toBeNull();
+	return path!;
 }
 
 const classicAxisTitle =
@@ -472,7 +536,13 @@ test.describe('chart title rich text (multi-run titles)', () => {
 		await expect(titleInput).toHaveValue(EDITED_SINGLE_RUN_TITLE);
 		await expect
 			.poll(async () => await titleTspans(page))
-			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+			.toStrictEqual([
+				{
+					...initialSpan,
+					text: EDITED_SINGLE_RUN_TITLE,
+					rawText: initialSpan.rawText.replace(SINGLE_RUN_TITLE, EDITED_SINGLE_RUN_TITLE),
+				},
+			]);
 
 		const download = await savePptxViaBackstage(page);
 		const downloadPath = await download.path();
@@ -496,7 +566,13 @@ test.describe('chart title rich text (multi-run titles)', () => {
 		await expect(chartTitleInput(page)).toHaveValue(EDITED_SINGLE_RUN_TITLE);
 		await expect
 			.poll(async () => await titleTspans(page))
-			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+			.toStrictEqual([
+				{
+					...initialSpan,
+					text: EDITED_SINGLE_RUN_TITLE,
+					rawText: initialSpan.rawText.replace(SINGLE_RUN_TITLE, EDITED_SINGLE_RUN_TITLE),
+				},
+			]);
 	});
 
 	test('single-run title edits stay in sync through undo, redo, save, and reload', async ({
@@ -522,7 +598,13 @@ test.describe('chart title rich text (multi-run titles)', () => {
 		await expect(titleInput).toHaveValue(EDITED_SINGLE_RUN_TITLE);
 		await expect
 			.poll(async () => await titleTspans(page))
-			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+			.toStrictEqual([
+				{
+					...initialSpan,
+					text: EDITED_SINGLE_RUN_TITLE,
+					rawText: initialSpan.rawText.replace(SINGLE_RUN_TITLE, EDITED_SINGLE_RUN_TITLE),
+				},
+			]);
 
 		const undo = page.getByRole('button', { name: 'Undo' });
 		const redo = page.getByRole('button', { name: 'Redo' });
@@ -537,7 +619,13 @@ test.describe('chart title rich text (multi-run titles)', () => {
 		await expect(chartTitleInput(page)).toHaveValue(EDITED_SINGLE_RUN_TITLE);
 		await expect
 			.poll(async () => await titleTspans(page))
-			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+			.toStrictEqual([
+				{
+					...initialSpan,
+					text: EDITED_SINGLE_RUN_TITLE,
+					rawText: initialSpan.rawText.replace(SINGLE_RUN_TITLE, EDITED_SINGLE_RUN_TITLE),
+				},
+			]);
 
 		const download = await savePptxViaBackstage(page);
 		const downloadPath = await download.path();
@@ -555,7 +643,13 @@ test.describe('chart title rich text (multi-run titles)', () => {
 		await expect(chartTitleInput(page)).toHaveValue(EDITED_SINGLE_RUN_TITLE);
 		await expect
 			.poll(async () => await titleTspans(page))
-			.toStrictEqual([{ ...initialSpan, text: EDITED_SINGLE_RUN_TITLE }]);
+			.toStrictEqual([
+				{
+					...initialSpan,
+					text: EDITED_SINGLE_RUN_TITLE,
+					rawText: initialSpan.rawText.replace(SINGLE_RUN_TITLE, EDITED_SINGLE_RUN_TITLE),
+				},
+			]);
 	});
 
 	test('editing a single-run title directly on the canvas refreshes immediately', async ({
@@ -584,6 +678,89 @@ test.describe('chart title rich text (multi-run titles)', () => {
 		await expect
 			.poll(async () => (await titleTspans(page)).map((span) => span.text))
 			.toStrictEqual([ON_CANVAS_TITLE]);
+	});
+	test('an unrelated chart edit preserves an untouched two-run axis title', async ({
+		page,
+	}, testInfo) => {
+		const deck = await twoRunAxisDeck(testInfo);
+		let chart = await openAxisDeck(page, deck);
+		await expect.poll(() => renderedTextCount(chart, AXIS_TITLE)).toBe(1);
+		await expect(await visibleInputWithValue(page, AXIS_TITLE)).toBeVisible();
+
+		const x = inspector(page).getByRole('spinbutton', { name: 'X', exact: true });
+		const previousX = Number(await x.inputValue());
+		await x.fill(String(previousX + 1));
+		await x.press('Tab');
+		await expect(x).toHaveValue(String(previousX + 1));
+
+		const saved = await savePath(page);
+		expect(axisTitleSnapshot(await savedChartXml(saved))).toStrictEqual({
+			texts: ['Quarter', 'ly Axis'],
+			firstLang: true,
+			firstSize: true,
+			firstBold: true,
+			firstScheme: true,
+			firstTypeface: true,
+			secondLang: true,
+			secondItalic: true,
+			secondRed: true,
+			paragraphDefaults: true,
+			endProperties: true,
+		});
+
+		chart = await openAxisDeck(page, saved);
+		await expect.poll(() => renderedTextCount(chart, AXIS_TITLE)).toBe(1);
+		await expect(await visibleInputWithValue(page, AXIS_TITLE)).toBeVisible();
+
+		const repeated = await savePath(page);
+		expect(axisTitleSnapshot(await savedChartXml(repeated)).texts).toStrictEqual([
+			'Quarter',
+			'ly Axis',
+		]);
+	});
+
+	test('editing a two-run axis title removes its stale tail and preserves its first style', async ({
+		page,
+	}, testInfo) => {
+		const deck = await twoRunAxisDeck(testInfo);
+		let chart = await openAxisDeck(page, deck);
+		const axisTitle = await visibleInputWithValue(page, AXIS_TITLE);
+		await axisTitle.fill(EDITED_AXIS_TITLE);
+		await axisTitle.press('Tab');
+		await expect.poll(() => renderedTextCount(chart, EDITED_AXIS_TITLE)).toBe(1);
+
+		const undo = page.getByRole('button', { name: 'Undo' });
+		const redo = page.getByRole('button', { name: 'Redo' });
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expect.poll(() => renderedTextCount(chart, AXIS_TITLE)).toBe(1);
+		await expect(redo).toBeEnabled();
+		await redo.click();
+		await expect.poll(() => renderedTextCount(chart, EDITED_AXIS_TITLE)).toBe(1);
+
+		const saved = await savePath(page);
+		expect(axisTitleSnapshot(await savedChartXml(saved))).toStrictEqual({
+			texts: [EDITED_AXIS_TITLE],
+			firstLang: true,
+			firstSize: true,
+			firstBold: true,
+			firstScheme: true,
+			firstTypeface: true,
+			secondLang: false,
+			secondItalic: false,
+			secondRed: false,
+			paragraphDefaults: true,
+			endProperties: true,
+		});
+
+		chart = await openAxisDeck(page, saved);
+		await expect.poll(() => renderedTextCount(chart, EDITED_AXIS_TITLE)).toBe(1);
+		await expect(await visibleInputWithValue(page, EDITED_AXIS_TITLE)).toBeVisible();
+
+		const repeated = await savePath(page);
+		expect(axisTitleSnapshot(await savedChartXml(repeated)).texts).toStrictEqual([
+			EDITED_AXIS_TITLE,
+		]);
 	});
 });
 

--- a/packages/core/src/__tests__/integration/chart-axis-label-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/chart-axis-label-roundtrip.test.ts
@@ -55,6 +55,112 @@ async function buildDeckWithAttributedAxisTitle(): Promise<ArrayBuffer> {
 	return (await zip.generateAsync({ type: 'uint8array' })).buffer as ArrayBuffer;
 }
 
+const CHART_PATH = 'ppt/charts/chart1.xml';
+const xmlParser = new XMLParser({
+	ignoreAttributes: false,
+	attributeNamePrefix: '@_',
+	trimValues: false,
+});
+const xmlBuilder = new XMLBuilder({ ignoreAttributes: false, attributeNamePrefix: '@_' });
+const getLocalName = (key: string): string => key.split(':').at(-1)!;
+
+function asArray<T>(value: T | T[] | undefined): T[] {
+	return value === undefined ? [] : Array.isArray(value) ? value : [value];
+}
+
+function axisNode(document: XmlObject, axisType: 'catAx' | 'valAx'): XmlObject {
+	const chartSpace = document['c:chartSpace'] as XmlObject;
+	const chart = chartSpace['c:chart'] as XmlObject;
+	const plotArea = chart['c:plotArea'] as XmlObject;
+	return plotArea[`c:${axisType}`] as XmlObject;
+}
+
+function titleNode(document: XmlObject, axisType: 'catAx' | 'valAx'): XmlObject {
+	return axisNode(document, axisType)['c:title'] as XmlObject;
+}
+
+function titleParagraph(title: XmlObject): XmlObject {
+	return (((title['c:tx'] as XmlObject)['c:rich'] as XmlObject)['a:p'] ?? {}) as XmlObject;
+}
+
+function titleTextValues(title: XmlObject): string[] {
+	return asArray(titleParagraph(title)['a:r'] as XmlObject | XmlObject[] | undefined).map((run) =>
+		typeof run['a:t'] === 'object'
+			? String((run['a:t'] as XmlObject)['#text'] ?? '')
+			: String(run['a:t'] ?? ''),
+	);
+}
+
+function setTwoRunTitle(
+	axis: XmlObject,
+	firstText: string,
+	secondText: string,
+	accent: string,
+): void {
+	applyChartAxisTitleToXml(axis, `${firstText}${secondText}`, getLocalName);
+	const existingTitle = axis['c:title'] as XmlObject;
+	const rich = (existingTitle['c:tx'] as XmlObject)['c:rich'] as XmlObject;
+	rich['a:p'] = {
+		'a:pPr': { '@_algn': 'ctr', 'a:defRPr': { '@_lang': 'en-US' } },
+		'a:r': [
+			{
+				'a:rPr': {
+					'@_lang': 'en-AU',
+					'@_b': '1',
+					'a:solidFill': {
+						'a:schemeClr': { '@_val': accent, 'a:lumMod': { '@_val': '75000' } },
+					},
+					'a:latin': { '@_typeface': '+mj-lt' },
+				},
+				'a:t': firstText,
+			},
+			{ 'a:rPr': { '@_lang': 'de-DE', '@_i': '1' }, 'a:t': secondText },
+		],
+		'a:endParaRPr': { '@_lang': 'fr-FR' },
+	};
+	axis['c:title'] = {
+		'c:tx': existingTitle['c:tx'],
+		'c:layout': {
+			'c:manualLayout': { 'c:xMode': { '@_val': 'factor' }, 'c:x': { '@_val': '0.2' } },
+		},
+		'c:overlay': { '@_val': '1' },
+		'c:spPr': {
+			'a:ln': {
+				'@_w': '12700',
+				'a:solidFill': { 'a:srgbClr': { '@_val': accent === 'accent2' ? '123456' : '654321' } },
+			},
+		},
+	};
+}
+
+function exactArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+async function parseChartXml(bytes: ArrayBuffer | Uint8Array): Promise<XmlObject> {
+	const zip = await JSZip.loadAsync(bytes);
+	return xmlParser.parse(await zip.file(CHART_PATH)!.async('string')) as XmlObject;
+}
+
+async function buildDeckWithTwoRunAxisTitles(): Promise<ArrayBuffer> {
+	const { handler, data, createSlide } = await PresentationBuilder.create();
+	data.slides.push(
+		createSlide('Blank')
+			.addChart(
+				'bar',
+				{ categories: ['Q1', 'Q2'], series: [{ name: 'Revenue', values: [10, 20] }] },
+				{ x: 50, y: 50, width: 500, height: 300 },
+			)
+			.build(),
+	);
+	const zip = await JSZip.loadAsync(await handler.save(data.slides));
+	const document = xmlParser.parse(await zip.file(CHART_PATH)!.async('string')) as XmlObject;
+	setTwoRunTitle(axisNode(document, 'catAx'), 'Category-', 'control', 'accent3');
+	setTwoRunTitle(axisNode(document, 'valAx'), 'Revenue-', 'by-quarter', 'accent2');
+	zip.file(CHART_PATH, xmlBuilder.build(document));
+	return exactArrayBuffer(await zip.generateAsync({ type: 'uint8array' }));
+}
+
 describe('chartML axis label formatting round-trip', () => {
 	it('preserves an attributed axis title through an unrelated save', async () => {
 		let handler = new PptxHandler();
@@ -107,6 +213,98 @@ describe('chartML axis label formatting round-trip', () => {
 		expect(chartXml).not.toContain(' Value axis ');
 		expect(chartXml).not.toContain('[object Object]');
 	});
+
+	it('keeps unchanged two-run axis title XML stable through repeated dirty saves', async () => {
+		const seed = await buildDeckWithTwoRunAxisTitles();
+		const originalXml = await parseChartXml(seed);
+		const originalCategoryTitle = titleNode(originalXml, 'catAx');
+		const originalValueTitle = titleNode(originalXml, 'valAx');
+		const handler = new PptxHandler();
+		const loaded = await handler.load(seed);
+		const chart = chartFrom(loaded.slides);
+		expect(chart.chartData?.axes?.find((axis) => axis.axisType === 'catAx')?.titleText).toBe(
+			'Category-control',
+		);
+		expect(chart.chartData?.axes?.find((axis) => axis.axisType === 'valAx')?.titleText).toBe(
+			'Revenue-by-quarter',
+		);
+
+		chart.x += 1;
+		loaded.slides[0].isDirty = true;
+		const firstSaved = await handler.save(loaded.slides);
+		const firstXml = await parseChartXml(firstSaved);
+		expect(titleNode(firstXml, 'catAx')).toStrictEqual(originalCategoryTitle);
+		expect(titleNode(firstXml, 'valAx')).toStrictEqual(originalValueTitle);
+
+		chart.x += 1;
+		loaded.slides[0].isDirty = true;
+		const secondSaved = await handler.save(loaded.slides);
+		const secondXml = await parseChartXml(secondSaved);
+		expect(titleNode(secondXml, 'catAx')).toStrictEqual(originalCategoryTitle);
+		expect(titleNode(secondXml, 'valAx')).toStrictEqual(originalValueTitle);
+
+		const reloadedHandler = new PptxHandler();
+		const reloaded = await reloadedHandler.load(exactArrayBuffer(secondSaved));
+		chartFrom(reloaded.slides).x += 1;
+		reloaded.slides[0].isDirty = true;
+		const reloadedXml = await parseChartXml(await reloadedHandler.save(reloaded.slides));
+		expect(titleNode(reloadedXml, 'catAx')).toStrictEqual(originalCategoryTitle);
+		expect(titleNode(reloadedXml, 'valAx')).toStrictEqual(originalValueTitle);
+	});
+
+	it.each(['Edited-value-axis', ' Edited value axis '])(
+		'collapses a genuinely edited rich axis title to %j without changing the other axis or its styles',
+		async (editedText) => {
+			const seed = await buildDeckWithTwoRunAxisTitles();
+			const originalXml = await parseChartXml(seed);
+			const originalCategoryTitle = titleNode(originalXml, 'catAx');
+			const originalValueTitle = titleNode(originalXml, 'valAx');
+			const originalValueParagraph = titleParagraph(originalValueTitle);
+			const originalFirstRun = asArray(originalValueParagraph['a:r'] as XmlObject | XmlObject[])[0];
+			const handler = new PptxHandler();
+			const loaded = await handler.load(seed);
+			const valueAxis = chartFrom(loaded.slides).chartData?.axes?.find(
+				(axis) => axis.axisType === 'valAx',
+			);
+			expect(valueAxis?.titleText).toBe('Revenue-by-quarter');
+			valueAxis!.titleText = editedText;
+			loaded.slides[0].isDirty = true;
+
+			const firstSaved = await handler.save(loaded.slides);
+			const firstXml = await parseChartXml(firstSaved);
+			const editedTitle = titleNode(firstXml, 'valAx');
+			const editedParagraph = titleParagraph(editedTitle);
+			const editedRuns = asArray(editedParagraph['a:r'] as XmlObject | XmlObject[]);
+			expect(titleNode(firstXml, 'catAx')).toStrictEqual(originalCategoryTitle);
+			expect(titleTextValues(editedTitle)).toStrictEqual([editedText]);
+			expect(editedRuns).toHaveLength(1);
+			expect(editedRuns[0]['a:rPr']).toStrictEqual(originalFirstRun['a:rPr']);
+			expect(editedParagraph['a:pPr']).toStrictEqual(originalValueParagraph['a:pPr']);
+			expect(editedParagraph['a:endParaRPr']).toStrictEqual(originalValueParagraph['a:endParaRPr']);
+			expect(editedTitle['c:layout']).toStrictEqual(originalValueTitle['c:layout']);
+			expect(editedTitle['c:overlay']).toStrictEqual(originalValueTitle['c:overlay']);
+			expect(editedTitle['c:spPr']).toStrictEqual(originalValueTitle['c:spPr']);
+
+			chartFrom(loaded.slides).x += 1;
+			loaded.slides[0].isDirty = true;
+			const secondSaved = await handler.save(loaded.slides);
+			const secondXml = await parseChartXml(secondSaved);
+			expect(titleNode(secondXml, 'catAx')).toStrictEqual(originalCategoryTitle);
+			expect(titleNode(secondXml, 'valAx')).toStrictEqual(editedTitle);
+
+			const reloadedHandler = new PptxHandler();
+			const reloaded = await reloadedHandler.load(exactArrayBuffer(secondSaved));
+			const reloadedChart = chartFrom(reloaded.slides);
+			expect(
+				reloadedChart.chartData?.axes?.find((axis) => axis.axisType === 'valAx')?.titleText,
+			).toBe(editedText);
+			reloadedChart.x += 1;
+			reloaded.slides[0].isDirty = true;
+			const reloadedXml = await parseChartXml(await reloadedHandler.save(reloaded.slides));
+			expect(titleNode(reloadedXml, 'catAx')).toStrictEqual(originalCategoryTitle);
+			expect(titleNode(reloadedXml, 'valAx')).toStrictEqual(editedTitle);
+		},
+	);
 
 	it('generates, parses, edits, and dirty-saves category-axis label controls', async () => {
 		const { handler, data, createSlide } = await PresentationBuilder.create();

--- a/packages/core/src/core/utils/chart-axis-title-serializer.test.ts
+++ b/packages/core/src/core/utils/chart-axis-title-serializer.test.ts
@@ -5,6 +5,7 @@ import {
 	applyChartAxisTitleToXml,
 	applyChartAxisTitleStyleToXml,
 } from './chart-axis-title-serializer';
+import { collectAllText } from './chart-title-xml-ops';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -38,6 +39,164 @@ function titleWith(text: string): XmlObject {
 // ---------------------------------------------------------------------------
 
 describe('applyChartAxisTitleToXml', () => {
+	const runProperties: XmlObject = {
+		'@_lang': 'en-US',
+		'a:solidFill': { 'a:schemeClr': { '@_val': 'accent2' } },
+		'a:latin': { '@_typeface': '+mj-lt' },
+	};
+	const paragraphProperties: XmlObject = { '@_algn': 'ctr' };
+
+	function richTitle(paragraphs: XmlObject | XmlObject[]): XmlObject {
+		return {
+			'c:tx': {
+				'c:rich': {
+					'a:bodyPr': { '@_rot': '-5400000' },
+					'a:lstStyle': {},
+					'a:p': paragraphs,
+				},
+			},
+			'c:layout': { 'c:manualLayout': { 'c:x': { '@_val': '0.1' } } },
+			'c:overlay': { '@_val': '1' },
+			'c:spPr': { 'a:noFill': {} },
+			'c:txPr': { 'a:bodyPr': {}, 'a:p': { 'a:pPr': { 'a:defRPr': { '@_sz': '1400' } } } },
+		};
+	}
+
+	function richBody(title: XmlObject): XmlObject {
+		return (title['c:tx'] as XmlObject)['c:rich'] as XmlObject;
+	}
+
+	it.each([
+		{ 'a:r': [{ 'a:rPr': runProperties, 'a:t': 'Value ' }, { 'a:t': 'Axis' }] },
+		{ 'a:r': { 'a:t': 'Value ' }, 'a:fld': { '@_id': 'field', 'a:t': 'Axis' } },
+	])('preserves an unchanged rich title without duplicating text', (paragraph) => {
+		const node = { ...axisNode(), 'c:title': richTitle(paragraph) };
+		const before = structuredClone(node);
+		const title = node['c:title'];
+		applyChartAxisTitleToXml(node, 'Value Axis', getLocalName);
+		expect(node).toStrictEqual(before);
+		expect(node['c:title']).toBe(title);
+	});
+
+	it.each([
+		{
+			'a:pPr': paragraphProperties,
+			'a:r': [{ 'a:rPr': runProperties, 'a:t': 'Value ' }, { 'a:t': 'Axis' }],
+			'a:endParaRPr': { '@_lang': 'en-US' },
+		},
+		{
+			'a:pPr': paragraphProperties,
+			'a:fld': { '@_id': 'field', '@_type': 'slidenum', 'a:rPr': runProperties, 'a:t': '1' },
+			'a:r': { 'a:t': ' Axis' },
+			'a:endParaRPr': { '@_lang': 'en-US' },
+		},
+		{
+			'a:pPr': paragraphProperties,
+			'a:r': { 'a:rPr': runProperties, 'a:t': 'Value' },
+			'a:br': {},
+			'a:endParaRPr': { '@_lang': 'en-US' },
+		},
+	])(
+		'replaces changed rich content with one literal run while retaining its raw style',
+		(paragraph) => {
+			const title = richTitle(paragraph);
+			const node = { ...axisNode(), 'c:title': title };
+			const original = structuredClone(title);
+			applyChartAxisTitleToXml(node, 'Edited axis', getLocalName);
+			const texts: string[] = [];
+			collectAllText(title, getLocalName, texts);
+			expect(texts).toStrictEqual(['Edited axis']);
+			expect(richBody(title)['a:p']).toStrictEqual({
+				'a:pPr': paragraphProperties,
+				'a:r': { 'a:rPr': runProperties, 'a:t': 'Edited axis' },
+				'a:endParaRPr': { '@_lang': 'en-US' },
+			});
+			expect(Object.keys(richBody(title)['a:p'] as XmlObject)).toStrictEqual([
+				'a:pPr',
+				'a:r',
+				'a:endParaRPr',
+			]);
+			for (const key of ['c:layout', 'c:overlay', 'c:spPr', 'c:txPr']) {
+				expect(title[key]).toStrictEqual(original[key]);
+			}
+			expect(richBody(title)['a:bodyPr']).toStrictEqual(richBody(original)['a:bodyPr']);
+			const once = structuredClone(node);
+			applyChartAxisTitleToXml(node, 'Edited axis', getLocalName);
+			expect(node).toStrictEqual(once);
+		},
+	);
+
+	it('removes extra paragraphs on a flat edit and preserves attributed boundary whitespace', () => {
+		const title = richTitle([
+			{
+				'a:pPr': paragraphProperties,
+				'a:r': { 'a:rPr': runProperties, 'a:t': { '@_xml:space': 'preserve', '#text': 'Value ' } },
+			},
+			{ 'a:r': { 'a:t': 'Axis' } },
+		]);
+		const node = { ...axisNode(), 'c:title': title };
+		applyChartAxisTitleToXml(node, ' Edited axis ', getLocalName);
+		const paragraph = richBody(title)['a:p'] as XmlObject;
+		expect(Array.isArray(paragraph)).toBeFalsy();
+		expect(paragraph['a:pPr']).toStrictEqual(paragraphProperties);
+		expect((paragraph['a:r'] as XmlObject)['a:t']).toStrictEqual({
+			'@_xml:space': 'preserve',
+			'#text': ' Edited axis ',
+		});
+	});
+
+	it('turns a lone field into literal text without changing primitive boundary-space representation', () => {
+		const title = richTitle({
+			'a:fld': { '@_id': 'field', '@_type': 'slidenum', 'a:rPr': runProperties, 'a:t': '1' },
+		});
+		applyChartAxisTitleToXml({ 'c:title': title }, ' New ', getLocalName);
+		expect(richBody(title)['a:p']).toStrictEqual({
+			'a:r': { 'a:rPr': runProperties, 'a:t': ' New ' },
+		});
+	});
+
+	it('uses the first text-bearing paragraph rather than preceding empty paragraph formatting', () => {
+		const title = richTitle([
+			{ 'a:pPr': { '@_algn': 'l' } },
+			{ 'a:pPr': paragraphProperties, 'a:r': { 'a:rPr': runProperties, 'a:t': 'Axis' } },
+		]);
+		applyChartAxisTitleToXml({ 'c:title': title }, 'Edited', getLocalName);
+		expect(richBody(title)['a:p']).toStrictEqual({
+			'a:pPr': paragraphProperties,
+			'a:r': { 'a:rPr': runProperties, 'a:t': 'Edited' },
+		});
+	});
+
+	it('replaces a linked title text without discarding the outer title properties', () => {
+		const title = richTitle({});
+		title['c:tx'] = { 'c:strRef': { 'c:f': 'Sheet1!$A$1' } };
+		const original = structuredClone(title);
+		const node = { ...axisNode(), 'c:title': title };
+		applyChartAxisTitleToXml(node, 'Literal title', getLocalName);
+		expect(node['c:title']).toBe(title);
+		expect((title['c:tx'] as XmlObject)['c:strRef']).toBeUndefined();
+		for (const key of ['c:layout', 'c:overlay', 'c:spPr', 'c:txPr']) {
+			expect(title[key]).toStrictEqual(original[key]);
+		}
+		const texts: string[] = [];
+		collectAllText(title, getLocalName, texts);
+		expect(texts).toStrictEqual(['Literal title']);
+	});
+
+	it('inserts missing text before existing layout and style properties', () => {
+		const title = richTitle({});
+		delete title['c:tx'];
+		const original = structuredClone(title);
+		applyChartAxisTitleToXml({ 'c:title': title }, 'Added title', getLocalName);
+		expect(Object.keys(title)).toStrictEqual(['c:tx', ...Object.keys(original)]);
+		for (const key of Object.keys(original)) {
+			expect(title[key]).toStrictEqual(original[key]);
+		}
+		const texts: string[] = [];
+		collectAllText(title, getLocalName, texts);
+		expect(texts).toStrictEqual(['Added title']);
+	});
+
 	it('is a no-op when titleText is undefined', () => {
 		const node = axisNode();
 		const before = JSON.stringify(node);

--- a/packages/core/src/core/utils/chart-axis-title-serializer.ts
+++ b/packages/core/src/core/utils/chart-axis-title-serializer.ts
@@ -14,6 +14,7 @@
 import type { XmlObject } from '../types';
 import type { ResolveChartColor } from './chart-color-choice';
 import { writeChartColorChoice } from './chart-color-choice';
+import { collectAllText, findKey, insertAt } from './chart-title-xml-ops';
 
 type GetLocalName = (key: string) => string;
 
@@ -42,35 +43,79 @@ const AFTER_TITLE = new Set([
 	'minorTimeUnit',
 ]);
 
-function findKey(obj: XmlObject, local: string, getLocalName: GetLocalName): string | undefined {
-	return Object.keys(obj).find((k) => getLocalName(k) === local);
+/** The first direct literal run or field carrying text in a paragraph. */
+function firstTextRun(
+	paragraph: XmlObject,
+	getLocalName: GetLocalName,
+): [string, XmlObject] | undefined {
+	for (const [key, value] of Object.entries(paragraph)) {
+		if (!['r', 'fld'].includes(getLocalName(key))) {
+			continue;
+		}
+		for (const run of Array.isArray(value) ? value : [value]) {
+			if (
+				run &&
+				typeof run === 'object' &&
+				!Array.isArray(run) &&
+				findKey(run, 't', getLocalName)
+			) {
+				return [key, run];
+			}
+		}
+	}
+	return undefined;
 }
 
-/** Set the first descendant text run (`a:t`) to `text`. Returns whether one was found. */
-function setFirstText(node: unknown, text: string, getLocalName: GetLocalName): boolean {
-	if (!node || typeof node !== 'object') {
-		return false;
+/** Preserve unchanged rich text; a flat edit replaces content, not authored formatting. */
+function setTitleText(title: XmlObject, text: string, getLocalName: GetLocalName): void {
+	const txKey = findKey(title, 'tx', getLocalName) ?? 'c:tx';
+	const tx = title[txKey] as XmlObject | undefined;
+	const texts: string[] = [];
+	if (tx && typeof tx === 'object') {
+		collectAllText(tx, getLocalName, texts);
 	}
-	const obj = node as XmlObject;
-	for (const key of Object.keys(obj)) {
-		if (getLocalName(key) === 't') {
-			const value = obj[key];
-			if (value && typeof value === 'object' && !Array.isArray(value)) {
-				(value as XmlObject)['#text'] = text;
-			} else {
-				obj[key] = text;
-			}
-			return true;
-		}
-		const child = obj[key];
-		const children = Array.isArray(child) ? child : [child];
-		for (const c of children) {
-			if (setFirstText(c, text, getLocalName)) {
-				return true;
-			}
-		}
+	if (texts.join('') === text) {
+		return;
 	}
-	return false;
+	const richKey = tx && typeof tx === 'object' ? findKey(tx, 'rich', getLocalName) : undefined;
+	const rich = richKey ? (tx![richKey] as XmlObject) : undefined;
+	if (!rich || typeof rich !== 'object' || Array.isArray(rich)) {
+		const textNode = buildTitle(text)['c:tx'];
+		if (txKey in title) {
+			title[txKey] = textNode;
+		} else {
+			insertAt(title, 0, txKey, textNode);
+		}
+		return;
+	}
+	const pKey = findKey(rich, 'p', getLocalName) ?? 'a:p';
+	const value = rich[pKey];
+	const paragraphs = (Array.isArray(value) ? value : [value]).filter(
+		(entry): entry is XmlObject =>
+			Boolean(entry) && typeof entry === 'object' && !Array.isArray(entry),
+	);
+	const paragraph = paragraphs.find((p) => firstTextRun(p, getLocalName)) ?? paragraphs[0] ?? {};
+	const carrier = firstTextRun(paragraph, getLocalName);
+	const original = carrier?.[1] ?? {};
+	const runKey = carrier ? carrier[0].replace(/[^:]+$/u, 'r') : 'a:r';
+	const rPrKey = findKey(original, 'rPr', getLocalName);
+	const run =
+		carrier && getLocalName(carrier[0]) === 'r'
+			? { ...original }
+			: rPrKey
+				? { [rPrKey]: original[rPrKey] }
+				: {};
+	const textKey = findKey(original, 't', getLocalName) ?? 'a:t';
+	const oldText = original[textKey];
+	const attributes =
+		oldText && typeof oldText === 'object' && !Array.isArray(oldText) ? oldText : undefined;
+	run[textKey] = attributes ? { ...attributes, '#text': text } : text;
+	const entries = Object.entries(paragraph);
+	rich[pKey] = Object.fromEntries([
+		...entries.filter(([key]) => key.startsWith('@_') || getLocalName(key) === 'pPr'),
+		[runKey, run],
+		...entries.filter(([key]) => getLocalName(key) === 'endParaRPr'),
+	]);
 }
 
 /** Build a minimal `c:title` carrying a single text run. */
@@ -134,8 +179,10 @@ export function applyChartAxisTitleToXml(
 	}
 
 	if (titleKey) {
-		const updated = setFirstText(axisNode[titleKey], titleText, getLocalName);
-		if (!updated) {
+		const title = axisNode[titleKey];
+		if (title && typeof title === 'object' && !Array.isArray(title)) {
+			setTitleText(title, titleText, getLocalName);
+		} else {
 			axisNode[titleKey] = buildTitle(titleText);
 		}
 		return;


### PR DESCRIPTION
## What does this change?

A classic chart-axis title split across runs is read as one flat string. Saving currently writes that whole string into the first run but leaves the remaining runs behind: `Quarter` + `ly Axis` becomes `Quarterly Axisly Axis`. The same stale tail remains after an actual title edit.

Preserve an unchanged title without rewriting its content. For a genuine flat-title edit, keep one literal run with the first authored run's formatting, retaining body/paragraph settings and outer layout/style properties while removing stale runs, fields, breaks and extra paragraphs. An ordinary single-run edit retains its full raw run details. Linked or textless titles receive text without losing their outer properties, in schema order.

## Type of change

- [x] Bug fix (non-breaking)

## Why this approach?

The original axis-title writer intentionally patched the first run in place to preserve formatting. That works for one run, but the axis model exposes a flat title joined from all runs. Reusing the existing chart text and XML-order helpers fixes the mismatch without adding a rich-axis API or guessing how an arbitrary flat edit should be distributed across runs.

The change stays in the existing core axis-title serializer. A no-op preserves the whole title; a genuine flat replacement retains the first run's authored style rather than rebuilding it from a limited style model. A field becomes literal text so its old value cannot return through recalculation.

## Latest conflict refresh

Rebased onto `4b17c8bb` at signed commit `0a06dcea`. The production serializer and its core tests are unchanged. The existing browser spec retains all newly merged main-title tests plus the two axis-save flows, reuses the existing inspector helper, and corrects five stale rawText expectations while preserving renderer whitespace and strict styling assertions.

Fresh dependency-ordered builds and independent code/browser reviews pass. Focused tests: 26/26. Full core: 14,317 passed, 231 existing skips (crypto run separately); full shared: 8,892 passed, 3 existing skips. Expanded five-binding browser matrix: 55/55, no failures, skips, flakes, or top-level errors. Core typecheck, scoped lint/format, and neutral-E2E checks pass. Detailed evidence and native-PowerPoint limitations are recorded in the latest comment.

## Original pre-rebase validation

Seven initial serializer assertions and two integration cases failed before the change. Corrected, independent browser fixtures with ordinary text leaves reproduce both unrelated dirty-save duplication and genuine edit/save duplication in all five bindings.

- Full core: 14,268 passed, 231 skipped.
- Full shared: 8,870 passed, 3 skipped.
- Focused serializer/integration: 24 passed, including same-handler repeated saves, reload stability, exact title/paragraph order, boundary-space edits, target-axis isolation and raw formatting retention.
- Final framework-neutral Chromium matrix: 20 passed, 0 failed, 0 flaky across all five bindings. Includes existing main-title controls and both new axis-save flows.
- Core typecheck, changed-file formatting/lint, E2E neutrality and diff checks passed.
- Independent code and actual-browser reviews approved. Review caught and resolved a missing-text-node ordering case and an unnecessary attribute-writing dependency before publication.

## Cross-binding parity

React, Vue, Angular, Svelte and Vanilla all pass the flat axis title to the same core writer. No adapter changes are required. The same neutral browser tests cover their dirty save/reload and actual title edit/Undo/Redo/save/reload flows, with repeated-save and authored-style checks.

## Scope

- Classic axes only. This does not add ChartEx axis-title edit serialization.
- No dependency on the pending attributed-text parser fix: browser and integration fixtures use ordinary text leaves.
- Primitive text remains primitive, including leading/trailing spaces; existing attributed wrappers are retained. An explicit boundary-space edit/save/reload regression verifies this against current main.
- Existing interleaved field-order parsing is not changed. Pure XML tests preserve unchanged structures using the current flat-text model; browser roundtrips isolate ordinary runs.
- This does not address the separate main-chart-title save/history metadata issue.

These are Chromium and PPTX XML roundtrip checks, not native PowerPoint validation or a full all-package/all-E2E sweep.

## Conventional Commits

- [x] Commit message follows Conventional Commits.

