### PR TITLE
fix(vanilla): close the chart title editor only once

### DIFF
--- a/e2e/chart-title-runs.spec.ts
+++ b/e2e/chart-title-runs.spec.ts
@@ -23,7 +23,7 @@
  * Run: bunx playwright test chart-title-runs
  */
 import { test, expect } from '@playwright/test';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 import {
 	CHART_TITLE_RUN_1,
@@ -33,6 +33,9 @@ import {
 import { fixture, inspector, loadDeck, selectElement } from './support/deck';
 
 const CHART_FIXTURE = fixture('chart-title-runs.pptx');
+const ENTERED_TITLE = 'Committed with Enter';
+const CANCELLED_TITLE = 'Must not commit';
+const BLURRED_TITLE = 'Committed on blur';
 
 interface TitleTspan {
 	text: string;
@@ -70,6 +73,45 @@ async function openChart(page: Page): Promise<void> {
 		.first()
 		.waitFor();
 	await page.waitForTimeout(300);
+}
+
+function chartLocator(page: Page): Locator {
+	return page
+		.locator('[aria-roledescription="slide"]')
+		.first()
+		.locator('[aria-roledescription="chart"]')
+		.first();
+}
+
+async function openTitleEditor(target: Locator): Promise<Locator> {
+	const title = target.locator('[data-chart-part="title"]');
+	const box = await title.boundingBox();
+	if (!box) {
+		throw new Error('chart title has no browser hit target');
+	}
+	await title.dblclick({
+		position: { x: Math.max(1, box.width / 8), y: box.height / 2 },
+	});
+	const input = target.locator('input:visible').first();
+	await expect(input).toBeVisible();
+	return input;
+}
+
+async function normalizedTitleText(target: Locator): Promise<string> {
+	return ((await target.locator('[data-chart-part="title"]').textContent()) ?? '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function collectRuntimeErrors(page: Page): string[] {
+	const errors: string[] = [];
+	page.on('pageerror', (error) => errors.push(`${error.name}: ${error.message}`));
+	page.on('console', (message) => {
+		if (message.type() === 'error' && /NotFoundError|closeTitleEditor/.test(message.text())) {
+			errors.push(message.text());
+		}
+	});
+	return errors;
 }
 
 test.describe('chart title rich text (multi-run titles)', () => {
@@ -124,5 +166,81 @@ test.describe('chart title rich text (multi-run titles)', () => {
 
 		const tspans = await titleTspans(page);
 		expect(tspans.length, 'a collapsed multi-run title must render as a single run').toBe(1);
+	});
+
+	test('commits an on-canvas title edit once on Enter and can reopen it', async ({ page }) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await openChart(page);
+		const target = chartLocator(page);
+		await selectElement(page, target);
+
+		const input = await openTitleEditor(target);
+		await input.fill(ENTERED_TITLE);
+		await input.press('Enter');
+		await expect(target.locator('input:visible')).toHaveCount(0);
+		await expect.poll(() => normalizedTitleText(target)).toBe(ENTERED_TITLE);
+
+		const reopened = await openTitleEditor(target);
+		await expect(reopened).toHaveValue(ENTERED_TITLE);
+		await reopened.press('Escape');
+		await expect(target.locator('input:visible')).toHaveCount(0);
+
+		const undo = page.getByRole('button', { name: 'Undo' });
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expect
+			.poll(() => normalizedTitleText(target))
+			.toBe(`${CHART_TITLE_RUN_1}${CHART_TITLE_RUN_2}`);
+		expect(runtimeErrors).toStrictEqual([]);
+	});
+
+	test('cancels an on-canvas title edit on Escape and can reopen it', async ({ page }) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await openChart(page);
+		const target = chartLocator(page);
+		await selectElement(page, target);
+
+		const input = await openTitleEditor(target);
+		await input.fill(CANCELLED_TITLE);
+		await input.press('Escape');
+		await expect(target.locator('input:visible')).toHaveCount(0);
+		await expect
+			.poll(() => normalizedTitleText(target))
+			.toBe(`${CHART_TITLE_RUN_1}${CHART_TITLE_RUN_2}`);
+
+		const reopened = await openTitleEditor(target);
+		await expect(reopened).toHaveValue(CHART_TITLE_RUN_1);
+		await reopened.press('Escape');
+		await expect(target.locator('input:visible')).toHaveCount(0);
+		expect(runtimeErrors).toStrictEqual([]);
+	});
+
+	test('commits an on-canvas title edit once on blur and can reopen it', async ({ page }) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await openChart(page);
+		const target = chartLocator(page);
+		await selectElement(page, target);
+
+		const input = await openTitleEditor(target);
+		await input.fill(BLURRED_TITLE);
+		await page
+			.getByRole('toolbar', { name: 'Presentation toolbar' })
+			.getByRole('tab', { name: 'Home', exact: true })
+			.click();
+		await expect(target.locator('input:visible')).toHaveCount(0);
+		await expect.poll(() => normalizedTitleText(target)).toBe(BLURRED_TITLE);
+
+		const reopened = await openTitleEditor(target);
+		await expect(reopened).toHaveValue(BLURRED_TITLE);
+		await reopened.press('Escape');
+		await expect(target.locator('input:visible')).toHaveCount(0);
+
+		const undo = page.getByRole('button', { name: 'Undo' });
+		await expect(undo).toBeEnabled();
+		await undo.click();
+		await expect
+			.poll(() => normalizedTitleText(target))
+			.toBe(`${CHART_TITLE_RUN_1}${CHART_TITLE_RUN_2}`);
+		expect(runtimeErrors).toStrictEqual([]);
 	});
 });

--- a/packages/vanilla/src/viewer/render/elements/chart-editable.test.ts
+++ b/packages/vanilla/src/viewer/render/elements/chart-editable.test.ts
@@ -275,6 +275,18 @@ describe('vanilla chart title double-click rename', () => {
 		target.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true }));
 	}
 
+	/** Model the browser's synchronous blur when a focused editor is removed. */
+	function blurDuringRemove(input: HTMLInputElement) {
+		const nativeRemove = input.remove.bind(input);
+		const remove = vi.spyOn(input, 'remove').mockImplementation(() => {
+			if (remove.mock.calls.length === 1) {
+				input.dispatchEvent(new FocusEvent('blur'));
+			}
+			nativeRemove();
+		});
+		return remove;
+	}
+
 	it('opens an input pre-filled with the current title on double-click', () => {
 		const onChartPointChange = vi.fn();
 		const container = renderChartElement(titled, 1, makeContext({ onChartPointChange }));
@@ -306,6 +318,25 @@ describe('vanilla chart title double-click rename', () => {
 		expect(container?.querySelector('.pptxv-chart-title-input')).toBeNull();
 	});
 
+	it('commits once when removing the editor synchronously fires blur during Enter', () => {
+		const onChartPointChange = vi.fn();
+		const container = renderChartElement(titled, 1, makeContext({ onChartPointChange }));
+		document.body.appendChild(container as HTMLElement);
+		const titleNode = container?.querySelector('[data-chart-part="title"]') as SVGElement;
+
+		dblclick(titleNode);
+		const input = container?.querySelector('.pptxv-chart-title-input') as HTMLInputElement;
+		input.value = 'Quarterly Sales';
+		const remove = blurDuringRemove(input);
+
+		expect(() =>
+			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })),
+		).not.toThrow();
+		expect(remove).toHaveBeenCalledOnce();
+		expect(onChartPointChange).toHaveBeenCalledOnce();
+		expect(onChartPointChange.mock.calls[0][1].title).toBe('Quarterly Sales');
+	});
+
 	it('cancels on Escape without committing', () => {
 		const onChartPointChange = vi.fn();
 		const container = renderChartElement(titled, 1, makeContext({ onChartPointChange }));
@@ -318,6 +349,54 @@ describe('vanilla chart title double-click rename', () => {
 		input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
 
 		expect(onChartPointChange).not.toHaveBeenCalled();
+		expect(container?.querySelector('.pptxv-chart-title-input')).toBeNull();
+	});
+
+	it('does not commit when removing the editor synchronously fires blur during Escape', () => {
+		const onChartPointChange = vi.fn();
+		const container = renderChartElement(titled, 1, makeContext({ onChartPointChange }));
+		document.body.appendChild(container as HTMLElement);
+		const titleNode = container?.querySelector('[data-chart-part="title"]') as SVGElement;
+
+		dblclick(titleNode);
+		const input = container?.querySelector('.pptxv-chart-title-input') as HTMLInputElement;
+		input.value = 'Discarded';
+		const remove = blurDuringRemove(input);
+
+		expect(() =>
+			input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })),
+		).not.toThrow();
+		expect(remove).toHaveBeenCalledOnce();
+		expect(onChartPointChange).not.toHaveBeenCalled();
+	});
+
+	it('cleans up an old editor without committing and ignores its stale events after reopening', () => {
+		const onChartPointChange = vi.fn();
+		const container = renderChartElement(titled, 1, makeContext({ onChartPointChange }));
+		document.body.appendChild(container as HTMLElement);
+		const titleNode = container?.querySelector('[data-chart-part="title"]') as SVGElement;
+
+		dblclick(titleNode);
+		const oldInput = container?.querySelector('.pptxv-chart-title-input') as HTMLInputElement;
+		oldInput.value = 'Stale title';
+		const oldRemove = blurDuringRemove(oldInput);
+		dblclick(titleNode);
+		const currentInput = container?.querySelector('.pptxv-chart-title-input') as HTMLInputElement;
+
+		expect(currentInput).not.toBe(oldInput);
+		expect(oldRemove).toHaveBeenCalledOnce();
+		expect(onChartPointChange).not.toHaveBeenCalled();
+		oldInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		expect(onChartPointChange).not.toHaveBeenCalled();
+		expect(container?.querySelector('.pptxv-chart-title-input')).toBe(currentInput);
+		oldInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+		expect(onChartPointChange).not.toHaveBeenCalled();
+		expect(container?.querySelector('.pptxv-chart-title-input')).toBe(currentInput);
+
+		currentInput.value = 'Current title';
+		currentInput.dispatchEvent(new FocusEvent('blur'));
+		expect(onChartPointChange).toHaveBeenCalledOnce();
+		expect(onChartPointChange.mock.calls[0][1].title).toBe('Current title');
 		expect(container?.querySelector('.pptxv-chart-title-input')).toBeNull();
 	});
 

--- a/packages/vanilla/src/viewer/render/elements/chart-editable.ts
+++ b/packages/vanilla/src/viewer/render/elements/chart-editable.ts
@@ -20,6 +20,7 @@ import {
 import type { ChartMarkDragState, ChartPartRef, ChartValueDragState } from 'pptx-viewer-shared';
 
 import type { ElementRenderContext } from '../types';
+import { createChartTitleEditor } from './chart-title-editor';
 
 /**
  * chart-editable: direct on-canvas chart editing for the vanilla binding, the
@@ -89,7 +90,6 @@ export function attachChartEditing(
 	let selected: ChartPartRef | null =
 		context.chartPartSelection?.elementId === element.id ? context.chartPartSelection.part : null;
 	let badge: HTMLElement | null = null;
-	let titleInput: HTMLInputElement | null = null;
 	applyChartPartHighlight(container, selected);
 
 	const showBadge = (text: string): void => {
@@ -184,52 +184,11 @@ export function attachChartEditing(
 		}
 	}
 
-	const closeTitleEditor = (): void => {
-		titleInput?.remove();
-		titleInput = null;
-	};
-
-	/**
-	 * Open an inline `<input>` over the chart title, the vanilla port of React's
-	 * / Vue's title editor overlay. Committed on Enter/blur, cancelled on
-	 * Escape; the commit routes through the SAME `onChartPointChange` path a
-	 * dragged data point uses, since both are just a `chartData` patch.
-	 */
-	const openTitleEditor = (): void => {
-		closeTitleEditor();
-		if (!chart.chartData) {
-			return;
-		}
-		const doc = container.ownerDocument;
-		titleInput = doc.createElement('input');
-		titleInput.type = 'text';
-		titleInput.className = 'pptxv-chart-title-input';
-		titleInput.value = chart.chartData.title ?? '';
-		const commitTitle = (): void => {
-			const value = titleInput?.value ?? '';
-			closeTitleEditor();
-			if (!chart.chartData) {
-				return;
-			}
+	const openTitleEditor = createChartTitleEditor(container, (value) => {
+		if (chart.chartData) {
 			context.onChartPointChange?.(element, withChartTitle(chart.chartData, value));
-		};
-		titleInput.addEventListener('blur', commitTitle, { once: true });
-		titleInput.addEventListener('keydown', (keyEvent) => {
-			if (keyEvent.key === 'Enter') {
-				keyEvent.preventDefault();
-				commitTitle();
-			} else if (keyEvent.key === 'Escape') {
-				keyEvent.preventDefault();
-				closeTitleEditor();
-			}
-			keyEvent.stopPropagation();
-		});
-		titleInput.addEventListener('pointerdown', (pointerEvent) => pointerEvent.stopPropagation());
-		titleInput.addEventListener('dblclick', (dblEvent) => dblEvent.stopPropagation());
-		container.appendChild(titleInput);
-		titleInput.focus();
-		titleInput.select();
-	};
+		}
+	});
 
 	container.addEventListener('dblclick', (event: MouseEvent) => {
 		const target = event.target;
@@ -238,7 +197,9 @@ export function attachChartEditing(
 		}
 		if (target.closest("[data-chart-part='title']")) {
 			event.stopPropagation();
-			openTitleEditor();
+			if (chart.chartData) {
+				openTitleEditor(chart.chartData.title ?? '');
+			}
 			return;
 		}
 		if (findChartPartTarget(event.target)) {

--- a/packages/vanilla/src/viewer/render/elements/chart-title-editor.ts
+++ b/packages/vanilla/src/viewer/render/elements/chart-title-editor.ts
@@ -1,0 +1,48 @@
+/** Open a chart-title input; Enter/blur commit and Escape cancels. */
+export function createChartTitleEditor(
+	container: HTMLElement,
+	onCommit: (value: string) => void,
+): (initialValue: string) => void {
+	let activeInput: HTMLInputElement | null = null;
+	const close = (input = activeInput): void => {
+		if (!input || input !== activeInput) {
+			return;
+		}
+		// Removing a focused input can synchronously fire its blur handler.
+		activeInput = null;
+		input.remove();
+	};
+
+	return (initialValue): void => {
+		close();
+		const input = container.ownerDocument.createElement('input');
+		activeInput = input;
+		input.type = 'text';
+		input.className = 'pptxv-chart-title-input';
+		input.value = initialValue;
+		const commit = (): void => {
+			if (input !== activeInput) {
+				return;
+			}
+			const value = input.value;
+			close(input);
+			onCommit(value);
+		};
+		input.addEventListener('blur', commit, { once: true });
+		input.addEventListener('keydown', (event) => {
+			if (event.key === 'Enter') {
+				event.preventDefault();
+				commit();
+			} else if (event.key === 'Escape') {
+				event.preventDefault();
+				close(input);
+			}
+			event.stopPropagation();
+		});
+		input.addEventListener('pointerdown', (event) => event.stopPropagation());
+		input.addEventListener('dblclick', (event) => event.stopPropagation());
+		container.appendChild(input);
+		input.focus();
+		input.select();
+	};
+}


### PR DESCRIPTION
## What does this change?

Fixes the Vanilla on-canvas chart-title editor committing a cancelled edit on Escape and creating a duplicate history entry on Enter. Both actions could also raise `NotFoundError`: removing the focused input fires blur, which re-enters the still-active editor's commit/close path.

The fix clears the active input before removing it and checks each handler's captured input identity. Enter and click-away still commit; Escape still cancels. Events from a detached previous input cannot affect a newly opened editor.

Christopher's original port (`48b997ca`) explicitly establishes those keyboard and blur semantics. The existing `withChartTitle`/`onChartPointChange` update path, focus, hit testing, drag behavior, and no-drilldown guard are unchanged. Only the title-input DOM plumbing is extracted to a 48-line internal helper, bringing the caller from 318 to 279 lines without a new public API or generic state machine.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

All five demos were tested in Chromium through normal off-center double-clicks, keyboard actions, click-away, reopening, and Undo. No forced clicks or programmatic editor-state mutations were used.

| Binding | Affected? | Fixed here? | Before-fix result |
| --- | --- | --- | --- |
| React | No | No change needed | Enter, Escape, blur and Undo controls passed |
| Vue | No | No change needed | Same controls passed |
| Angular | No | No change needed | Same controls passed |
| Svelte | No | No change needed | Same controls passed |
| Vanilla | Yes | Yes | Enter produced duplicate history; Escape committed cancelled text; both raised a close error |

This is Vanilla's imperative DOM lifecycle, not shared chart-title logic. The other bindings conditionally render their inputs through reactive draft state and did not reproduce the defect.

- [x] Reproduced the bug or confirmed its absence in every binding above
- [x] Every binding affected by this chart-title defect is fixed here

## Testing

- [x] Existing Vanilla test file updated; no new test file
- [x] Three regressions fail on unmodified main and pass with the fix
- [x] Existing framework-neutral `e2e/chart-title-runs.spec.ts` extended

Local checks, using Node 22:

- Full Vanilla suite: **1,813 passed** across 256 files.
- Focused chart editing: **19 passed**. Covers synchronous blur during Enter/Escape removal, editor replacement, stale Enter/Escape events, natural blur, selection and no-drilldown controls.
- Existing shared chart-title suite: **8 passed**.
- Framework-neutral chart-title browser spec: **25 passed** across all five bindings, including one-step Undo after Enter and blur, Escape cancellation, reopening, and no runtime errors.
- Vanilla typecheck, changed-file formatting/lint, E2E neutrality, and `git diff --check` passed.
- Independent source and browser reviews completed.

The browser cases use the existing multi-run fixture and do not depend on pending single-run display changes. This PR does not change chart serialization or claim native PowerPoint fidelity validation. The entire monorepo test suite was not rerun for this Vanilla-only lifecycle change.

## Conventional Commits

- [x] Commit follows Conventional Commits
