### PR TITLE
fix(svelte): focus the SmartArt node editor on entry

### DIFF
--- a/e2e/smartart-insert-edit.spec.ts
+++ b/e2e/smartart-insert-edit.spec.ts
@@ -14,9 +14,10 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { test, expect } from '@playwright/test';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
-import { resetTabSession } from './support/deck';
+import { savePptxViaBackstage } from './save-pptx';
+import { loadDeck as loadDeckFile, resetTabSession } from './support/deck';
 
 const fixturePath = resolve(fileURLToPath(new URL('./fixtures/sample-deck.pptx', import.meta.url)));
 
@@ -81,6 +82,139 @@ async function openInspector(page: Page): Promise<void> {
 		await page.waitForTimeout(200);
 	}
 	await expect(inspector).toBeVisible();
+}
+
+function currentSmartArt(page: Page): Locator {
+	return page.locator('[data-pptx-viewport] [data-testid^="smartart-"]').first();
+}
+
+function firstSmartArtNode(smartArt: Locator): Locator {
+	return smartArt.locator('[data-smartart-node-id]').first();
+}
+
+async function renderedNodeText(smartArt: Locator): Promise<string> {
+	const labels = await firstSmartArtNode(smartArt).locator('text').allTextContents();
+	return labels.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+async function unobstructedNodePoint(node: Locator): Promise<{ x: number; y: number }> {
+	const point = await node.evaluate((element) => {
+		const box = element.getBoundingClientRect();
+		for (const yFraction of [0.8, 0.65, 0.5, 0.35, 0.2]) {
+			for (const xFraction of [0.25, 0.5, 0.75, 0.1, 0.9]) {
+				const x = box.left + box.width * xFraction;
+				const y = box.top + box.height * yFraction;
+				if (document.elementFromPoint(x, y)?.closest('[data-smartart-node-id]') === element) {
+					return { x, y };
+				}
+			}
+		}
+		return null;
+	});
+	if (!point) {
+		throw new Error('SmartArt node has no unobstructed browser hit target');
+	}
+	return point;
+}
+
+async function openFocusedNodeEditor(
+	page: Page,
+	smartArt: Locator,
+): Promise<{
+	editor: Locator;
+	diagramBox: NonNullable<Awaited<ReturnType<Locator['boundingBox']>>>;
+}> {
+	const point = await unobstructedNodePoint(firstSmartArtNode(smartArt));
+	const diagramBox = await smartArt.boundingBox();
+	expect(diagramBox, 'SmartArt diagram should have a rendered box').not.toBeNull();
+	await page.mouse.dblclick(point.x, point.y);
+
+	const editor = page.locator('[data-pptx-viewport] textarea:visible');
+	await expect(editor).toHaveCount(1);
+	await expect(editor).toBeFocused();
+	return { editor, diagramBox: diagramBox! };
+}
+
+async function expectCaretClickDoesNotMoveDiagram(
+	editor: Locator,
+	smartArt: Locator,
+	diagramBox: NonNullable<Awaited<ReturnType<Locator['boundingBox']>>>,
+): Promise<void> {
+	const editorBox = await editor.boundingBox();
+	expect(editorBox, 'SmartArt editor should have a rendered box').not.toBeNull();
+	await editor.click({
+		position: { x: Math.max(1, editorBox!.width * 0.75), y: editorBox!.height / 2 },
+	});
+	await expect(editor).toBeFocused();
+	await expect
+		.poll(async () => {
+			const current = await smartArt.boundingBox();
+			return current
+				? {
+						x: Math.round(current.x),
+						y: Math.round(current.y),
+						width: Math.round(current.width),
+						height: Math.round(current.height),
+					}
+				: null;
+		})
+		.toStrictEqual({
+			x: Math.round(diagramBox.x),
+			y: Math.round(diagramBox.y),
+			width: Math.round(diagramBox.width),
+			height: Math.round(diagramBox.height),
+		});
+}
+
+async function blurNodeEditor(page: Page): Promise<void> {
+	await page
+		.getByRole('toolbar', { name: 'Presentation toolbar' })
+		.getByRole('tab', { name: 'Home', exact: true })
+		.click();
+	await expect(page.locator('[data-pptx-viewport] textarea:visible')).toHaveCount(0);
+}
+
+async function clickHistory(page: Page, name: 'Undo' | 'Redo'): Promise<void> {
+	const button = page.getByRole('button', { name, exact: true });
+	await expect(button).toBeEnabled();
+	await button.click();
+}
+
+function collectRuntimeErrors(page: Page): string[] {
+	const errors: string[] = [];
+	page.on('pageerror', (error) => errors.push(`${error.name}: ${error.message}`));
+	page.on('console', (message) => {
+		if (message.type() === 'error') {
+			errors.push(message.text());
+		}
+	});
+	return errors;
+}
+
+async function exerciseDirectKeyboardNodeEdit(
+	page: Page,
+	smartArt: Locator,
+	editedText: string,
+): Promise<void> {
+	const authoredText = await renderedNodeText(smartArt);
+	expect(authoredText).not.toBe('');
+	const { editor, diagramBox } = await openFocusedNodeEditor(page, smartArt);
+	await page.keyboard.type(editedText);
+	await expect(editor).toHaveValue(editedText);
+	await expectCaretClickDoesNotMoveDiagram(editor, smartArt, diagramBox);
+	await blurNodeEditor(page);
+	await expect.poll(() => renderedNodeText(smartArt)).toBe(editedText);
+
+	await clickHistory(page, 'Undo');
+	await expect.poll(() => renderedNodeText(smartArt)).toBe(authoredText);
+	await clickHistory(page, 'Redo');
+	await expect.poll(() => renderedNodeText(smartArt)).toBe(editedText);
+
+	const download = await savePptxViaBackstage(page);
+	const savedPath = await download.path();
+	expect(savedPath, 'the browser should retain the saved SmartArt deck').not.toBeNull();
+	await loadDeckFile(page, savedPath!);
+	await expect.poll(() => renderedNodeText(currentSmartArt(page))).toBe(editedText);
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -239,5 +373,16 @@ test.describe('smartart insert and edit', () => {
 		const changed =
 			fillsBefore.some((f, i) => fillsAfter[i] !== f) || fillsBefore.length !== fillsAfter.length;
 		expect(changed).toBe(true);
+	});
+
+	test('focuses an inserted fallback node for immediate keyboard editing', async ({ page }) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await loadDeck(page);
+		await switchToInsertTab(page);
+		await insertSmartArtPreset(page);
+		const smartArt = currentSmartArt(page);
+		await expect(smartArt).toBeVisible();
+		await exerciseDirectKeyboardNodeEdit(page, smartArt, 'Edited fallback node');
+		expect(runtimeErrors).toStrictEqual([]);
 	});
 });

--- a/packages/svelte/src/viewer/components/SmartArtDrawingView.svelte
+++ b/packages/svelte/src/viewer/components/SmartArtDrawingView.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { SMARTART_SVG_STYLE } from '../render';
+	import type { SmartArtDrawingViewProps } from './props';
+
+	const { view, canEditNodeText, onopeneditor, onshowstyle }: SmartArtDrawingViewProps = $props();
+</script>
+
+<svg
+	class="pptx-svelte-smartart-svg"
+	viewBox={view.viewBox}
+	preserveAspectRatio="xMidYMid meet"
+	style={SMARTART_SVG_STYLE}
+>
+	{#each view.shapes as shape (shape.key)}
+		<g
+			style={`${view.shadow ? `filter: ${view.shadow};` : ''}${shape.nodeId && canEditNodeText ? 'pointer-events: auto; cursor: text;' : ''}`}
+			data-smartart-node-id={shape.nodeId}
+			role={shape.ariaLabel ? 'img' : undefined}
+			aria-label={shape.ariaLabel}
+			ondblclick={(event) => onopeneditor(event, shape.nodeId)}
+			onmouseenter={(event) => onshowstyle(event, shape.nodeId)}
+		>
+			{#if shape.ariaLabel}<title>{shape.ariaLabel}</title>{/if}
+			{#if shape.gradient}
+				<defs>
+					{#if shape.gradient.kind === 'radial'}
+						<radialGradient
+							id={shape.gradient.id}
+							cx={shape.gradient.cx}
+							cy={shape.gradient.cy}
+							r={shape.gradient.r}
+						>
+							{#each shape.gradient.stops as stop, si (si)}
+								<stop
+									offset={stop.offset}
+									stop-color={stop.color}
+									stop-opacity={stop.opacity}
+								/>
+							{/each}
+						</radialGradient>
+					{:else}
+						<linearGradient
+							id={shape.gradient.id}
+							x1={shape.gradient.x1}
+							y1={shape.gradient.y1}
+							x2={shape.gradient.x2}
+							y2={shape.gradient.y2}
+						>
+							{#each shape.gradient.stops as stop, si (si)}
+								<stop
+									offset={stop.offset}
+									stop-color={stop.color}
+									stop-opacity={stop.opacity}
+								/>
+							{/each}
+						</linearGradient>
+					{/if}
+				</defs>
+			{/if}
+			{#if shape.kind === 'image'}
+				<image
+					x={shape.x}
+					y={shape.y}
+					width={shape.width}
+					height={shape.height}
+					href={shape.imageUrl}
+					preserveAspectRatio="xMidYMid meet"
+					transform={shape.transform}
+				/>
+			{:else if shape.kind === 'ellipse'}
+				<ellipse
+					cx={shape.cx}
+					cy={shape.cy}
+					rx={shape.width / 2}
+					ry={shape.height / 2}
+					fill={shape.fill}
+					stroke={shape.stroke}
+					stroke-width={shape.strokeWidth}
+					transform={shape.transform}
+				/>
+			{:else if shape.kind === 'path'}
+				<path
+					d={shape.pathData}
+					fill={shape.fill}
+					stroke={shape.stroke}
+					stroke-width={shape.strokeWidth}
+					transform={shape.pathTransform}
+				/>
+			{:else}
+				<rect
+					x={shape.x}
+					y={shape.y}
+					width={shape.width}
+					height={shape.height}
+					rx={shape.rx}
+					fill={shape.fill}
+					stroke={shape.stroke}
+					stroke-width={shape.strokeWidth}
+					transform={shape.transform}
+				/>
+			{/if}
+			{#if shape.textLines.length > 0}
+				<text
+					x={shape.textX}
+					text-anchor="middle"
+					dominant-baseline="central"
+					fill={shape.fontColor}
+					font-family={shape.fontFamily}
+					font-weight={shape.fontWeight}
+					font-style={shape.fontStyle}
+					font-size={shape.fontSize}
+				>
+					{#each shape.textLines as line, i (i)}
+						<tspan x={shape.textX} y={line.y}>{line.text}</tspan>
+					{/each}
+				</text>
+			{/if}
+		</g>
+	{/each}
+</svg>

--- a/packages/svelte/src/viewer/components/SmartArtView.svelte
+++ b/packages/svelte/src/viewer/components/SmartArtView.svelte
@@ -31,6 +31,7 @@
 	import type { RenderedNode } from 'pptx-viewer-shared';
 	import { getContainerStyle, styleToString } from '../style';
 	import type { ElementRendererProps } from './props';
+	import SmartArtDrawingView from './SmartArtDrawingView.svelte';
 
 	const { element, zIndex, interactive, marked = false, animationState, onsmartartnodecommit, onsmartartnodefill }: ElementRendererProps = $props();
 	const t = useTranslator();
@@ -82,6 +83,14 @@
 		if (!editing || !smartArt) {return;}
 		onsmartartnodecommit?.(smartArt.id, editing.nodeId, draft);
 		editing = null;
+	}
+
+	function focusInput(node: HTMLTextAreaElement): void {
+		queueMicrotask(() => {
+			if (!node.isConnected) {return;}
+			node.focus();
+			node.select();
+		});
 	}
 
 	function editorKeydown(event: KeyboardEvent): void {
@@ -137,119 +146,7 @@
 			aria-label={ariaLabel}
 		>
 			{#if view.kind === 'drawing'}
-				<svg
-					class="pptx-svelte-smartart-svg"
-					viewBox={view.viewBox}
-					preserveAspectRatio="xMidYMid meet"
-					style={SMARTART_SVG_STYLE}
-				>
-					{#each view.shapes as shape (shape.key)}
-						<g
-							style={`${view.shadow ? `filter: ${view.shadow};` : ''}${shape.nodeId && onsmartartnodecommit ? 'pointer-events: auto; cursor: text;' : ''}`}
-							data-smartart-node-id={shape.nodeId}
-							role={shape.ariaLabel ? 'img' : undefined}
-							aria-label={shape.ariaLabel}
-							ondblclick={(event) => openEditor(event, shape.nodeId)}
-							onmouseenter={(event) => showStyle(event, shape.nodeId)}
-						>
-							{#if shape.ariaLabel}<title>{shape.ariaLabel}</title>{/if}
-							{#if shape.gradient}
-								<defs>
-									{#if shape.gradient.kind === 'radial'}
-										<radialGradient
-											id={shape.gradient.id}
-											cx={shape.gradient.cx}
-											cy={shape.gradient.cy}
-											r={shape.gradient.r}
-										>
-											{#each shape.gradient.stops as stop, si (si)}
-												<stop
-													offset={stop.offset}
-													stop-color={stop.color}
-													stop-opacity={stop.opacity}
-												/>
-											{/each}
-										</radialGradient>
-									{:else}
-										<linearGradient
-											id={shape.gradient.id}
-											x1={shape.gradient.x1}
-											y1={shape.gradient.y1}
-											x2={shape.gradient.x2}
-											y2={shape.gradient.y2}
-										>
-											{#each shape.gradient.stops as stop, si (si)}
-												<stop
-													offset={stop.offset}
-													stop-color={stop.color}
-													stop-opacity={stop.opacity}
-												/>
-											{/each}
-										</linearGradient>
-									{/if}
-								</defs>
-							{/if}
-							{#if shape.kind === 'image'}
-								<image
-									x={shape.x}
-									y={shape.y}
-									width={shape.width}
-									height={shape.height}
-									href={shape.imageUrl}
-									preserveAspectRatio="xMidYMid meet"
-									transform={shape.transform}
-								/>
-							{:else if shape.kind === 'ellipse'}
-								<ellipse
-									cx={shape.cx}
-									cy={shape.cy}
-									rx={shape.width / 2}
-									ry={shape.height / 2}
-									fill={shape.fill}
-									stroke={shape.stroke}
-									stroke-width={shape.strokeWidth}
-									transform={shape.transform}
-								/>
-							{:else if shape.kind === 'path'}
-								<path
-									d={shape.pathData}
-									fill={shape.fill}
-									stroke={shape.stroke}
-									stroke-width={shape.strokeWidth}
-									transform={shape.pathTransform}
-								/>
-							{:else}
-								<rect
-									x={shape.x}
-									y={shape.y}
-									width={shape.width}
-									height={shape.height}
-									rx={shape.rx}
-									fill={shape.fill}
-									stroke={shape.stroke}
-									stroke-width={shape.strokeWidth}
-									transform={shape.transform}
-								/>
-							{/if}
-							{#if shape.textLines.length > 0}
-								<text
-									x={shape.textX}
-									text-anchor="middle"
-									dominant-baseline="central"
-									fill={shape.fontColor}
-									font-family={shape.fontFamily}
-									font-weight={shape.fontWeight}
-									font-style={shape.fontStyle}
-									font-size={shape.fontSize}
-								>
-									{#each shape.textLines as line, i (i)}
-										<tspan x={shape.textX} y={line.y}>{line.text}</tspan>
-									{/each}
-								</text>
-							{/if}
-						</g>
-					{/each}
-				</svg>
+				<SmartArtDrawingView {view} canEditNodeText={Boolean(onsmartartnodecommit)} onopeneditor={openEditor} onshowstyle={showStyle} />
 			{:else if view.kind === 'layout'}
 				<svg
 					class="pptx-svelte-smartart-svg"
@@ -296,11 +193,13 @@
 			{/if}
 			{#if editing}
 				<textarea
+					use:focusInput
 					class="pptx-svelte-smartart-editor"
 					style={`left:${editing.left}px;top:${editing.top}px;width:${editing.width}px;height:${editing.height}px`}
 					bind:value={draft}
 					onkeydown={editorKeydown}
 					onblur={commitEdit}
+					onpointerdown={(event) => event.stopPropagation()}
 					onclick={(event) => event.stopPropagation()}
 				></textarea>
 			{/if}

--- a/packages/svelte/src/viewer/components/props-elements.ts
+++ b/packages/svelte/src/viewer/components/props-elements.ts
@@ -1,6 +1,8 @@
 import type { PptxChartData, PptxElement, ShapeStyle } from 'pptx-viewer-core';
 import type { ElementAnimationState, RenderParagraph } from 'pptx-viewer-shared';
 
+import type { SmartArtView } from '../render';
+
 /**
  * Prop contracts for the element-level renderers (the per-`PptxElement` views
  * and the shared text block). Split out of `props.ts` to keep every source
@@ -121,6 +123,14 @@ export interface ElementRendererProps {
 	ontableresizecolumns?: (elementId: string, widths: number[]) => void;
 	/** Commit one row's new pixel height after a row-boundary drag. */
 	ontableresizerow?: (elementId: string, rowIndex: number, height: number) => void;
+}
+
+/** Stateless cached drawing branch of the SmartArt renderer. */
+export interface SmartArtDrawingViewProps {
+	view: Extract<SmartArtView, { kind: 'drawing' }>;
+	canEditNodeText: boolean;
+	onopeneditor: (event: MouseEvent, nodeId: string | undefined) => void;
+	onshowstyle: (event: MouseEvent, nodeId: string | undefined) => void;
 }
 
 export interface TextBlockProps {

--- a/packages/svelte/src/viewer/components/props.ts
+++ b/packages/svelte/src/viewer/components/props.ts
@@ -8,7 +8,11 @@
  * single file exceeds the repo's size budget.
  */
 
-export type { ElementRendererProps, TextBlockProps } from './props-elements';
+export type {
+	ElementRendererProps,
+	SmartArtDrawingViewProps,
+	TextBlockProps,
+} from './props-elements';
 export type { SlideCanvasProps, SlideStageProps } from './props-stage';
 export type { NotesPanelProps, ThumbnailRailProps, ViewerToolbarProps } from './props-chrome';
 export type {

--- a/packages/svelte/src/viewer/components/smartart-view.test.ts
+++ b/packages/svelte/src/viewer/components/smartart-view.test.ts
@@ -66,6 +66,34 @@ function drawingShapesElement(): PptxElement {
 	};
 }
 
+function fallbackLayoutElement(): PptxElement {
+	return {
+		type: 'smartArt',
+		id: 'sa-layout',
+		x: 0,
+		y: 0,
+		width: 400,
+		height: 240,
+		smartArtData: {
+			nodes: [{ id: 'n1', text: 'Alpha' }],
+		},
+	};
+}
+
+function openNodeEditorNow(target: HTMLElement): HTMLTextAreaElement {
+	const group = target.querySelector<SVGGElement>('[data-smartart-node-id="n1"]')!;
+	group.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+	flushSync();
+	return target.querySelector<HTMLTextAreaElement>('.pptx-svelte-smartart-editor')!;
+}
+
+async function openNodeEditor(target: HTMLElement): Promise<HTMLTextAreaElement> {
+	const editor = openNodeEditorNow(target);
+	await Promise.resolve();
+	flushSync();
+	return editor;
+}
+
 describe('smartArtView', () => {
 	it('renders pre-computed drawing shapes as SVG rect/ellipse with labels', () => {
 		const target = mountEl(drawingShapesElement());
@@ -181,6 +209,106 @@ describe('smartArtView', () => {
 		editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 		flushSync();
 		expect(onsmartartnodecommit).toHaveBeenCalledWith('sa-1', 'n1', 'Changed');
+	});
+
+	it.each([
+		['drawing-shapes', drawingShapesElement],
+		['fallback-layout', fallbackLayoutElement],
+	] as const)('focuses and selects the %s node editor when it opens', async (_name, element) => {
+		const target = mountEl(element(), 3, {
+			interactive: true,
+			onsmartartnodecommit: vi.fn(),
+		});
+		const editor = await openNodeEditor(target);
+
+		expect(document.activeElement).toBe(editor);
+		expect(editor.value).toBe('Alpha');
+		expect(editor.selectionStart).toBe(0);
+		expect(editor.selectionEnd).toBe(editor.value.length);
+	});
+
+	it('isolates editor pointerdown without preventing native caret behavior or reselecting after input', async () => {
+		const target = mountEl(drawingShapesElement(), 3, {
+			interactive: true,
+			onsmartartnodecommit: vi.fn(),
+		});
+		const parentPointerDown = vi.fn();
+		const onParentPointerDown = (event: PointerEvent): void => {
+			parentPointerDown();
+			event.preventDefault();
+		};
+		document.body.addEventListener('pointerdown', onParentPointerDown);
+		const editor = await openNodeEditor(target);
+		const pointerDown = new PointerEvent('pointerdown', { bubbles: true, cancelable: true });
+
+		editor.dispatchEvent(pointerDown);
+		document.body.removeEventListener('pointerdown', onParentPointerDown);
+		expect(parentPointerDown).not.toHaveBeenCalled();
+		expect(pointerDown.defaultPrevented).toBeFalsy();
+
+		editor.value = 'AlXpha';
+		editor.setSelectionRange(3, 3);
+		editor.dispatchEvent(new Event('input', { bubbles: true }));
+		flushSync();
+		await Promise.resolve();
+		expect(target.querySelector('.pptx-svelte-smartart-editor')).toBe(editor);
+		expect(editor.selectionStart).toBe(3);
+		expect(editor.selectionEnd).toBe(3);
+	});
+
+	it('does not focus a stale editor after it is unmounted before the queued action runs', async () => {
+		const target = mountEl(drawingShapesElement(), 3, {
+			interactive: true,
+			onsmartartnodecommit: vi.fn(),
+		});
+		const editor = openNodeEditorNow(target);
+		const focus = vi.spyOn(editor, 'focus');
+		const select = vi.spyOn(editor, 'select');
+		const dispose = cleanup;
+		cleanup = undefined;
+		dispose?.();
+
+		await Promise.resolve();
+		expect(editor.isConnected).toBeFalsy();
+		expect(focus).not.toHaveBeenCalled();
+		expect(select).not.toHaveBeenCalled();
+	});
+
+	it('cancels without committing and focuses the editor again when reopened', async () => {
+		const onsmartartnodecommit = vi.fn();
+		const target = mountEl(drawingShapesElement(), 3, {
+			interactive: true,
+			onsmartartnodecommit,
+		});
+		const editor = await openNodeEditor(target);
+		editor.value = 'Discarded';
+		editor.dispatchEvent(new Event('input', { bubbles: true }));
+		const escape = new KeyboardEvent('keydown', {
+			key: 'Escape',
+			bubbles: true,
+			cancelable: true,
+		});
+		editor.dispatchEvent(escape);
+		flushSync();
+		await Promise.resolve();
+		expect(escape.defaultPrevented).toBeTruthy();
+		expect(onsmartartnodecommit).not.toHaveBeenCalled();
+		expect(target.querySelector('.pptx-svelte-smartart-editor')).toBeNull();
+
+		const reopened = await openNodeEditor(target);
+		expect(document.activeElement).toBe(reopened);
+		expect(reopened.value).toBe('Alpha');
+		expect(reopened.selectionStart).toBe(0);
+		expect(reopened.selectionEnd).toBe(reopened.value.length);
+	});
+
+	it('does not expose the node editor without an editing callback', () => {
+		const target = mountEl(drawingShapesElement(), 3, { interactive: true });
+		const group = target.querySelector<SVGGElement>('[data-smartart-node-id="n1"]')!;
+
+		group.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+		flushSync();
+		expect(target.querySelector('.pptx-svelte-smartart-editor')).toBeNull();
 	});
 
 	// G8 (OpenXML parity audit, D3): a:graphicFrameLocks/@noDrilldown was


### PR DESCRIPTION
## What does this change?

Makes the Svelte SmartArt node editor ready for typing after a double-click. Previously, the textarea appeared but never received focus; clicking it also bubbled into the canvas move handler, which prevented native focus.

The textarea now focuses and selects its text once on mount, and stops pointerdown from reaching the canvas without preventing normal caret placement. Queued work is ignored if the textarea has already unmounted. Enter, Escape, blur, history, and locking policies are unchanged.

The existing drawing SVG is moved unchanged into a small sibling component to keep source files below 300 lines. No wrapper, geometry, styling, accessibility, or event target changes are introduced.

## Type of change

- [x] Bug fix (non-breaking)

## Why this behavior?

The original Svelte SmartArt editing commit (`304d9c2d`) explicitly aimed to match React. React, Vue, Angular, and Vanilla already focus/select their SmartArt editors and isolate canvas pointer handling. This follows Svelte's existing table-editor mount-action pattern; it does not change the shared canvas gesture policy.

## Cross-binding parity

| Binding | Affected by missing focus? | Checked |
| --- | --- | --- |
| React | No | Inserted fallback and imported drawing flows |
| Vue | No | Inserted fallback and imported drawing flows |
| Angular | No on fallback; separate imported-entry bug | Fallback passes; imported drawing opens a generic editor, tracked in #239 |
| Svelte | Yes, fixed here | Both fallback and imported drawing, including save/reload |
| Vanilla | No | Inserted fallback and imported drawing flows |

The broader imported-drawing check passed in four bindings and exposed Angular's separate missing node-entry handler (#239). That is not fixed or claimed here. The tracked neutral regression covers the complete inserted-fallback flow; Svelte's imported-drawing path also has component coverage and a passing real-browser supplement. The Angular follow-up is being investigated separately.

- [x] Reproduced this focus bug, or checked its absence, across all five bindings.
- [x] Fixed the Svelte focus defect without changing other bindings' editing policies.

## Testing

- Existing Svelte component test file covers drawing and fallback entry focus, initial selection, pointer isolation, selection stability after typing, stale unmount work, cancel/reopen, and callback-absent/locked controls.
- Existing neutral SmartArt browser spec covers inserted fallback with real double-click and immediate keyboard typing, then caret clicks, natural blur, history, and save/reload. Imported drawing was exercised separately as described above.
- No programmatic focus, fill, forced clicks, or framework-internal state changes are used to make entry succeed.

Results:

- Unchanged-source baseline: 4/18 component tests failed as expected; both Svelte browser routes failed immediate focus.
- Focused component suite: 18/18 passed.
- Full Svelte suite: 1,808/1,808 tests passed across 286 files.
- Tracked browser spec: 25/25 passed across all five bindings.
- Imported-drawing supplement: 4/5 passed; Angular's separate failure is tracked in #239.
- Svelte typecheck: 0 errors, 5 existing warnings in unchanged files.
- Fresh package builds, changed-file formatting/lint, E2E neutrality, and diff checks passed. Independent code and actual-browser reviews completed.

The entire monorepo test suite was not rerun for this framework-local fix. Browser and saved-file reload checks are not native PowerPoint visual validation.

## Conventional Commits

- [x] Uses a `fix(svelte)` Conventional Commit.
