### PR TITLE
fix: preserve the current deck when an older load finishes

### DIFF
--- a/packages/angular/src/viewer/load-content-stale.test.ts
+++ b/packages/angular/src/viewer/load-content-stale.test.ts
@@ -1,0 +1,68 @@
+import { Injector } from '@angular/core';
+import { PptxHandler } from 'pptx-viewer-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	editPresentation,
+	holdPresentationAsset,
+	presentationLoadFixtures,
+} from '../../../shared/test-utils/presentation-load.mjs';
+import { LoadContentService } from './load-content.service';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('presentation load cancellation after parsing', () => {
+	it.each([
+		['replace', 'image'],
+		['destroy', 'image'],
+		['replace', 'media'],
+		['destroy', 'media'],
+	] as const)(
+		'discards delayed assets on %s (%s)',
+		async (action, asset) => {
+			const fixtures = await presentationLoadFixtures(PptxHandler, asset);
+			const held = holdPresentationAsset(PptxHandler, asset);
+			const injector = Injector.create({
+				providers: [{ provide: LoadContentService, useClass: LoadContentService }],
+			});
+			const destroy = () => {
+				if (!injector.destroyed) {
+					injector.destroy();
+				}
+			};
+			const loader = injector.get(LoadContentService);
+			const first = loader.load(fixtures.first);
+			try {
+				await held.entered;
+				if (action === 'destroy') {
+					destroy();
+				} else {
+					await loader.load(fixtures.second);
+					loader.slides.set(editPresentation(loader.slides()));
+				}
+				const currentMedia = [...loader.mediaDataUrls()];
+				held.release();
+				await first;
+				if (action === 'replace') {
+					expect([...loader.mediaDataUrls()]).toStrictEqual(currentMedia);
+					expect(loader.coreProperties()?.title).toBe('Presentation B');
+					expect(loader.slides()[0].notes).toBe('Unsaved edit in B');
+					const saved = new PptxHandler();
+					try {
+						const data = await saved.load((await loader.getContent()).buffer as ArrayBuffer);
+						expect(data.slides[0].notes).toBe('Unsaved edit in B');
+					} finally {
+						saved.dispose();
+					}
+				} else {
+					expect(loader.slides()).toHaveLength(0);
+				}
+				expect(held.disposal).toHaveBeenCalledOnce();
+			} finally {
+				held.release();
+				destroy();
+			}
+		},
+		30_000,
+	);
+});

--- a/packages/angular/src/viewer/load-content.service.ts
+++ b/packages/angular/src/viewer/load-content.service.ts
@@ -41,6 +41,7 @@ import {
 	collectAnimationSoundPaths,
 	collectImagePaths,
 	collectMediaElements,
+	createPresentationLoadResources,
 	describeFontEmbedding,
 	resolveMediaElementSource,
 	resolveSlideSizeSelection,
@@ -320,7 +321,9 @@ export class LoadContentService {
 			return;
 		}
 		const token = ++this.renderToken;
-		const loadBlobUrls: string[] = [];
+		const newHandler = new PptxHandler();
+		const resources = createPresentationLoadResources(newHandler);
+		const loadBlobUrls = resources.blobUrls;
 
 		try {
 			this.loading.set(true);
@@ -345,7 +348,6 @@ export class LoadContentService {
 			const sigBuffer = (buffer as ArrayBuffer).slice(0);
 
 			const previousHandler = this.handler;
-			const newHandler = new PptxHandler();
 			// Trust Center > "Allow external content": gates linked (non-embedded)
 			// http(s) image URLs. Defaults to blocked when the options service is
 			// unreachable (e.g. constructed outside DI in a unit test).
@@ -362,17 +364,14 @@ export class LoadContentService {
 			);
 			const parsed = await newHandler.load(buffer as ArrayBuffer, { allowExternalImages });
 			if (token !== this.renderToken) {
-				newHandler.dispose();
 				return;
 			}
-			previousHandler?.dispose();
 
 			// ── Resolve media Blob URLs (audio/video + poster frames) ──
 			const mediaElements: MediaPptxElement[] = [];
 			for (const slide of parsed.slides) {
 				collectMediaElements(slide.elements, mediaElements);
 			}
-			this.revokeBlobUrls(Array.from(this.mediaDataUrls().values()));
 			const nextMediaUrls = new Map<string, string>();
 			// Shared with the other four bindings (G17): a LINKED media
 			// element's `mediaPath` is already the verbatim external URL by the
@@ -449,8 +448,14 @@ export class LoadContentService {
 			);
 
 			// Commit reactive state.
+			if (token !== this.renderToken) {
+				return;
+			}
+			previousHandler?.dispose();
+			this.revokeBlobUrls(Array.from(this.mediaDataUrls().values()));
 			this.revokeBlobUrls(this.activeBlobUrls);
 			this.activeBlobUrls = loadBlobUrls;
+			resources.commit();
 			this.handler = newHandler;
 			this.slides.set(nextSlides);
 			this.parsedData.set({ ...parsed, slides: nextSlides, tableStyleMap: nextTableStyleMap });
@@ -539,6 +544,7 @@ export class LoadContentService {
 				}
 			}
 		} finally {
+			resources.releaseIfUncommitted();
 			if (token === this.renderToken) {
 				this.loading.set(false);
 			}

--- a/packages/react/src/viewer/hooks/useLoadContent.stale.test.tsx
+++ b/packages/react/src/viewer/hooks/useLoadContent.stale.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { PptxHandler } from 'pptx-viewer-core';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	editPresentation,
+	holdPresentationAsset,
+	presentationLoadFixtures,
+	settlePresentationLoad,
+} from '../../../../shared/test-utils/presentation-load.mjs';
+import type { EditorHistoryResult } from './useEditorHistory';
+import { useLoadContent } from './useLoadContent';
+import { useViewerState } from './useViewerState';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('presentation load cancellation after parsing', () => {
+	it.each([
+		['replace', 'image'],
+		['unmount', 'image'],
+		['replace', 'media'],
+		['unmount', 'media'],
+	] as const)(
+		'discards delayed assets on %s (%s)',
+		async (action, asset) => {
+			const fixtures = await presentationLoadFixtures(PptxHandler, asset);
+			const held = holdPresentationAsset(PptxHandler, asset);
+			const resetHistory = vi.fn();
+			const applied = vi.fn();
+			let state!: ReturnType<typeof useViewerState>;
+			let loaded!: ReturnType<typeof useLoadContent>;
+			function Harness({ content }: { content: Uint8Array }) {
+				state = useViewerState({ content, canEdit: true });
+				loaded = useLoadContent({
+					...state,
+					content,
+					clearSelection: vi.fn(),
+					history: { resetHistory } as unknown as EditorHistoryResult,
+					setIsEncrypted: vi.fn(),
+					setReadOnlyRecommendation: vi.fn(),
+					setModifyVerifier: vi.fn(),
+					setCompatToasts: vi.fn(),
+					onContentApplied: applied,
+				});
+				return null;
+			}
+			const host = document.createElement('div');
+			const root = createRoot(host);
+			let unmounted = false;
+			try {
+				await act(async () => {
+					root.render(<Harness content={fixtures.first} />);
+				});
+				await held.entered;
+				if (action === 'unmount') {
+					await act(async () => root.unmount());
+					unmounted = true;
+				} else {
+					await act(async () => {
+						root.render(<Harness content={fixtures.second} />);
+					});
+					await vi.waitFor(async () => {
+						await act(settlePresentationLoad);
+						expect(state.coreProperties?.title).toBe('Presentation B');
+					});
+					await act(async () => {
+						state.setSlides(editPresentation(state.slides));
+						state.setIsDirty(true);
+					});
+				}
+				const currentMedia = [...state.mediaDataUrls];
+				const currentHandler = loaded.handlerRef.current;
+				await act(async () => {
+					held.release();
+					await settlePresentationLoad();
+				});
+				if (action === 'replace') {
+					expect([...state.mediaDataUrls]).toStrictEqual(currentMedia);
+					expect(state.coreProperties?.title).toBe('Presentation B');
+					expect(state.slides[0].notes).toBe('Unsaved edit in B');
+					expect(state.isDirty).toBeTruthy();
+					expect(loaded.handlerRef.current).toBe(currentHandler);
+				}
+				expect(applied).toHaveBeenCalledTimes(action === 'replace' ? 1 : 0);
+				expect(resetHistory).toHaveBeenCalledTimes(action === 'replace' ? 1 : 0);
+				expect(held.disposal).toHaveBeenCalledOnce();
+			} finally {
+				held.release();
+				if (!unmounted) {
+					await act(async () => root.unmount());
+				}
+				host.remove();
+			}
+		},
+		30_000,
+	);
+});

--- a/packages/react/src/viewer/hooks/useLoadContent.ts
+++ b/packages/react/src/viewer/hooks/useLoadContent.ts
@@ -30,6 +30,7 @@ import type {
 import {
 	applyImagePathPatches,
 	compatibilityWarningToasts,
+	createPresentationLoadResources,
 	readOnlyRecommendation,
 	resolveAuthoredCustomShowId,
 	resolveTableCellImageUrls,
@@ -203,7 +204,9 @@ export function useLoadContent({
 
 		// Track Blob URLs created in this load cycle so they can be revoked
 		// on unmount or when a new file is loaded.
-		const loadBlobUrls: string[] = [];
+		const handler = new PptxHandler();
+		const resources = createPresentationLoadResources(handler);
+		const loadBlobUrls = resources.blobUrls;
 
 		(async () => {
 			try {
@@ -230,34 +233,20 @@ export function useLoadContent({
 				// of broken images while the new file loads.
 				const previousHandler = handlerRef.current;
 
-				const handler = new PptxHandler();
 				// Trust Center > "Allow external content" (default off, matching
 				// core's own SSRF/privacy-safe default): only pass `true` through
 				// when the option is explicitly on.
 				const parsed = await handler.load(buffer as ArrayBuffer, { allowExternalImages });
 				if (cancelled || token !== renderTokenRef.current) {
-					handler.dispose();
 					return;
 				}
-
-				// New load succeeded: now safe to dispose the previous handler.
-				if (previousHandler) {
-					previousHandler.dispose();
-				}
-				handlerRef.current = null;
 
 				// ── Resolve media Blob URLs (audio/video) ───────────────────
 				const mediaElements: MediaPptxElement[] = [];
 				for (const slide of parsed.slides) {
 					collectMediaElements(slide.elements, mediaElements);
 				}
-				// Revoke old media Blob URLs before replacing
-				for (const url of mediaDataUrls.values()) {
-					if (url.startsWith('blob:')) {
-						URL.revokeObjectURL(url);
-					}
-				}
-				mediaDataUrls.clear();
+				const nextMediaUrls = new Map<string, string>();
 				// Shared with the other four bindings (G17): a LINKED media
 				// element's `mediaPath` is already the verbatim external URL by
 				// the time it reaches here, and `resolveMediaElementSource` hands
@@ -270,7 +259,7 @@ export function useLoadContent({
 							mediaElement.mediaMissing = true;
 							return;
 						}
-						mediaDataUrls.set(resolved.mediaPath, resolved.url);
+						nextMediaUrls.set(resolved.mediaPath, resolved.url);
 						if (resolved.isBlobUrl) {
 							loadBlobUrls.push(resolved.url);
 						}
@@ -323,6 +312,21 @@ export function useLoadContent({
 					handler.getImageData(path),
 				);
 
+				// Content can change while media, pictures or table fills are resolving.
+				if (cancelled || token !== renderTokenRef.current) {
+					return;
+				}
+				previousHandler?.dispose();
+				for (const url of mediaDataUrls.values()) {
+					if (url.startsWith('blob:')) {
+						URL.revokeObjectURL(url);
+					}
+				}
+				mediaDataUrls.clear();
+				for (const [path, url] of nextMediaUrls) {
+					mediaDataUrls.set(path, url);
+				}
+				resources.commit();
 				handlerRef.current = handler;
 				// Separate the inherited master/layout (template) elements that the
 				// core loader merged into `slide.elements` into their own per-slide
@@ -432,6 +436,7 @@ export function useLoadContent({
 					}
 				}
 			} finally {
+				resources.releaseIfUncommitted();
 				if (!cancelled && token === renderTokenRef.current) {
 					setLoading(false);
 				}

--- a/packages/shared/src/loader/index.ts
+++ b/packages/shared/src/loader/index.ts
@@ -1,4 +1,5 @@
 export type { GuideEntry, ImagePathElement, TableCellImageRef } from './load-content-helpers';
+export { createPresentationLoadResources } from './presentation-load-resources';
 export {
 	collectMediaElements,
 	collectAnimationSoundPaths,

--- a/packages/shared/src/loader/presentation-load-resources.test.ts
+++ b/packages/shared/src/loader/presentation-load-resources.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createPresentationLoadResources } from './presentation-load-resources';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('presentation load resources', () => {
+	it('releases an abandoned handler and its media once, including URLs added after cancellation', () => {
+		const handler = { dispose: vi.fn() };
+		const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+		const resources = createPresentationLoadResources(handler);
+		resources.blobUrls.push('blob:early');
+		// A media read may settle after the viewer has moved to another file.
+		resources.blobUrls.push('blob:late', 'https://example.test/linked.mp4');
+		resources.releaseIfUncommitted();
+		resources.releaseIfUncommitted();
+		expect(handler.dispose).toHaveBeenCalledOnce();
+		expect(revoke.mock.calls).toStrictEqual([['blob:early'], ['blob:late']]);
+	});
+
+	it('leaves committed resources owned by the viewer', () => {
+		const handler = { dispose: vi.fn() };
+		const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+		const resources = createPresentationLoadResources(handler);
+		resources.blobUrls.push('blob:current');
+		resources.commit();
+		resources.releaseIfUncommitted();
+		expect(handler.dispose).not.toHaveBeenCalled();
+		expect(revoke).not.toHaveBeenCalled();
+	});
+});

--- a/packages/shared/src/loader/presentation-load-resources.ts
+++ b/packages/shared/src/loader/presentation-load-resources.ts
@@ -1,0 +1,26 @@
+/** Keep a load's resources private until the binding accepts its result. */
+export function createPresentationLoadResources(handler: { dispose(): void }) {
+	const blobUrls: string[] = [];
+	let committed = false;
+	let released = false;
+	return {
+		blobUrls,
+		/** The live viewer now owns the handler and media URLs. */
+		commit(): void {
+			committed = true;
+		},
+		/** Call in finally, after pending asset reads have settled. */
+		releaseIfUncommitted(): void {
+			if (committed || released) {
+				return;
+			}
+			released = true;
+			handler.dispose();
+			for (const url of blobUrls) {
+				if (url.startsWith('blob:')) {
+					URL.revokeObjectURL(url);
+				}
+			}
+		},
+	};
+}

--- a/packages/shared/test-utils/presentation-load.d.mts
+++ b/packages/shared/test-utils/presentation-load.d.mts
@@ -1,0 +1,20 @@
+import type { PptxHandler, PptxSlide } from 'pptx-viewer-core';
+import type { MockInstance } from 'vitest';
+
+export function presentationLoadFixtures(
+	Handler: typeof PptxHandler,
+	asset?: 'image' | 'media',
+): Promise<{ first: Uint8Array; second: Uint8Array }>;
+
+export function holdPresentationAsset(
+	Handler: typeof PptxHandler,
+	asset?: 'image' | 'media',
+): {
+	entered: Promise<void>;
+	release(): void;
+	readonly handler: PptxHandler | undefined;
+	readonly disposal: MockInstance<() => void> | undefined;
+};
+
+export function editPresentation(slides: PptxSlide[]): PptxSlide[];
+export function settlePresentationLoad(): Promise<void>;

--- a/packages/shared/test-utils/presentation-load.mjs
+++ b/packages/shared/test-utils/presentation-load.mjs
@@ -1,0 +1,86 @@
+import { vi } from 'vitest';
+
+const PNG =
+	'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+/** Small real OOXML archives, parsed normally by each binding under test. */
+export async function presentationLoadFixtures(Handler, asset = 'image') {
+	async function deck(title, image) {
+		const { handler, createSlide } = await Handler.create({ title, initialSlideCount: 0 });
+		try {
+			const slide = createSlide('Blank').addText(title, {
+				x: 50,
+				y: 50,
+				width: 400,
+				height: 60,
+			});
+			if (image && asset === 'image') {
+				slide.addImage(PNG, { x: 50, y: 150, width: 100, height: 100 });
+			}
+			if (asset === 'media') {
+				slide.addMedia(
+					'audio',
+					'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQAAAAA=',
+					{ x: 50, y: 150, width: 100, height: 100 },
+				);
+			}
+			return await handler.save([slide.build()]);
+		} finally {
+			handler.dispose();
+		}
+	}
+	return { first: await deck('Presentation A', true), second: await deck('Presentation B', false) };
+}
+/** Delay a real asset read after parsing, without replacing parsed slides. */
+export function holdPresentationAsset(Handler, asset = 'image') {
+	let release;
+	const gate = new Promise((resolve) => {
+		release = resolve;
+	});
+	let started;
+	const entered = new Promise((resolve) => {
+		started = resolve;
+	});
+	const owner = {};
+	let dispose;
+	function delay(read) {
+		return async function (path) {
+			if (!owner.handler) {
+				owner.handler = this;
+				dispose = vi.spyOn(this, 'dispose');
+				started();
+			}
+			if (this === owner.handler) {
+				await gate;
+			}
+			return read.call(this, path);
+		};
+	}
+	if (asset === 'image') {
+		const read = Handler.prototype.getImageData;
+		vi.spyOn(Handler.prototype, 'getImageData').mockImplementation(delay(read));
+	} else {
+		const read = Handler.prototype.getMediaArrayBuffer;
+		vi.spyOn(Handler.prototype, 'getMediaArrayBuffer').mockImplementation(delay(read));
+	}
+	return {
+		entered,
+		release,
+		get handler() {
+			return owner.handler;
+		},
+		get disposal() {
+			return dispose;
+		},
+	};
+}
+export function editPresentation(slides) {
+	return slides.map((slide) => ({ ...slide, notes: 'Unsaved edit in B' }));
+}
+/** Drain the async image/table stages after a held read has been released. */
+export async function settlePresentationLoad() {
+	for (let i = 0; i < 20; i++) {
+		await new Promise((resolve) => {
+			setTimeout(resolve, 0);
+		});
+	}
+}

--- a/packages/svelte/src/viewer/state/presentation-loader.stale.test.ts
+++ b/packages/svelte/src/viewer/state/presentation-loader.stale.test.ts
@@ -1,0 +1,53 @@
+import { PptxHandler } from 'pptx-viewer-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	editPresentation,
+	holdPresentationAsset,
+	presentationLoadFixtures,
+} from '../../../../shared/test-utils/presentation-load.mjs';
+import { PresentationLoader } from './presentation-loader.svelte';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('presentation load cancellation after parsing', () => {
+	it.each([
+		['replace', 'image'],
+		['dispose', 'image'],
+		['replace', 'media'],
+		['dispose', 'media'],
+	] as const)(
+		'discards delayed assets on %s (%s)',
+		async (action, asset) => {
+			const fixtures = await presentationLoadFixtures(PptxHandler, asset);
+			const held = holdPresentationAsset(PptxHandler, asset);
+			const loader = new PresentationLoader();
+			const first = loader.load(fixtures.first);
+			try {
+				await held.entered;
+				if (action === 'dispose') {
+					loader.dispose();
+				} else {
+					await loader.load(fixtures.second);
+					loader.slides = editPresentation(loader.slides);
+				}
+				const currentMedia = [...loader.mediaDataUrls];
+				const currentHandler = loader.handler;
+				held.release();
+				await first;
+				if (action === 'replace') {
+					expect([...loader.mediaDataUrls]).toStrictEqual(currentMedia);
+					expect(loader.coreProperties?.title).toBe('Presentation B');
+					expect(loader.slides[0].notes).toBe('Unsaved edit in B');
+					expect(loader.handler).toBe(currentHandler);
+				}
+				expect(loader.loadCount).toBe(action === 'replace' ? 1 : 0);
+				expect(held.disposal).toHaveBeenCalledOnce();
+			} finally {
+				held.release();
+				loader.dispose();
+			}
+		},
+		30_000,
+	);
+});

--- a/packages/svelte/src/viewer/state/presentation-loader.svelte.ts
+++ b/packages/svelte/src/viewer/state/presentation-loader.svelte.ts
@@ -25,7 +25,11 @@ import type {
 } from 'pptx-viewer-core';
 import { EncryptedFileError, PptxHandler } from 'pptx-viewer-core';
 import type { CanvasSize, CollabLoadOrigin, SlideSizeEmu } from 'pptx-viewer-shared';
-import { DEFAULT_CANVAS_HEIGHT, DEFAULT_CANVAS_WIDTH } from 'pptx-viewer-shared';
+import {
+	DEFAULT_CANVAS_HEIGHT,
+	DEFAULT_CANVAS_WIDTH,
+	createPresentationLoadResources,
+} from 'pptx-viewer-shared';
 
 import { glyphOutlineFontCache } from './glyph-outline-cache.svelte';
 import {
@@ -159,7 +163,9 @@ export class PresentationLoader {
 	async load(raw: Uint8Array | ArrayBuffer, origin: CollabLoadOrigin = 'user'): Promise<void> {
 		this.loadOrigin = origin;
 		const token = ++this.#renderToken;
-		const loadBlobUrls: string[] = [];
+		const newHandler = new PptxHandler();
+		const resources = createPresentationLoadResources(newHandler);
+		const loadBlobUrls = resources.blobUrls;
 
 		try {
 			this.loading = true;
@@ -175,16 +181,12 @@ export class PresentationLoader {
 			// in-flight Blob URLs are not yanked mid-paint.
 			const previousHandler = this.handler;
 
-			const newHandler = new PptxHandler();
 			const parsed = await newHandler.load(buffer as ArrayBuffer, this.getLoadOptions());
 			if (token !== this.#renderToken) {
-				newHandler.dispose();
 				return;
 			}
-			previousHandler?.dispose();
 
 			// Audio/video Blob URLs + poster frames, then lazy picture URLs.
-			revokeBlobUrls(this.mediaDataUrls.values());
 			const media = await resolveMediaUrls(newHandler, parsed.slides);
 			loadBlobUrls.push(...media.blobUrls);
 			const imageResolvedSlides = await resolveLazyImages(newHandler, parsed.slides);
@@ -192,8 +194,14 @@ export class PresentationLoader {
 			const nextTableStyleMap = await resolveLazyTableStyleImages(newHandler, parsed.tableStyleMap);
 
 			// Commit reactive state.
+			if (token !== this.#renderToken) {
+				return;
+			}
+			previousHandler?.dispose();
+			revokeBlobUrls(this.mediaDataUrls.values());
 			revokeBlobUrls(this.#activeBlobUrls);
 			this.#activeBlobUrls = loadBlobUrls;
+			resources.commit();
 			this.handler = newHandler;
 			this.slides = nextSlides;
 			this.slideMasters = parsed.slideMasters ?? [];
@@ -264,6 +272,7 @@ export class PresentationLoader {
 				}
 			}
 		} finally {
+			resources.releaseIfUncommitted();
 			if (token === this.#renderToken) {
 				this.loading = false;
 			}

--- a/packages/vanilla/src/viewer/loading-controller.stale.test.ts
+++ b/packages/vanilla/src/viewer/loading-controller.stale.test.ts
@@ -1,0 +1,63 @@
+import { PptxHandler } from 'pptx-viewer-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+	editPresentation,
+	holdPresentationAsset,
+	presentationLoadFixtures,
+} from '../../../shared/test-utils/presentation-load.mjs';
+import { createLoadingController } from './loading-controller';
+import { createInitialViewerState, createStore } from './state';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('presentation load cancellation after parsing', () => {
+	it.each([
+		['replace', 'image'],
+		['invalidate', 'image'],
+		['replace', 'media'],
+		['invalidate', 'media'],
+	] as const)(
+		'discards delayed assets on %s (%s)',
+		async (action, asset) => {
+			const fixtures = await presentationLoadFixtures(PptxHandler, asset);
+			const held = holdPresentationAsset(PptxHandler, asset);
+			const store = createStore(createInitialViewerState());
+			const applied = vi.fn();
+			const loader = createLoadingController({
+				options: {},
+				store,
+				getTranslator: () => (key) => key,
+				getEditor: () => undefined,
+				onContentApplied: applied,
+			});
+			const first = loader.load(fixtures.first);
+			try {
+				await held.entered;
+				if (action === 'invalidate') {
+					loader.invalidate();
+					loader.releaseLoaded();
+				} else {
+					await loader.load(fixtures.second);
+					store.set({ slides: editPresentation(store.get().slides) });
+				}
+				const currentMedia = [...store.get().mediaDataUrls];
+				const currentHandler = loader.getHandler();
+				held.release();
+				await first;
+				if (action === 'replace') {
+					expect([...store.get().mediaDataUrls]).toStrictEqual(currentMedia);
+					expect(store.get().coreProperties?.title).toBe('Presentation B');
+					expect(store.get().slides[0].notes).toBe('Unsaved edit in B');
+					expect(loader.getHandler()).toBe(currentHandler);
+				}
+				expect(applied).toHaveBeenCalledTimes(action === 'replace' ? 1 : 0);
+				expect(held.disposal).toHaveBeenCalledOnce();
+			} finally {
+				held.release();
+				loader.releaseLoaded();
+			}
+		},
+		30_000,
+	);
+});

--- a/packages/vue/src/viewer/composables/useLoadContent.stale.test.ts
+++ b/packages/vue/src/viewer/composables/useLoadContent.stale.test.ts
@@ -1,0 +1,60 @@
+import { PptxHandler } from 'pptx-viewer-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, ref } from 'vue';
+
+import {
+	editPresentation,
+	holdPresentationAsset,
+	presentationLoadFixtures,
+	settlePresentationLoad,
+} from '../../../../shared/test-utils/presentation-load.mjs';
+import { useLoadContent } from './useLoadContent';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('presentation load cancellation after parsing', () => {
+	it.each([
+		['replace', 'image'],
+		['dispose', 'image'],
+		['replace', 'media'],
+		['dispose', 'media'],
+	] as const)(
+		'discards delayed assets on %s (%s)',
+		async (action, asset) => {
+			const fixtures = await presentationLoadFixtures(PptxHandler, asset);
+			const held = holdPresentationAsset(PptxHandler, asset);
+			const scope = effectScope();
+			const content = ref(fixtures.first);
+			const applied = vi.fn();
+			const loader = scope.run(() =>
+				useLoadContent(() => content.value, { onContentApplied: applied }),
+			)!;
+			try {
+				await held.entered;
+				if (action === 'dispose') {
+					scope.stop();
+				} else {
+					content.value = fixtures.second;
+					await vi.waitFor(() => expect(loader.coreProperties.value?.title).toBe('Presentation B'));
+					loader.slides.value = editPresentation(loader.slides.value);
+				}
+				const currentMedia = [...loader.mediaDataUrls.value];
+				const currentHandler = loader.handler.value;
+				held.release();
+				await settlePresentationLoad();
+				if (action === 'replace') {
+					expect([...loader.mediaDataUrls.value]).toStrictEqual(currentMedia);
+					expect(loader.coreProperties.value?.title).toBe('Presentation B');
+					expect(loader.slides.value[0].notes).toBe('Unsaved edit in B');
+					expect(loader.handler.value).toBe(currentHandler);
+				}
+				expect(applied).toHaveBeenCalledTimes(action === 'replace' ? 1 : 0);
+				expect(held.disposal).toHaveBeenCalledOnce();
+			} finally {
+				held.release();
+				scope.stop();
+			}
+		},
+		30_000,
+	);
+});

--- a/packages/vue/src/viewer/composables/useLoadContent.ts
+++ b/packages/vue/src/viewer/composables/useLoadContent.ts
@@ -36,6 +36,7 @@ import {
 } from 'pptx-viewer-core';
 import type { DeckSaveIntent, DeckSavePurpose, SlideSizeEmu } from 'pptx-viewer-shared';
 import {
+	createPresentationLoadResources,
 	applyImagePathPatches,
 	buildDeckSaveOptions,
 	resolveSlideSizeSelection,
@@ -355,7 +356,9 @@ export function useLoadContent(
 
 	const load = async (raw: Uint8Array | ArrayBuffer) => {
 		const token = ++renderToken;
-		const loadBlobUrls: string[] = [];
+		const newHandler = new PptxHandler();
+		const resources = createPresentationLoadResources(newHandler);
+		const loadBlobUrls = resources.blobUrls;
 
 		try {
 			loading.value = true;
@@ -382,17 +385,11 @@ export function useLoadContent(
 			// in-flight Blob URLs aren't yanked mid-paint.
 			const previousHandler = handler.value;
 
-			const newHandler = new PptxHandler();
 			const parsed = await newHandler.load(buffer as ArrayBuffer, {
 				allowExternalImages: options?.getAllowExternalImages?.(),
 			});
 			if (token !== renderToken) {
-				newHandler.dispose();
 				return;
-			}
-
-			if (previousHandler) {
-				previousHandler.dispose();
 			}
 
 			// ── Resolve media Blob URLs (audio/video + poster frames) ──
@@ -400,7 +397,6 @@ export function useLoadContent(
 			for (const slide of parsed.slides) {
 				collectMediaElements(slide.elements, mediaElements);
 			}
-			revokeBlobUrls(Array.from(mediaDataUrls.value.values()));
 			const nextMediaUrls = new Map<string, string>();
 			// Shared with the other four bindings (G17): a LINKED media
 			// element's `mediaPath` is already the verbatim external URL by the
@@ -476,13 +472,24 @@ export function useLoadContent(
 				newHandler.getImageData(path),
 			);
 
+			const nextSignatures =
+				parsed.hasDigitalSignatures && signatureBuffer instanceof ArrayBuffer
+					? await parseSignaturesFromBuffer(signatureBuffer)
+					: [];
+			if (token !== renderToken) {
+				return;
+			}
+
 			// Pull master/layout (template) elements out of each slide into their own
 			// store so the editor can gate / route / merge them back independently.
 			const partitioned = partitionTemplateElements(nextSlides);
 
 			// Commit reactive state.
+			previousHandler?.dispose();
+			revokeBlobUrls(Array.from(mediaDataUrls.value.values()));
 			revokeBlobUrls(activeBlobUrls);
 			activeBlobUrls = loadBlobUrls;
+			resources.commit();
 			handler.value = newHandler;
 			slides.value = partitioned.slides;
 			templateElementsBySlideId.value = partitioned.templateElementsBySlideId;
@@ -539,10 +546,7 @@ export function useLoadContent(
 							height: Math.round(parsed.notesHeightEmu / 9525),
 						}
 					: undefined;
-			signatures.value =
-				parsed.hasDigitalSignatures && signatureBuffer instanceof ArrayBuffer
-					? await parseSignaturesFromBuffer(signatureBuffer)
-					: [];
+			signatures.value = nextSignatures;
 			options?.onContentApplied?.();
 		} catch (err) {
 			if (token === renderToken) {
@@ -553,6 +557,7 @@ export function useLoadContent(
 				}
 			}
 		} finally {
+			resources.releaseIfUncommitted();
 			if (token === renderToken) {
 				loading.value = false;
 			}


### PR DESCRIPTION
Switching from presentation A to B while A is resolving images or media lets A's successful load path replace B afterward. Any edits made in B can be discarded, and React clears the dirty flag and undo history.

Check cancellation again after asset resolution, before committing the loaded document. Keep React's media map local to the request until that check passes, and release uncommitted handlers and media URLs in `finally`. Vue's signature parsing also completes before the guarded state update.

Checked all five bindings. React, Vue, Angular, and Svelte reproduced the race and are fixed here. Vanilla already checks the token after its complete loading pipeline; its production code is unchanged, with the same regression cases added as a control.

Closes #242.

### Validation

- 22 focused tests: image and media completion after replacement or teardown in all five bindings, plus shared resource ownership tests. The 16 affected-binding cases fail with the original loaders at `fc1d194312b85adb898f398497965d26aef967bf`. Fixtures are real generated PPTX archives; only the timing of the actual asset read is controlled.
- Full React viewer in Chrome 152 on macOS: open A, pause its image read, open and edit B, then release A. The original code restores A and reports saved; the fix retains the edited B and its unsaved state.
- Existing `file-backstage-open.spec.ts`: 15 passed across all five demos using Chrome.
- `bun run build`, `bun run typecheck`, `bun run lint`, and `bun run fmt:check` passed.
- Ran each package's `bun run test --maxWorkers=2`: 40,869 passed, 234 skipped, and one failed test across the final package runs. React's existing random ID uniqueness test returned 4,999 unique IDs out of 5,000; its six-test file passed on rerun. The ID minter is unchanged. All new load regressions passed.
