### PR TITLE
fix(angular): edit cached SmartArt drawing nodes

### DIFF
--- a/e2e/smartart-insert-edit.spec.ts
+++ b/e2e/smartart-insert-edit.spec.ts
@@ -20,6 +20,9 @@ import { savePptxViaBackstage } from './save-pptx';
 import { loadDeck as loadDeckFile, resetTabSession } from './support/deck';
 
 const fixturePath = resolve(fileURLToPath(new URL('./fixtures/sample-deck.pptx', import.meta.url)));
+const drawingFixturePath = resolve(
+	fileURLToPath(new URL('./fixtures/smartart-build-reveal.pptx', import.meta.url)),
+);
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -179,7 +182,6 @@ async function clickHistory(page: Page, name: 'Undo' | 'Redo'): Promise<void> {
 	await expect(button).toBeEnabled();
 	await button.click();
 }
-
 function collectRuntimeErrors(page: Page): string[] {
 	const errors: string[] = [];
 	page.on('pageerror', (error) => errors.push(`${error.name}: ${error.message}`));
@@ -383,6 +385,73 @@ test.describe('smartart insert and edit', () => {
 		const smartArt = currentSmartArt(page);
 		await expect(smartArt).toBeVisible();
 		await exerciseDirectKeyboardNodeEdit(page, smartArt, 'Edited fallback node');
+		expect(runtimeErrors).toStrictEqual([]);
+	});
+
+	test('edits a loaded drawing node through the SmartArt editor', async ({ page }) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await loadDeckFile(page, drawingFixturePath);
+		const smartArt = currentSmartArt(page);
+		await expect(smartArt).toBeVisible();
+		const authoredText = await renderedNodeText(smartArt);
+		expect(authoredText).toBe('Alpha');
+		const diagramBox = await smartArt.boundingBox();
+		expect(diagramBox, 'SmartArt diagram should have a rendered box').not.toBeNull();
+
+		const point = await unobstructedNodePoint(firstSmartArtNode(smartArt));
+		await page.mouse.dblclick(point.x, point.y);
+		const editor = page.locator('[data-pptx-viewport] textarea:visible');
+		await expect(editor).toHaveCount(1);
+		// The generic element editor also mounts a textarea for this graphic frame,
+		// but it is empty. Requiring the authored node text proves this is the real
+		// SmartArt node editor before focus and typing assertions can pass.
+		await expect(editor).toHaveValue(authoredText);
+		await expect(editor).toBeFocused();
+		await page.keyboard.type('Edited drawing node');
+		await expect(editor).toHaveValue('Edited drawing node');
+
+		const editorBox = await editor.boundingBox();
+		expect(editorBox, 'SmartArt editor should have a rendered box').not.toBeNull();
+		await editor.click({
+			position: { x: Math.max(1, editorBox!.width * 0.75), y: editorBox!.height / 2 },
+		});
+		await expect(editor).toBeFocused();
+		await expect
+			.poll(async () => {
+				const current = await smartArt.boundingBox();
+				return current
+					? {
+							x: Math.round(current.x),
+							y: Math.round(current.y),
+							width: Math.round(current.width),
+							height: Math.round(current.height),
+						}
+					: null;
+			})
+			.toStrictEqual({
+				x: Math.round(diagramBox!.x),
+				y: Math.round(diagramBox!.y),
+				width: Math.round(diagramBox!.width),
+				height: Math.round(diagramBox!.height),
+			});
+
+		await page
+			.getByRole('toolbar', { name: 'Presentation toolbar' })
+			.getByRole('tab', { name: 'Home', exact: true })
+			.click();
+		await expect(editor).toHaveCount(0);
+		await expect.poll(() => renderedNodeText(smartArt)).toBe('Edited drawing node');
+
+		await clickHistory(page, 'Undo');
+		await expect.poll(() => renderedNodeText(smartArt)).toBe(authoredText);
+		await clickHistory(page, 'Redo');
+		await expect.poll(() => renderedNodeText(smartArt)).toBe('Edited drawing node');
+
+		const download = await savePptxViaBackstage(page);
+		const savedPath = await download.path();
+		expect(savedPath, 'the browser should retain the saved SmartArt deck').not.toBeNull();
+		await loadDeckFile(page, savedPath!);
+		await expect.poll(() => renderedNodeText(currentSmartArt(page))).toBe('Edited drawing node');
 		expect(runtimeErrors).toStrictEqual([]);
 	});
 });

--- a/packages/angular/src/viewer/canvas-element-locks.test.ts
+++ b/packages/angular/src/viewer/canvas-element-locks.test.ts
@@ -20,6 +20,7 @@ import {
 	computeSingleSelected,
 	resolveInteractiveElementId,
 } from './selection-geometry';
+import { SlideCanvasComponent } from './slide-canvas.component';
 import { isElementInteractive } from './template-mode';
 
 // ---------------------------------------------------------------------------
@@ -111,11 +112,10 @@ describe('noRotation', () => {
 // noMove / noTextEdit: gated in the component's pointer paths
 //
 // The canvas component needs a TestBed to drive real pointer events (this
-// package has none: see `vitest.config.ts`), so its two remaining gates are
-// pinned against the component SOURCE, exactly as
-// `slide-canvas-handle-labels.test.ts` pins the accessible names. Both
-// assertions fail on the pre-change file, which armed the move drag and opened
-// the inline editor with no lock check at all.
+// package has none: see `vitest.config.ts`). Source checks pin pointer wiring,
+// as `slide-canvas-handle-labels.test.ts` pins accessible names. The generic
+// text-editor eligibility method can be exercised directly on the prototype
+// without constructing the component or its injected services.
 // ---------------------------------------------------------------------------
 
 const component = readFileSync(join(__dirname, 'slide-canvas.component.ts'), 'utf8');
@@ -126,9 +126,24 @@ describe('slide-canvas pointer gates', () => {
 	});
 
 	it('gates inline text editing on noTextEdit', () => {
-		expect(component).toContain(`'textEdit',`);
 		expect(component).toContain('this.canTextEdit(id)');
+		const canvas = {
+			allElements: () => [shape('free'), shape('locked', { noTextEdit: true })],
+		} as unknown as SlideCanvasComponent;
+		expect(SlideCanvasComponent.prototype['canTextEdit'].call(canvas, 'free')).toBeTruthy();
+		expect(SlideCanvasComponent.prototype['canTextEdit'].call(canvas, 'locked')).toBeFalsy();
 	});
+
+	it.each(['smartArt', 'chart', 'table', 'image', 'group'] as const)(
+		'does not open the generic text editor for %s or a missing element',
+		(type) => {
+			const canvas = {
+				allElements: () => [{ ...shape('non-text'), type } as PptxElement],
+			} as unknown as SlideCanvasComponent;
+			expect(SlideCanvasComponent.prototype['canTextEdit'].call(canvas, 'non-text')).toBeFalsy();
+			expect(SlideCanvasComponent.prototype['canTextEdit'].call(canvas, 'missing')).toBeFalsy();
+		},
+	);
 
 	it('guards the resize and rotate handle pointer-downs, not just their rendering', () => {
 		expect(component).toContain(`!canInteractWithElement(this.singleSelectedElement(), 'resize')`);

--- a/packages/angular/src/viewer/slide-canvas.component.ts
+++ b/packages/angular/src/viewer/slide-canvas.component.ts
@@ -891,9 +891,11 @@ export class SlideCanvasComponent implements SlideContext {
 	 * bindings enforced it: a locked caption opened an editable textarea here.
 	 */
 	private canTextEdit(id: string): boolean {
-		return canInteractWithElement(
-			this.allElements().find((el) => el.id === id),
-			'textEdit',
+		const element = this.allElements().find((el) => el.id === id);
+		return (
+			element !== undefined &&
+			hasTextProperties(element) &&
+			canInteractWithElement(element, 'textEdit')
 		);
 	}
 

--- a/packages/angular/src/viewer/smart-art-inline-edit.test.ts
+++ b/packages/angular/src/viewer/smart-art-inline-edit.test.ts
@@ -16,6 +16,7 @@ import { computeSmartArtLayout } from '../internal/shared';
 import type { RenderedNode } from '../internal/shared';
 import { DEFAULT_PALETTE } from './smart-art-drawing';
 import {
+	beginDrawingNodeEdit,
 	beginNodeEdit,
 	canEditSmartArtNodes,
 	commitNodeText,
@@ -180,6 +181,53 @@ describe('beginNodeEdit', () => {
 			textY: 5,
 		};
 		expect(beginNodeEdit(fake, ELEMENT_ID)).toBeNull();
+	});
+});
+
+describe('beginDrawingNodeEdit', () => {
+	it('projects the local drawing box and applies the editor padding', () => {
+		const box = { x: 50, y: 30, width: 100, height: 60 };
+		const viewBox = { width: 400, height: 300 };
+		const viewport = { width: 800, height: 600 };
+		const boxBefore = { ...box };
+		const viewBoxBefore = { ...viewBox };
+		const viewportBefore = { ...viewport };
+
+		expect(beginDrawingNodeEdit('n1', 'Alpha', box, viewBox, viewport)).toStrictEqual({
+			nodeId: 'n1',
+			text: 'Alpha',
+			box: { x: 96, y: 56, width: 208, height: 128 },
+		});
+		expect(box).toStrictEqual(boxBefore);
+		expect(viewBox).toStrictEqual(viewBoxBefore);
+		expect(viewport).toStrictEqual(viewportBefore);
+	});
+
+	it('accepts empty authored text and enforces the minimum editor size', () => {
+		expect(
+			beginDrawingNodeEdit(
+				'n1',
+				'',
+				{ x: 10, y: 10, width: 5, height: 5 },
+				{ width: 100, height: 100 },
+				{ width: 100, height: 100 },
+			),
+		).toStrictEqual({
+			nodeId: 'n1',
+			text: '',
+			box: { x: 6, y: 6, width: 48, height: 30 },
+		});
+	});
+
+	it('rejects missing ids, missing text, and invalid projection dimensions', () => {
+		const box = { x: 10, y: 10, width: 20, height: 10 };
+		const viewBox = { width: 100, height: 100 };
+		const viewport = { width: 100, height: 100 };
+		expect(beginDrawingNodeEdit(undefined, 'Alpha', box, viewBox, viewport)).toBeNull();
+		expect(beginDrawingNodeEdit('n1', undefined, box, viewBox, viewport)).toBeNull();
+		expect(
+			beginDrawingNodeEdit('n1', 'Alpha', box, { width: 0, height: 100 }, viewport),
+		).toBeNull();
 	});
 });
 

--- a/packages/angular/src/viewer/smart-art-inline-edit.ts
+++ b/packages/angular/src/viewer/smart-art-inline-edit.ts
@@ -21,7 +21,7 @@
 import type { PptxElement, PptxSlide, PptxSmartArtData } from 'pptx-viewer-core';
 
 import type { RenderedNode } from '../internal/shared';
-import { canDrillDown, isTemplateElementId } from '../internal/shared';
+import { canDrillDown, isTemplateElementId, projectSmartArtViewBoxRect } from '../internal/shared';
 import { updateSmartArtNodeText } from './editor-insert';
 
 /**
@@ -171,6 +171,36 @@ export function beginNodeEdit(
 		box: nodeEditBox(node),
 		text: rawText ?? node.text,
 	};
+}
+
+/** Seed a cached-drawing edit from model text and its local SVG bounding box. */
+export function beginDrawingNodeEdit(
+	nodeId: string | undefined,
+	rawText: string | undefined,
+	box: NodeEditBox,
+	viewBox: { width: number; height: number },
+	viewport: { width: number; height: number },
+): InlineEditState | null {
+	if (!nodeId || rawText === undefined) {
+		return null;
+	}
+	const rect = projectSmartArtViewBoxRect(
+		{ left: box.x, top: box.y, width: box.width, height: box.height },
+		viewBox,
+		viewport,
+	);
+	return rect
+		? {
+				nodeId,
+				text: rawText,
+				box: {
+					x: rect.left - 4,
+					y: rect.top - 4,
+					width: Math.max(48, rect.width + 8),
+					height: Math.max(30, rect.height + 8),
+				},
+			}
+		: null;
 }
 
 /**

--- a/packages/angular/src/viewer/smart-art-renderer.component.html
+++ b/packages/angular/src/viewer/smart-art-renderer.component.html
@@ -23,6 +23,11 @@
 					[ngStyle]="shadowFilter() ? { filter: shadowFilter() } : {}"
 					[attr.data-smartart-node-id]="drawingShapeNodeIds()[i] ?? null"
 					[class.pptx-ng-smartart-node--editable]="canEditNodes() && !!drawingShapeNodeIds()[i]"
+					[attr.tabindex]="canEditNodes() && drawingShapeNodeIds()[i] ? 0 : null"
+					[attr.role]="drawingShapeNodeIds()[i] ? (canEditNodes() ? 'button' : 'img') : null"
+					[attr.aria-label]="drawingNodeAriaLabel(i)"
+					(dblclick)="onDrawingNodeDblClick($event, i)"
+					(keydown)="onDrawingNodeKeydown($event, i)"
 				>
 					@if (shape.gradient) {
 						<defs>

--- a/packages/angular/src/viewer/smart-art-renderer.component.ts
+++ b/packages/angular/src/viewer/smart-art-renderer.component.ts
@@ -21,6 +21,7 @@ import {
 	buildSmartArtA11y,
 	computeInlineEditorRect,
 	computeSmartArtElementLayout,
+	findSmartArtNodeText,
 	flattenNodes,
 	rebuildDrawingShapesIfCleared,
 	resolveRevealedDrawingShapeNodeIds,
@@ -48,6 +49,7 @@ import {
 } from './smart-art-drawing';
 import type { DrawingViewBox, RenderedShape } from './smart-art-drawing';
 import {
+	beginDrawingNodeEdit,
 	beginNodeEdit,
 	canEditSmartArtNodes,
 	commitNodeText,
@@ -347,6 +349,12 @@ export class SmartArtRendererComponent {
 		return this.a11yLabelById().get(nodeId) ?? null;
 	}
 
+	/** Cached drawings use the revealed shape mapping, not fallback node order. */
+	drawingNodeAriaLabel(index: number): string | null {
+		const nodeId = this.drawingShapeNodeIds()[index];
+		return nodeId ? (this.a11yLabelById().get(nodeId) ?? null) : null;
+	}
+
 	/**
 	 * Polite live-region message announcing the most recent node-text commit.
 	 * Empty between commits so assistive tech only speaks on change.
@@ -362,6 +370,49 @@ export class SmartArtRendererComponent {
 	protected readonly asRect = narrowToRect;
 
 	// ── Inline node-text editing ───────────────────────────────────────────
+
+	onDrawingNodeDblClick(event: Event, index: number): void {
+		this.enterDrawingEdit(event, index);
+	}
+
+	onDrawingNodeKeydown(event: KeyboardEvent, index: number): void {
+		if ((event.key === 'Enter' || event.key === 'F2') && this.enterDrawingEdit(event, index)) {
+			event.preventDefault();
+		}
+	}
+
+	private enterDrawingEdit(event: Event, index: number): boolean {
+		const nodeId = this.drawingShapeNodeIds()[index];
+		const data = this.smartArtData();
+		const group = event.currentTarget;
+		const container = this.smartartContainer()?.nativeElement as HTMLElement | undefined;
+		if (
+			!this.canEditNodes() ||
+			!nodeId ||
+			!data ||
+			!container ||
+			!(group instanceof SVGGraphicsElement)
+		) {
+			return false;
+		}
+		// SVG-local boxes avoid applying the stage's zoom/rotation a second time.
+		const textBox = group.querySelector('text')?.getBBox();
+		const box = textBox && textBox.width > 0 && textBox.height > 0 ? textBox : group.getBBox();
+		const seed = beginDrawingNodeEdit(
+			nodeId,
+			findSmartArtNodeText(data, nodeId),
+			box,
+			this.viewBox(),
+			{ width: container.clientWidth, height: container.clientHeight },
+		);
+		if (!seed) {
+			return false;
+		}
+		event.stopPropagation();
+		this.editSettled = false;
+		this.editState.set(seed);
+		return true;
+	}
 
 	/** Double-click a node enters inline edit mode (when editable). */
 	onNodeDblClick(event: Event, node: RenderedNode, index: number): void {

--- a/packages/angular/src/viewer/smart-art-renderer.diagram-reveal.test.ts
+++ b/packages/angular/src/viewer/smart-art-renderer.diagram-reveal.test.ts
@@ -10,7 +10,11 @@
 import type { PptxSmartArtDrawingShape, PptxSmartArtNode } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
-import { resolveRevealedDrawingShapes, resolveRevealedSmartArtNodes } from '../internal/shared';
+import {
+	resolveRevealedDrawingShapeNodeIds,
+	resolveRevealedDrawingShapes,
+	resolveRevealedSmartArtNodes,
+} from '../internal/shared';
 
 function node(id: string, text: string): PptxSmartArtNode {
 	return { id, text };
@@ -60,5 +64,6 @@ describe('smartArtRendererComponent cached drawing-shape reveal', () => {
 			},
 		});
 		expect(result.map((s) => s.id)).toStrictEqual(['s3']);
+		expect(resolveRevealedDrawingShapeNodeIds(shapes, result, nodes)).toStrictEqual(['n3']);
 	});
 });

--- a/packages/angular/src/viewer/smart-art-renderer.test.ts
+++ b/packages/angular/src/viewer/smart-art-renderer.test.ts
@@ -240,6 +240,14 @@ describe('smartArtRenderer template bindings', () => {
 		join(dirname(fileURLToPath(import.meta.url)), 'smart-art-renderer.component.html'),
 		'utf8',
 	);
+	const drawingBranch = template.slice(
+		template.indexOf('@else if (hasDrawingShapes())'),
+		template.indexOf('@else if (hasLayout())'),
+	);
+	const fallbackBranch = template.slice(
+		template.indexOf('@else if (hasLayout())'),
+		template.lastIndexOf('@else {'),
+	);
 
 	it('binds the shared label descriptor instead of a hardcoded white fill', () => {
 		expect(template).toContain('[attr.fill]="layoutLabels()[ni]!.fill"');
@@ -251,5 +259,26 @@ describe('smartArtRenderer template bindings', () => {
 	it('binds the shared connector paint instead of a hardcoded grey stroke', () => {
 		expect(template).toContain('[attr.stroke]="layoutConnectors()[ci]!.stroke"');
 		expect(template).not.toContain('stroke="#94a3b8"');
+	});
+
+	it('routes cached drawing nodes through their mapped inline-edit entry path', () => {
+		expect(drawingBranch).toContain(
+			'[attr.data-smartart-node-id]="drawingShapeNodeIds()[i] ?? null"',
+		);
+		expect(drawingBranch).toContain('(dblclick)="onDrawingNodeDblClick($event, i)"');
+		expect(drawingBranch).toContain('(keydown)="onDrawingNodeKeydown($event, i)"');
+		expect(drawingBranch).toContain('drawingNodeAriaLabel(i)');
+		expect(drawingBranch).toContain(
+			'[attr.tabindex]="canEditNodes() && drawingShapeNodeIds()[i] ? 0 : null"',
+		);
+		expect(drawingBranch).toContain(
+			`[attr.role]="drawingShapeNodeIds()[i] ? (canEditNodes() ? 'button' : 'img') : null"`,
+		);
+	});
+
+	it('keeps the existing fallback-node edit path intact', () => {
+		expect(fallbackBranch).toContain('(dblclick)="onNodeDblClick($event, node, ni)"');
+		expect(fallbackBranch).toContain('(keydown)="onNodeKeydown($event, node, ni)"');
+		expect(fallbackBranch).toContain('[attr.data-smartart-node-id]="nodeIdAt(ni)"');
 	});
 });

--- a/packages/shared/src/render/smartart-inline-edit.test.ts
+++ b/packages/shared/src/render/smartart-inline-edit.test.ts
@@ -10,6 +10,7 @@ import {
 	shouldCommitSmartArtNodeText,
 	resolveDrawingShapeNodeId,
 	computeInlineEditorRect,
+	projectSmartArtViewBoxRect,
 } from './smartart-inline-edit';
 
 function node(id: string, text: string): PptxSmartArtNode {
@@ -120,5 +121,72 @@ describe('computeInlineEditorRect', () => {
 			{ left: 100, top: 50, width: 400, height: 300 },
 		);
 		expect(rect).toStrictEqual({ left: 30, top: 40, width: 40, height: 24 });
+	});
+});
+
+describe('projectSmartArtViewBoxRect', () => {
+	it('projects at the exact viewport scale', () => {
+		expect(
+			projectSmartArtViewBoxRect(
+				{ left: 50, top: 30, width: 100, height: 60 },
+				{ width: 400, height: 300 },
+				{ width: 800, height: 600 },
+			),
+		).toStrictEqual({ left: 100, top: 60, width: 200, height: 120 });
+	});
+
+	it('centres horizontal letterboxing with xMidYMid meet', () => {
+		expect(
+			projectSmartArtViewBoxRect(
+				{ left: 50, top: 100, width: 100, height: 50 },
+				{ width: 400, height: 400 },
+				{ width: 800, height: 400 },
+			),
+		).toStrictEqual({ left: 250, top: 100, width: 100, height: 50 });
+	});
+
+	it('centres vertical letterboxing with xMidYMid meet', () => {
+		expect(
+			projectSmartArtViewBoxRect(
+				{ left: 50, top: 20, width: 100, height: 40 },
+				{ width: 400, height: 200 },
+				{ width: 400, height: 400 },
+			),
+		).toStrictEqual({ left: 50, top: 120, width: 100, height: 40 });
+	});
+
+	it('rejects invalid source geometry or non-positive viewBox and viewport dimensions', () => {
+		const nodeRect = { left: 0, top: 0, width: 10, height: 10 };
+		const validViewBox = { width: 100, height: 100 };
+		const validViewport = { width: 200, height: 200 };
+		expect(
+			projectSmartArtViewBoxRect(
+				{ ...nodeRect, left: Number.POSITIVE_INFINITY },
+				validViewBox,
+				validViewport,
+			),
+		).toBeNull();
+		expect(
+			projectSmartArtViewBoxRect({ ...nodeRect, width: -1 }, validViewBox, validViewport),
+		).toBeNull();
+		expect(
+			projectSmartArtViewBoxRect(nodeRect, { width: 0, height: 100 }, validViewport),
+		).toBeNull();
+		expect(
+			projectSmartArtViewBoxRect(nodeRect, validViewBox, { width: 200, height: 0 }),
+		).toBeNull();
+		expect(
+			projectSmartArtViewBoxRect(nodeRect, validViewBox, { width: Number.NaN, height: 200 }),
+		).toBeNull();
+	});
+
+	it('preserves valid negative node coordinates', () => {
+		expect(
+			projectSmartArtViewBoxRect(
+				{ left: -10, top: -5, width: 20, height: 10 },
+				{ width: 400, height: 300 },
+				{ width: 800, height: 600 },
+			),
+		).toStrictEqual({ left: -20, top: -10, width: 40, height: 20 });
 	});
 });

--- a/packages/shared/src/render/smartart-inline-edit.ts
+++ b/packages/shared/src/render/smartart-inline-edit.ts
@@ -140,3 +140,42 @@ export function computeInlineEditorRect(
 		height: nodeRect.height,
 	};
 }
+
+/**
+ * Project a zero-origin SVG viewBox rectangle into an untransformed CSS viewport
+ * using `xMidYMid meet`. The editor and SVG can then inherit the same outer
+ * zoom, rotation and flip without applying those transforms twice.
+ */
+export function projectSmartArtViewBoxRect(
+	nodeRect: InlineEditRect,
+	viewBox: { width: number; height: number },
+	viewport: { width: number; height: number },
+): InlineEditRect | null {
+	if (
+		![
+			nodeRect.left,
+			nodeRect.top,
+			nodeRect.width,
+			nodeRect.height,
+			viewBox.width,
+			viewBox.height,
+			viewport.width,
+			viewport.height,
+		].every(Number.isFinite) ||
+		viewBox.width <= 0 ||
+		viewBox.height <= 0 ||
+		viewport.width <= 0 ||
+		viewport.height <= 0 ||
+		nodeRect.width < 0 ||
+		nodeRect.height < 0
+	) {
+		return null;
+	}
+	const scale = Math.min(viewport.width / viewBox.width, viewport.height / viewBox.height);
+	return {
+		left: (viewport.width - viewBox.width * scale) / 2 + nodeRect.left * scale,
+		top: (viewport.height - viewBox.height * scale) / 2 + nodeRect.top * scale,
+		width: nodeRect.width * scale,
+		height: nodeRect.height * scale,
+	};
+}


### PR DESCRIPTION
## Summary

Fix Angular's missing inline-edit entry for cached SmartArt drawing nodes in loaded presentations.

Double-clicking an imported node currently falls through to the generic element editor, which starts empty and does not edit that node. Inserted fallback SmartArt already has its own working editor; this connects the cached drawing path to the same lifecycle.

- Resolve the node through the existing revealed drawing-to-model mapping and seed its full model text.
- Support double-click, Enter and F2 entry, with the same editability/drill-down gates as fallback nodes.
- Project SVG-local label bounds into the local editor viewport so this newly connected path inherits zoom, rotation and letterboxing once.
- Restrict the shared Angular canvas's generic editor to text-capable elements, preserving interaction locks and covering its master-view consumer.
- Extend existing unit and framework-neutral browser test files.

## Scope

The existing node mapping and full-text policies are retained. Earlier changes already established fallback editing, authoritative model text and revealed-node alignment; the cached Angular SVG groups were missing the corresponding entry handlers.

React, Vue, Svelte and Vanilla already have cached-node entry paths. Their entry, immediate typing, caret interaction, commit, undo/redo and save/reload flows were checked with the same loaded fixture.

Separate existing overlay-positioning problems were found during that comparison: at fitted zoom the React, Svelte and Vanilla editor can miss its label. Vue overlap alone does not establish correct scaling either. Those unchanged paths need a focused cross-binding coordinate fix and are not claimed fixed here. The outer Angular selection border/handles also do not follow diagram rotation; that is separate from this node editor.

## Validation

- Angular: 3,643 unit tests passed; typecheck passed.
- Shared: 8,897 unit tests passed, 3 skipped; typecheck passed.
- Fresh builds: core, shared, locales, tools and all five bindings.
- Framework-neutral SmartArt insert/edit matrix: 30/30 passed across all five bindings, including loaded cached-node edit, no accidental movement, undo/redo and downloaded-file reload.
- Supplemental Angular browser checks: Enter/F2 entry and editor positioning after verified zoom/rotation passed.
- Independent code/history review and hands-on browser review.
- Changed-file formatting/lint, diff checks and E2E neutrality passed.

Save/reload was checked in the browser, not native PowerPoint. This does not claim complete visual fidelity or fix unrelated SmartArt selection chrome.
