### PR TITLE
fix(shared): align 2D SmartArt editors and hover controls

### DIFF
--- a/e2e/smartart-insert-edit.spec.ts
+++ b/e2e/smartart-insert-edit.spec.ts
@@ -180,6 +180,68 @@ async function clickHistory(page: Page, name: 'Undo' | 'Redo'): Promise<void> {
 	await button.click();
 }
 
+/** Bindings intentionally use either tight label bounds or the whole node. */
+async function expectLocalNodeEditor(node: Locator, editor: Locator): Promise<void> {
+	const candidates = await node.evaluate((element) => {
+		const boxes = [element, element.querySelector('text')].flatMap((source) => {
+			if (!(source instanceof SVGGraphicsElement)) {
+				return [];
+			}
+			const box = source.getBBox();
+			const matrix = source.getCTM();
+			if (!matrix) {
+				return [];
+			}
+			const points = [
+				[box.x, box.y],
+				[box.x + box.width, box.y],
+				[box.x, box.y + box.height],
+				[box.x + box.width, box.y + box.height],
+			].map(([x, y]) => ({
+				x: matrix.a * x + matrix.c * y + matrix.e,
+				y: matrix.b * x + matrix.d * y + matrix.f,
+			}));
+			const left = Math.min(...points.map(({ x }) => x));
+			const top = Math.min(...points.map(({ y }) => y));
+			return [
+				{
+					left,
+					top,
+					width: Math.max(...points.map(({ x }) => x)) - left,
+					height: Math.max(...points.map(({ y }) => y)) - top,
+				},
+			];
+		});
+		return boxes.flatMap((box) => [
+			box,
+			{ left: box.left - 4, top: box.top - 4, width: box.width + 8, height: box.height + 8 },
+			{
+				left: box.left - 4,
+				top: box.top - 4,
+				width: Math.max(48, box.width + 8),
+				height: Math.max(30, box.height + 8),
+			},
+		]);
+	});
+	const actual = await editor.evaluate((element) => {
+		const style = getComputedStyle(element);
+		return {
+			left: parseFloat(style.left),
+			top: parseFloat(style.top),
+			width: parseFloat(style.width),
+			height: parseFloat(style.height),
+		};
+	});
+	expect(
+		candidates.some((box) =>
+			(['left', 'top', 'width', 'height'] as const).every(
+				(key) => Math.abs(box[key] - actual[key]) < 1,
+			),
+		),
+		JSON.stringify({ actual, candidates }),
+	).toBeTruthy();
+}
+
 function collectRuntimeErrors(page: Page): string[] {
 	const errors: string[] = [];
 	page.on('pageerror', (error) => errors.push(`${error.name}: ${error.message}`));
@@ -221,6 +283,42 @@ async function exerciseDirectKeyboardNodeEdit(
 
 test.describe('smartart insert and edit', () => {
 	test.use({ viewport: { width: 1440, height: 900 } });
+
+	test('keeps the node editor in local coordinates at fitted and enlarged zoom', async ({
+		page,
+	}) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await loadDeck(page);
+		await switchToInsertTab(page);
+		await insertSmartArtPreset(page);
+		const smartArt = currentSmartArt(page);
+		for (const enlarge of [false, true]) {
+			if (enlarge) {
+				await page.getByRole('button', { name: /Zoom in/iu }).click();
+				await page.getByRole('button', { name: /Zoom in/iu }).click();
+			}
+			const labelBox = await firstSmartArtNode(smartArt).locator('text').first().boundingBox();
+			expect(labelBox, 'The label must be visibly rendered before editing').not.toBeNull();
+			const { editor } = await openFocusedNodeEditor(page, smartArt);
+			await expectLocalNodeEditor(firstSmartArtNode(smartArt), editor);
+			const editorBox = await editor.boundingBox();
+			expect(editorBox).not.toBeNull();
+			// Also check screen overlap independently of the local-coordinate calculation.
+			for (const [position, size] of [
+				['x', 'width'],
+				['y', 'height'],
+			] as const) {
+				expect(labelBox![size]).toBeGreaterThan(0);
+				expect(editorBox![size]).toBeGreaterThan(0);
+				const overlap =
+					Math.min(labelBox![position] + labelBox![size], editorBox![position] + editorBox![size]) -
+					Math.max(labelBox![position], editorBox![position]);
+				expect(overlap).toBeGreaterThanOrEqual(Math.min(labelBox![size], editorBox![size]) * 0.9);
+			}
+			await blurNodeEditor(page);
+		}
+		expect(runtimeErrors).toStrictEqual([]);
+	});
 
 	test('inserts SmartArt via dialog and verifies it renders on the slide', async ({ page }) => {
 		await loadDeck(page);

--- a/packages/angular/src/viewer/smart-art-renderer.component.ts
+++ b/packages/angular/src/viewer/smart-art-renderer.component.ts
@@ -19,7 +19,7 @@ import { setSmartArtNodeStyle } from 'pptx-viewer-core';
 
 import {
 	buildSmartArtA11y,
-	computeInlineEditorRect,
+	measureSvgViewportRect,
 	computeSmartArtElementLayout,
 	flattenNodes,
 	rebuildDrawingShapesIfCleared,
@@ -498,11 +498,7 @@ export class SmartArtRendererComponent {
 			this.cancelPendingHide();
 			const id = nodeEl.getAttribute('data-smartart-node-id');
 			this.hoveredNodeId.set(id);
-			this.hoveredNodeRect.set(
-				id
-					? computeInlineEditorRect(nodeEl.getBoundingClientRect(), cnt.getBoundingClientRect())
-					: null,
-			);
+			this.hoveredNodeRect.set(id ? measureSvgViewportRect(nodeEl) : null);
 			return;
 		}
 		// Pointer may be over the style-bar popover anchored to the currently

--- a/packages/angular/src/viewer/smart-art-renderer.test.ts
+++ b/packages/angular/src/viewer/smart-art-renderer.test.ts
@@ -17,14 +17,73 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { PptxSmartArtNode, SmartArtLayoutType } from 'pptx-viewer-core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { computeSmartArtElementLayout, computeSmartArtLayout } from '../internal/shared';
 import type { RenderedNode, SmartArtLayoutResult } from '../internal/shared';
 import { DEFAULT_PALETTE } from './smart-art-drawing';
 import { layoutConnectorPaints, layoutNodeLabels } from './smart-art-renderer-helpers';
+import { SmartArtRendererComponent } from './smart-art-renderer.component';
 
 const BOX = { width: 400, height: 300 };
+
+describe('smartArtRenderer hover coordinates', () => {
+	const onMouseMove = (
+		SmartArtRendererComponent.prototype as unknown as {
+			onMouseMove(event: MouseEvent): void;
+		}
+	).onMouseMove;
+
+	function hoverHarness(editable = true) {
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		const nodeEl = document.createElementNS(svg.namespaceURI, 'g');
+		nodeEl.setAttribute('data-smartart-node-id', 'alpha');
+		svg.appendChild(nodeEl);
+		Object.assign(nodeEl, {
+			getBBox: () => ({ x: 10, y: 20, width: 80, height: 30 }),
+			getCTM: () => ({ a: 2, b: 0, c: 0, d: 2, e: 5, f: 10 }),
+		});
+		return {
+			nodeEl,
+			harness: {
+				canEditNodes: () => editable,
+				findNodeEl: () => nodeEl,
+				smartartContainer: () => ({ nativeElement: document.createElement('div') }),
+				cancelPendingHide: vi.fn(),
+				hoveredNodeId: { set: vi.fn() },
+				hoveredNodeRect: { set: vi.fn() },
+			},
+		};
+	}
+
+	it('anchors hover controls in SVG-local coordinates, not scaled screen rectangles', () => {
+		const { nodeEl, harness } = hoverHarness();
+		const screenRect = vi.spyOn(nodeEl, 'getBoundingClientRect');
+		onMouseMove.call(harness, new MouseEvent('mousemove'));
+		expect(harness.hoveredNodeId.set).toHaveBeenCalledWith('alpha');
+		expect(harness.hoveredNodeRect.set).toHaveBeenCalledWith({
+			left: 25,
+			top: 50,
+			width: 160,
+			height: 60,
+		});
+		expect(screenRect).not.toHaveBeenCalled();
+	});
+
+	it('hides the hover rectangle when SVG geometry is unavailable', () => {
+		const { nodeEl, harness } = hoverHarness();
+		Object.assign(nodeEl, { getCTM: () => null });
+		onMouseMove.call(harness, new MouseEvent('mousemove'));
+		expect(harness.hoveredNodeRect.set).toHaveBeenCalledWith(null);
+	});
+
+	it('does not show controls when node editing is disabled', () => {
+		const { harness } = hoverHarness(false);
+		onMouseMove.call(harness, new MouseEvent('mousemove'));
+		expect(harness.hoveredNodeId.set).not.toHaveBeenCalled();
+		expect(harness.hoveredNodeRect.set).not.toHaveBeenCalled();
+	});
+});
 
 function node(id: string, text: string, over: Partial<PptxSmartArtNode> = {}): PptxSmartArtNode {
 	return { id, text, ...over };

--- a/packages/react/src/viewer/components/elements/SmartArtEditableLayer.tsx
+++ b/packages/react/src/viewer/components/elements/SmartArtEditableLayer.tsx
@@ -1,11 +1,17 @@
 import type { PptxSmartArtData } from 'pptx-viewer-core';
-import { computeInlineEditorRect, findSmartArtNodeText } from 'pptx-viewer-shared';
+import { findSmartArtNodeText } from 'pptx-viewer-shared';
 import type { InlineEditRect } from 'pptx-viewer-shared';
 import React from 'react';
 
 import { SmartArtInlineNodeEditor } from './SmartArtInlineNodeEditor';
 import { SmartArtNodeStyleBar } from './SmartArtNodeStyleBar';
-import { NODE_ID_ATTR, findNodeIdFromEvent, useSmartArtHoverState } from './useSmartArtHoverState';
+import {
+	NODE_ID_ATTR,
+	findNodeIdFromEvent,
+	measureScreenNodeRect,
+	useSmartArtHoverState,
+} from './useSmartArtHoverState';
+import type { SmartArtNodeMeasurement } from './useSmartArtHoverState';
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -30,6 +36,8 @@ interface SmartArtEditableLayerProps {
 	palette?: string[];
 	/** Commit a per-node fill colour change. */
 	onChangeNodeStyle?: (nodeId: string, fill: string) => void;
+	/** The 2D renderer supplies SVG-local geometry; other consumers keep their existing policy. */
+	measureNodeRect?: SmartArtNodeMeasurement;
 	/** The rendered SmartArt SVG content (node groups tagged with data attrs). */
 	children: React.ReactNode;
 }
@@ -60,6 +68,7 @@ export function SmartArtEditableLayer({
 	onCommitNodeText,
 	palette,
 	onChangeNodeStyle,
+	measureNodeRect = measureScreenNodeRect,
 	children,
 }: SmartArtEditableLayerProps): React.ReactNode {
 	const containerRef = React.useRef<HTMLDivElement | null>(null);
@@ -73,8 +82,10 @@ export function SmartArtEditableLayer({
 		fontSize?: number;
 	} | null>(null);
 
-	const { hoveredNodeId, hoveredNodeRect, handleMouseMove, clearHover } =
-		useSmartArtHoverState(containerRef);
+	const { hoveredNodeId, hoveredNodeRect, handleMouseMove, clearHover } = useSmartArtHoverState(
+		containerRef,
+		measureNodeRect,
+	);
 
 	const openEditor = React.useCallback(
 		(target: EventTarget | null): void => {
@@ -94,17 +105,19 @@ export function SmartArtEditableLayer({
 			// itself is drawn. Falls back to the group box when there's no text
 			// node yet (e.g. an empty node being given its first label).
 			const textEl = nodeEl.querySelector('text');
-			const textRect = textEl?.getBoundingClientRect();
-			const hasTextRect = textRect !== undefined && textRect.width > 0 && textRect.height > 0;
-			const sourceRect = hasTextRect ? textRect : nodeEl.getBoundingClientRect();
-			const rect = computeInlineEditorRect(sourceRect, container.getBoundingClientRect());
+			const textRect = textEl ? measureNodeRect(textEl, container) : null;
+			const hasTextRect = textRect !== null && textRect.width > 0 && textRect.height > 0;
+			const rect = hasTextRect ? textRect : measureNodeRect(nodeEl, container);
+			if (!rect) {
+				return;
+			}
 			const paddedRect: InlineEditRect = {
 				left: rect.left - EDITOR_PADDING,
 				top: rect.top - EDITOR_PADDING,
 				width: rect.width + EDITOR_PADDING * 2,
 				height: rect.height + EDITOR_PADDING * 2,
 			};
-			// Approximate the on-screen font size from the measured text box so
+			// Approximate font size in the caller's coordinate space so
 			// the overlay's typography doesn't visibly jump relative to the
 			// rendered text underneath (each layout picks its own per-node size).
 			const lineCount = Math.max(1, textEl?.querySelectorAll('tspan').length ?? 1);
@@ -114,7 +127,7 @@ export function SmartArtEditableLayer({
 			clearHover();
 			setEdit({ nodeId, rect: paddedRect, fontSize });
 		},
-		[clearHover],
+		[clearHover, measureNodeRect],
 	);
 
 	if (!canEdit) {

--- a/packages/react/src/viewer/components/elements/SmartArtInlineNodeEditor.test.tsx
+++ b/packages/react/src/viewer/components/elements/SmartArtInlineNodeEditor.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import type { InlineEditRect } from 'pptx-viewer-shared';
+import { measureSvgViewportRect } from 'pptx-viewer-shared';
 import React, { act } from 'react';
 /**
  * Tests for the inline (on-canvas) SmartArt node text editor.
@@ -12,6 +13,7 @@ import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
+import { SmartArtEditableLayer } from './SmartArtEditableLayer';
 import { SmartArtInlineNodeEditor } from './SmartArtInlineNodeEditor';
 
 const RECT: InlineEditRect = { left: 10, top: 20, width: 120, height: 40 };
@@ -82,6 +84,69 @@ function blur(el: HTMLElement): void {
 }
 
 describe('smartArtInlineNodeEditor', () => {
+	it('preserves default screen-rectangle measurement for non-2D consumers', () => {
+		act(() => {
+			root.render(
+				<SmartArtEditableLayer
+					smartArtData={{ nodes: [{ id: 'n1', text: 'Alpha' }] }}
+					canEdit
+					onCommitNodeText={vi.fn()}
+				>
+					<svg>
+						<g data-smartart-node-id='n1'>
+							<text>Alpha</text>
+						</g>
+					</svg>
+				</SmartArtEditableLayer>,
+			);
+		});
+		const text = container.querySelector('text')!;
+		Object.assign(text, {
+			getBoundingClientRect: () => ({ left: 150, top: 260, width: 80, height: 12 }),
+		});
+		Object.assign(container.firstElementChild!, {
+			getBoundingClientRect: () => ({ left: 100, top: 200, width: 400, height: 300 }),
+		});
+		act(() => text.dispatchEvent(new MouseEvent('dblclick', { bubbles: true })));
+		const editor = container.querySelector('textarea')!;
+		expect(editor.style.left).toBe('46px');
+		expect(editor.style.top).toBe('56px');
+		expect(editor.style.width).toBe('88px');
+		expect(editor.style.height).toBe('20px');
+		expect(editor.style.fontSize).toBe('10px');
+	});
+
+	it('places the editable layer and font in local SVG coordinates', () => {
+		act(() => {
+			root.render(
+				<SmartArtEditableLayer
+					smartArtData={{ nodes: [{ id: 'n1', text: 'Alpha' }] }}
+					canEdit
+					onCommitNodeText={vi.fn()}
+					measureNodeRect={measureSvgViewportRect}
+				>
+					<svg>
+						<g data-smartart-node-id='n1'>
+							<text>Alpha</text>
+						</g>
+					</svg>
+				</SmartArtEditableLayer>,
+			);
+		});
+		const text = container.querySelector('text')!;
+		Object.assign(text, {
+			getBBox: () => ({ x: 10, y: 20, width: 80, height: 12 }),
+			getCTM: () => ({ a: 2, b: 0, c: 0, d: 2, e: 5, f: 10 }),
+		});
+		act(() => text.dispatchEvent(new MouseEvent('dblclick', { bubbles: true })));
+		const editor = container.querySelector('textarea')!;
+		expect(editor.style.left).toBe('21px');
+		expect(editor.style.top).toBe('46px');
+		expect(editor.style.width).toBe('168px');
+		expect(editor.style.height).toBe('32px');
+		expect(editor.style.fontSize).toBe('20px');
+	});
+
 	it('renders with the initial text', () => {
 		const ta = mount({ initialText: 'Hello', onCommit: vi.fn(), onCancel: vi.fn() });
 		expect(ta.value).toBe('Hello');

--- a/packages/react/src/viewer/components/elements/SmartArtRenderer.tsx
+++ b/packages/react/src/viewer/components/elements/SmartArtRenderer.tsx
@@ -5,6 +5,7 @@ import {
 	canDrillDown,
 	computeSmartArtElementLayout,
 	flattenNodes,
+	measureSvgViewportRect,
 	resolveRevealedDrawingShapes,
 	resolveRevealedSmartArtNodes,
 	shouldCommitSmartArtNodeText,
@@ -220,6 +221,7 @@ function SmartArtRendererImpl({
 			onCommitNodeText={handleCommitNodeText}
 			palette={palette}
 			onChangeNodeStyle={handleChangeNodeStyle}
+			measureNodeRect={measureSvgViewportRect}
 		>
 			{content}
 		</SmartArtEditableLayer>

--- a/packages/react/src/viewer/components/elements/useSmartArtHoverState.ts
+++ b/packages/react/src/viewer/components/elements/useSmartArtHoverState.ts
@@ -18,6 +18,15 @@ import React from 'react';
 /** Attribute carried by each rendered node group so pointer events map back to a node. */
 export const NODE_ID_ATTR = 'data-smartart-node-id';
 
+export type SmartArtNodeMeasurement = (
+	node: Element,
+	container: HTMLElement,
+) => InlineEditRect | null;
+
+/** Preserve the existing measurement for consumers without a shared SVG origin. */
+export const measureScreenNodeRect: SmartArtNodeMeasurement = (node, container) =>
+	computeInlineEditorRect(node.getBoundingClientRect(), container.getBoundingClientRect());
+
 // ── Shared helper ─────────────────────────────────────────────────────────────
 
 /** Walk up from an event target to the nearest element bearing a node id. */
@@ -65,6 +74,7 @@ export interface SmartArtHoverState {
  */
 export function useSmartArtHoverState(
 	containerRef: React.RefObject<HTMLDivElement | null>,
+	measureNodeRect: SmartArtNodeMeasurement = measureScreenNodeRect,
 ): SmartArtHoverState {
 	const [hoveredNodeId, setHoveredNodeId] = React.useState<string | null>(null);
 	const [hoveredNodeRect, setHoveredNodeRect] = React.useState<InlineEditRect | null>(null);
@@ -90,12 +100,7 @@ export function useSmartArtHoverState(
 			if (nodeEl && container) {
 				cancelPendingHide();
 				setHoveredNodeId(nodeEl.getAttribute(NODE_ID_ATTR));
-				setHoveredNodeRect(
-					computeInlineEditorRect(
-						nodeEl.getBoundingClientRect(),
-						container.getBoundingClientRect(),
-					),
-				);
+				setHoveredNodeRect(measureNodeRect(nodeEl, container));
 				return;
 			}
 			// Pointer is over a popover anchored to the currently-hovered node
@@ -112,7 +117,7 @@ export function useSmartArtHoverState(
 				hideTimeoutRef.current = null;
 			}, 150);
 		},
-		[containerRef, cancelPendingHide],
+		[containerRef, cancelPendingHide, measureNodeRect],
 	);
 
 	const clearHover = React.useCallback((): void => {

--- a/packages/shared/src/render/smartart-inline-edit.test.ts
+++ b/packages/shared/src/render/smartart-inline-edit.test.ts
@@ -3,13 +3,14 @@ import type {
 	PptxSmartArtDrawingShape,
 	PptxSmartArtNode,
 } from 'pptx-viewer-core';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import {
 	findSmartArtNodeText,
 	shouldCommitSmartArtNodeText,
 	resolveDrawingShapeNodeId,
 	computeInlineEditorRect,
+	measureSvgViewportRect,
 } from './smartart-inline-edit';
 
 function node(id: string, text: string): PptxSmartArtNode {
@@ -120,5 +121,109 @@ describe('computeInlineEditorRect', () => {
 			{ left: 100, top: 50, width: 400, height: 300 },
 		);
 		expect(rect).toStrictEqual({ left: 30, top: 40, width: 40, height: 24 });
+	});
+});
+
+describe('measureSvgViewportRect', () => {
+	const box = { x: 10, y: 20, width: 40, height: 30 };
+	const identity = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+	function graphic(matrix = identity, bounds = box): Element {
+		return {
+			ownerSVGElement: {},
+			getCTM: () => matrix,
+			getBBox: () => bounds,
+		} as unknown as Element;
+	}
+
+	it('includes local viewBox scaling and letterboxing without screen measurement', () => {
+		expect(
+			measureSvgViewportRect(graphic({ ...identity, a: 2, d: 2, e: 30, f: 75 })),
+		).toStrictEqual({
+			left: 50,
+			top: 115,
+			width: 80,
+			height: 60,
+		});
+	});
+
+	it('bounds all four corners after a local rotation or flip', () => {
+		expect(
+			measureSvgViewportRect(graphic({ a: 0, b: 1, c: -1, d: 0, e: 100, f: 0 })),
+		).toStrictEqual({
+			left: 50,
+			top: 10,
+			width: 30,
+			height: 40,
+		});
+		expect(measureSvgViewportRect(graphic({ ...identity, a: -1 }))).toStrictEqual({
+			left: -50,
+			top: 20,
+			width: 40,
+			height: 30,
+		});
+	});
+
+	it('retains zero-size geometry and negative overhang for caller fallback/padding', () => {
+		expect(
+			measureSvgViewportRect(graphic(identity, { x: -10, y: -20, width: 0, height: 0 })),
+		).toStrictEqual({
+			left: -10,
+			top: -20,
+			width: 0,
+			height: 0,
+		});
+	});
+
+	it('crosses nested SVG viewports through the outer local-to-screen matrices', () => {
+		const sourceScreen = { a: 0.5, b: 0, c: 0, d: 0.5, e: 100, f: 200 };
+		const screenInverse = {};
+		const sourceProduct = vi.fn(() => ({ ...identity, e: 30, f: 50 }));
+		const viewportProduct = vi.fn(() => ({ multiply: sourceProduct }));
+		const inverse = vi.fn(() => screenInverse);
+		const source = {
+			ownerSVGElement: {
+				ownerSVGElement: {
+					getCTM: () => ({ multiply: viewportProduct }),
+					getScreenCTM: () => ({ inverse }),
+				},
+			},
+			getCTM: () => identity,
+			getScreenCTM: () => sourceScreen,
+			getBBox: () => box,
+		} as unknown as Element;
+		expect(measureSvgViewportRect(source)).toStrictEqual({
+			left: 40,
+			top: 70,
+			width: 40,
+			height: 30,
+		});
+		expect(inverse).toHaveBeenCalledOnce();
+		expect(viewportProduct).toHaveBeenCalledWith(screenInverse);
+		expect(sourceProduct).toHaveBeenCalledWith(sourceScreen);
+	});
+
+	it('rejects unsupported, detached, invalid or unmeasurable graphics', () => {
+		expect(measureSvgViewportRect({} as Element)).toBeNull();
+		expect(
+			measureSvgViewportRect({ getBBox: () => box, getCTM: () => identity } as unknown as Element),
+		).toBeNull();
+		expect(
+			measureSvgViewportRect({
+				ownerSVGElement: {},
+				getBBox: () => box,
+				getCTM: () => null,
+			} as unknown as Element),
+		).toBeNull();
+		expect(measureSvgViewportRect(graphic({ ...identity, a: NaN }))).toBeNull();
+		expect(measureSvgViewportRect(graphic(identity, { ...box, width: -1 }))).toBeNull();
+		expect(
+			measureSvgViewportRect({
+				ownerSVGElement: {},
+				getCTM: () => identity,
+				getBBox: () => {
+					throw new Error('not rendered');
+				},
+			} as unknown as Element),
+		).toBeNull();
 	});
 });

--- a/packages/shared/src/render/smartart-inline-edit.ts
+++ b/packages/shared/src/render/smartart-inline-edit.ts
@@ -8,9 +8,8 @@
  * - `findSmartArtNodeText`: look up a node's current text by id.
  * - `shouldCommitSmartArtNodeText`: decide whether a new value differs from the
  *   current one (so a no-op blur does not push a history entry).
- * - `computeInlineEditorRect`: project a node's on-screen bounding box into
- *   coordinates relative to the SmartArt container so an HTML editor overlay can
- *   be positioned exactly over the node.
+ * - `measureSvgViewportRect`: measure SVG geometry in local coordinates so an
+ *   HTML overlay inherits the diagram's outer transform exactly once.
  *
  * @module smartart-inline-edit
  */
@@ -120,14 +119,11 @@ export function resolveDrawingShapeNodeId(
 }
 
 /**
- * Project a node's on-screen bounding box (`nodeRect`, viewport coordinates)
- * into coordinates relative to the SmartArt container box (`containerRect`,
- * viewport coordinates) so an absolutely-positioned editor can sit exactly over
- * the node.
+ * Subtract a container origin from a node rectangle in the same coordinate space.
  *
- * Both rectangles are expected in the same coordinate space (e.g. both from
- * `getBoundingClientRect()`), so the result is unaffected by canvas zoom: the
- * editor inherits the rendered size of the node.
+ * Both rectangles must already use the overlay's local coordinate space.
+ * Screen rectangles are unsuitable when the overlay inherits a transform;
+ * use `measureSvgViewportRect` for the SVG-backed SmartArt overlays.
  */
 export function computeInlineEditorRect(
 	nodeRect: InlineEditRect,
@@ -139,4 +135,70 @@ export function computeInlineEditorRect(
 		width: nodeRect.width,
 		height: nodeRect.height,
 	};
+}
+
+/**
+ * Measure an SVG graphic in its outermost SVG viewport's local CSS pixels.
+ *
+ * The viewport and the HTML overlay must share an origin. This accounts for
+ * SVG viewBox/letterboxing and internal transforms, but deliberately excludes
+ * outer HTML transforms that the overlay will inherit itself.
+ */
+export function measureSvgViewportRect(source: Element): InlineEditRect | null {
+	const graphic = source as SVGGraphicsElement;
+	if (typeof graphic.getBBox !== 'function' || typeof graphic.getCTM !== 'function') {
+		return null;
+	}
+	try {
+		let viewport = graphic.ownerSVGElement;
+		if (!viewport) {
+			return null;
+		}
+		let matrix = graphic.getCTM();
+		if (viewport.ownerSVGElement) {
+			// getCTM targets the nearest SVG viewport. Cross nested viewports
+			// through screen matrices, then remove the outer HTML transform.
+			while (viewport.ownerSVGElement) {
+				viewport = viewport.ownerSVGElement;
+			}
+			const viewportMatrix = viewport.getCTM();
+			const viewportScreen = viewport.getScreenCTM();
+			const graphicScreen = graphic.getScreenCTM();
+			if (!viewportMatrix || !viewportScreen || !graphicScreen) {
+				return null;
+			}
+			matrix = viewportMatrix.multiply(viewportScreen.inverse()).multiply(graphicScreen);
+		}
+		if (!matrix) {
+			return null;
+		}
+		const box = graphic.getBBox();
+		const points = [
+			[box.x, box.y],
+			[box.x + box.width, box.y],
+			[box.x, box.y + box.height],
+			[box.x + box.width, box.y + box.height],
+		].map(([x, y]) => ({
+			x: matrix.a * x + matrix.c * y + matrix.e,
+			y: matrix.b * x + matrix.d * y + matrix.f,
+		}));
+		if (
+			box.width < 0 ||
+			box.height < 0 ||
+			points.some(({ x, y }) => !Number.isFinite(x) || !Number.isFinite(y))
+		) {
+			return null;
+		}
+		const left = Math.min(...points.map(({ x }) => x));
+		const top = Math.min(...points.map(({ y }) => y));
+		return {
+			left,
+			top,
+			width: Math.max(...points.map(({ x }) => x)) - left,
+			height: Math.max(...points.map(({ y }) => y)) - top,
+		};
+	} catch {
+		// Detached/unrenderable SVGs and singular nested matrices have no box.
+		return null;
+	}
 }

--- a/packages/svelte/src/viewer/components/SmartArtView.svelte
+++ b/packages/svelte/src/viewer/components/SmartArtView.svelte
@@ -22,7 +22,7 @@
 	} from '../render';
 	import {
 		canDrillDown,
-		computeInlineEditorRect,
+		measureSvgViewportRect,
 		findSmartArtNodeText,
 		resolvePalette,
 		smartArtConnectorPaint,
@@ -51,8 +51,8 @@
 	function nodeRect(target: SVGGElement) {
 		if (!chromeEl) {return null;}
 		const text = target.querySelector('text');
-		const source = text && text.getBoundingClientRect().width > 0 ? text : target;
-		return computeInlineEditorRect(source.getBoundingClientRect(), chromeEl.getBoundingClientRect());
+		const textRect = text ? measureSvgViewportRect(text) : null;
+		return textRect && textRect.width > 0 ? textRect : measureSvgViewportRect(target);
 	}
 
 	function openEditor(event: MouseEvent, nodeId: string | undefined): void {

--- a/packages/svelte/src/viewer/components/smartart-view.test.ts
+++ b/packages/svelte/src/viewer/components/smartart-view.test.ts
@@ -82,6 +82,10 @@ function fallbackLayoutElement(): PptxElement {
 
 function openNodeEditorNow(target: HTMLElement): HTMLTextAreaElement {
 	const group = target.querySelector<SVGGElement>('[data-smartart-node-id="n1"]')!;
+	Object.assign(group, {
+		getBBox: () => ({ x: 10, y: 20, width: 80, height: 30 }),
+		getCTM: () => ({ a: 2, b: 0, c: 0, d: 2, e: 5, f: 10 }),
+	});
 	group.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
 	flushSync();
 	return target.querySelector<HTMLTextAreaElement>('.pptx-svelte-smartart-editor')!;
@@ -95,6 +99,15 @@ async function openNodeEditor(target: HTMLElement): Promise<HTMLTextAreaElement>
 }
 
 describe('smartArtView', () => {
+	it('positions the inline editor using local SVG coordinates', async () => {
+		const target = mountEl(drawingShapesElement(), 3, { onsmartartnodecommit: vi.fn() });
+		const editor = await openNodeEditor(target);
+		expect(editor.style.left).toBe('21px');
+		expect(editor.style.top).toBe('46px');
+		expect(editor.style.width).toBe('168px');
+		expect(editor.style.height).toBe('68px');
+	});
+
 	it('renders pre-computed drawing shapes as SVG rect/ellipse with labels', () => {
 		const target = mountEl(drawingShapesElement());
 		const node = target.querySelector<HTMLElement>('[data-element-id="sa-1"]');

--- a/packages/vanilla/src/viewer/render/elements/smartart-editable.ts
+++ b/packages/vanilla/src/viewer/render/elements/smartart-editable.ts
@@ -1,7 +1,7 @@
 import type { SmartArtPptxElement } from 'pptx-viewer-core';
 import {
 	canDrillDown,
-	computeInlineEditorRect,
+	measureSvgViewportRect,
 	findSmartArtNodeText,
 	resolvePalette,
 } from 'pptx-viewer-shared';
@@ -47,13 +47,15 @@ export function enableSmartArtEditing(
 			return;
 		}
 		event.stopPropagation();
-		closeEditor();
-		swatches?.remove();
 
 		const textNode = target.querySelector('text');
-		const textRect = textNode?.getBoundingClientRect();
-		const source = textRect && textRect.width > 0 ? textRect : target.getBoundingClientRect();
-		const rect = computeInlineEditorRect(source, chrome.getBoundingClientRect());
+		const textRect = textNode ? measureSvgViewportRect(textNode) : null;
+		const rect = textRect && textRect.width > 0 ? textRect : measureSvgViewportRect(target);
+		if (!rect) {
+			return;
+		}
+		closeEditor();
+		swatches?.remove();
 		editor = createEl(chrome.ownerDocument, 'textarea', 'pptxv-smartart-node-editor', {
 			position: 'absolute',
 			left: `${rect.left - 4}px`,
@@ -102,10 +104,10 @@ export function enableSmartArtEditing(
 			return;
 		}
 		swatches?.remove();
-		const rect = computeInlineEditorRect(
-			target.getBoundingClientRect(),
-			chrome.getBoundingClientRect(),
-		);
+		const rect = measureSvgViewportRect(target);
+		if (!rect) {
+			return;
+		}
 		swatches = createEl(chrome.ownerDocument, 'div', 'pptxv-smartart-node-swatches', {
 			position: 'absolute',
 			left: `${Math.max(0, rect.left)}px`,

--- a/packages/vanilla/src/viewer/render/elements/smartart.test.ts
+++ b/packages/vanilla/src/viewer/render/elements/smartart.test.ts
@@ -206,6 +206,10 @@ describe('renderSmartArtElement', () => {
 		) as HTMLElement;
 		document.body.appendChild(node);
 		const group = node.querySelector<SVGGElement>('[data-smartart-node-id="n1"]')!;
+		Object.assign(group, {
+			getBBox: () => ({ x: 10, y: 20, width: 80, height: 30 }),
+			getCTM: () => ({ a: 2, b: 0, c: 0, d: 2, e: 5, f: 10 }),
+		});
 
 		group.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
 		const swatch = node.querySelector<HTMLButtonElement>('.pptxv-smartart-node-swatches button');
@@ -215,6 +219,10 @@ describe('renderSmartArtElement', () => {
 
 		group.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
 		const editor = node.querySelector<HTMLTextAreaElement>('.pptxv-smartart-node-editor')!;
+		expect(editor.style.left).toBe('21px');
+		expect(editor.style.top).toBe('46px');
+		expect(editor.style.width).toBe('168px');
+		expect(editor.style.height).toBe('68px');
 		expect(editor.value).toBe('Alpha');
 		editor.value = 'Changed';
 		editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));

--- a/packages/vue/src/viewer/components/SmartArtRenderer.test.ts
+++ b/packages/vue/src/viewer/components/SmartArtRenderer.test.ts
@@ -28,6 +28,12 @@ function mountEditable(
 		attachTo: document.body,
 		global: { provide: { [SmartArtNodeEditKey as symbol]: ctx } },
 	});
+	for (const group of wrapper.findAll('g[data-node-id]')) {
+		Object.assign(group.element, {
+			getBBox: () => ({ x: 10, y: 20, width: 80, height: 30 }),
+			getCTM: () => ({ a: 2, b: 0, c: 0, d: 2, e: 5, f: 10 }),
+		});
+	}
 	return { wrapper, commit };
 }
 
@@ -60,6 +66,17 @@ function node(id: string, text: string): PptxSmartArtNode {
 }
 
 describe('smartArtRenderer', () => {
+	it('uses local SVG bounds for the editor', async () => {
+		const { wrapper } = mountEditable({ nodes: [node('n1', 'Alpha')] });
+		await wrapper.findAll('g[data-node-id]')[0]?.trigger('dblclick');
+		const editor = wrapper.find('textarea').element as HTMLTextAreaElement;
+		expect(editor.style.left).toBe('25px');
+		expect(editor.style.top).toBe('50px');
+		expect(editor.style.width).toBe('160px');
+		expect(editor.style.height).toBe('60px');
+		wrapper.unmount();
+	});
+
 	it('renders one <g> shape group per decomposed drawing shape', () => {
 		const shapes: PptxSmartArtDrawingShape[] = [
 			shape({ id: 's1', x: 0, y: 0 }),

--- a/packages/vue/src/viewer/components/SmartArtRenderer.vue
+++ b/packages/vue/src/viewer/components/SmartArtRenderer.vue
@@ -12,6 +12,7 @@ import {
 	buildSmartArtA11y,
 	canDrillDown,
 	computeDrawingViewBox,
+	measureSvgViewportRect,
 	projectDrawingShapes,
 	resolveRevealedDrawingShapeNodeIds,
 	resolvePalette,
@@ -34,7 +35,6 @@ import { useI18n } from 'vue-i18n';
 
 import { getContainerStyle } from '../composables/element-style';
 import {
-	inlineEditorRect,
 	nodeIdsInRenderOrder,
 	useSmartArtInlineEditState,
 } from '../composables/smartart-inline-edit';
@@ -335,9 +335,8 @@ const styleBarStyle = computed<CSSProperties | undefined>(() => {
 });
 
 /**
- * Enter edit mode for a node. Projects the double-clicked SVG node's on-screen
- * rect into container-relative pixels (shared `computeInlineEditorRect`) so the
- * overlay textarea sits exactly over the node, independent of canvas zoom.
+ * Enter edit mode using local SVG geometry. The textarea inherits the same
+ * outer canvas transform, so its coordinates must not include zoom twice.
  */
 function beginEdit(nodeId: string | undefined, text: string, event: Event): void {
 	if (!editable.value || !nodeId) {
@@ -348,7 +347,10 @@ function beginEdit(nodeId: string | undefined, text: string, event: Event): void
 	if (!target || !host) {
 		return;
 	}
-	const rect = inlineEditorRect(target.getBoundingClientRect(), host.getBoundingClientRect());
+	const rect = measureSvgViewportRect(target);
+	if (!rect) {
+		return;
+	}
 	edit.begin(nodeId, text, rect);
 	void nextTick(() => {
 		editorEl.value?.focus();

--- a/packages/vue/src/viewer/composables/useSmartArtHoverRect.ts
+++ b/packages/vue/src/viewer/composables/useSmartArtHoverRect.ts
@@ -1,4 +1,4 @@
-import { computeInlineEditorRect } from 'pptx-viewer-shared';
+import { measureSvgViewportRect } from 'pptx-viewer-shared';
 import type { InlineEditRect } from 'pptx-viewer-shared';
 import { onUnmounted, ref } from 'vue';
 import type { Ref } from 'vue';
@@ -46,12 +46,7 @@ export function useSmartArtHoverRect(containerRef: Ref<HTMLElement | null>) {
 			const id = nodeEl.getAttribute(NODE_ID_ATTR);
 			if (id !== hoveredNodeId.value) {
 				hoveredNodeId.value = id;
-				hoveredNodeRect.value = id
-					? computeInlineEditorRect(
-							nodeEl.getBoundingClientRect(),
-							container.getBoundingClientRect(),
-						)
-					: null;
+				hoveredNodeRect.value = id ? measureSvgViewportRect(nodeEl) : null;
 			}
 			return;
 		}


### PR DESCRIPTION
## What does this change?

Keep SmartArt text editors and hover controls in the diagram's local coordinate space. Previously, screen-space rectangles were positioned inside an already transformed slide, applying zoom again and moving or shrinking the editor away from its label.

The shared helper measures SVG viewport-local geometry, including viewBox letterboxing and internal transforms. Existing text-first bounds, empty-node fallback, padding, palette sizing and commit behavior are preserved.

This change is limited to standard 2D SVG editing and hover controls. Experimental 3D rendering, hit planes, saved models and existing 3D measurement behavior are unchanged.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

All five demos were checked with the framework-neutral SmartArt editing suite.

| Binding | Affected? | Fixed here? | Notes |
| --- | --- | --- | --- |
| React | Yes | Yes | 2D inline editor position/font measurement and hover controls |
| Vue | Yes | Yes | 2D inline editor and hover geometry |
| Angular | Yes | Yes | 2D hover geometry; its ordinary 2D editor already uses model geometry |
| Svelte | Yes | Yes | Shared local node measurement used by inline editor and hover controls |
| Vanilla | Yes | Yes | Inline editor and swatch placement; failed measurement leaves the current editor intact |

No 3D editing capability or alignment fix is claimed here.

## Testing

- [x] Colocated shared and binding regression tests updated.
- [x] Framework-neutral 2D editing spec updated.
- [x] Regression checked against the previous screen-coordinate implementation.

Focused tests pass: shared 20, React 9, Vue 42, Angular 32, Svelte 19, Vanilla 20 (142 total). All six affected packages build and typecheck. The five-binding 2D matrix passes 30/30, including physical editor/label overlap and local coordinates at fitted/enlarged zoom, insertion, inspector text/layout/colour edits and direct keyboard editing with history and saved reload. The final positive-dimension assertion also passes in a separate five-project rerun.

Independent code review approves the narrowed implementation. Live browser checks covered React at 50%, 100%, 120% and 150% zoom, cancellation/history and reopening an empty node; Vue loaded drawings with letterboxing and rotation; and Angular hover-palette selection and Undo. A separate reviewer inspected actual screenshots with no blocking coarse geometry finding. Browser actions were performed by the primary agent, not independently replayed by the screenshot reviewer. Angular empty-node entry was not established in this manual check. No native PowerPoint, typography-baseline or 3D fidelity claim is made for this DOM-overlay fix.

## Checks run locally

Changed-file formatting and lint, whitespace checks, E2E neutrality, focused unit tests, affected-package builds/typechecks, and the named browser scenarios above. A complete repository-wide unit/E2E sweep is not claimed.

## Conventional Commits

- [x] Commit messages follow Conventional Commits.
