### PR TITLE
fix(react): repaint inspector table merges without saving

### DIFF
--- a/e2e/table-styling.spec.ts
+++ b/e2e/table-styling.spec.ts
@@ -506,10 +506,84 @@ async function expectRenderedRowCellCount(page: Page, row: number, count: number
 	).toHaveCount(count);
 }
 
+/** Use the inspector's pairwise command, or its public selected-cell equivalent. */
+async function mergeFromInspector(page: Page, direction: 'right' | 'down'): Promise<void> {
+	await selectTableCell(page, canvasCellAt(page, 0, 0));
+	// Some inspectors choose the formatting cursor independently of canvas selection.
+	for (const name of ['Row', 'Column']) {
+		const cursor = page.getByRole('combobox', { name, exact: true });
+		if (await cursor.isVisible()) {
+			await cursor.selectOption('0');
+		}
+	}
+	const pairwise = page.getByRole('button', { name: `Merge ${direction}`, exact: true });
+	if (await pairwise.isVisible()) {
+		await pairwise.click();
+	} else {
+		// An inspector with only "Merge selected" is a geometry/history control,
+		// not coverage of the pairwise cursor command or its text-aggregation policy.
+		await canvasCellAt(page, direction === 'down' ? 1 : 0, direction === 'right' ? 1 : 0).click({
+			modifiers: ['Shift'],
+		});
+		await page.getByRole('button', { name: 'Merge selected', exact: true }).click();
+	}
+}
+
 test.describe('table styling', () => {
 	test.beforeEach(async ({ page }) => {
 		await loadDeck(page);
 	});
+
+	for (const merge of [
+		{ direction: 'right', attribute: 'colspan', absorbedRow: 0, absorbedColumn: 1 },
+		{ direction: 'down', attribute: 'rowspan', absorbedRow: 1, absorbedColumn: 0 },
+	] as const) {
+		test(`repaints inspector merge ${merge.direction} and split without auto-save`, async ({
+			page,
+		}) => {
+			// Saving can synchronize raw XML as a side effect. Turn it off before any
+			// edit so polling cannot hide a stale loaded-table renderer behind auto-save.
+			const autoSave = page.getByRole('switch', { name: 'Toggle AutoSave', exact: true });
+			if ((await autoSave.getAttribute('aria-checked')) === 'true') {
+				await autoSave.click();
+			}
+			await expect(autoSave).toHaveAttribute('aria-checked', 'false');
+			await mergeFromInspector(page, merge.direction);
+			const anchor = canvasCellAt(page, 0, 0);
+			await expect(anchor).toHaveAttribute(merge.attribute, '2');
+			await expectRenderedRowCellCount(page, merge.absorbedRow, 3);
+
+			await selectTableCell(page, anchor);
+			await page.getByRole('button', { name: 'Split', exact: true }).click();
+			await expectRenderedRowCellCount(page, merge.absorbedRow, 4);
+			await expect(anchor).not.toHaveAttribute(merge.attribute, '2');
+			await expect(canvasCellAt(page, merge.absorbedRow, merge.absorbedColumn)).toHaveText('');
+
+			const undo = page.getByRole('button', { name: 'Undo', exact: true });
+			const redo = page.getByRole('button', { name: 'Redo', exact: true });
+			await undo.click();
+			await expect(anchor).toHaveAttribute(merge.attribute, '2');
+			await expectRenderedRowCellCount(page, merge.absorbedRow, 3);
+			await undo.click();
+			await expectRenderedRowCellCount(page, merge.absorbedRow, 4);
+			await expect(anchor).not.toHaveAttribute(merge.attribute, '2');
+			await expect(undo).toBeDisabled();
+			await redo.click();
+			await expect(anchor).toHaveAttribute(merge.attribute, '2');
+			await expectRenderedRowCellCount(page, merge.absorbedRow, 3);
+			await redo.click();
+			await expectRenderedRowCellCount(page, merge.absorbedRow, 4);
+			await expect(anchor).not.toHaveAttribute(merge.attribute, '2');
+			await expect(canvasCellAt(page, merge.absorbedRow, merge.absorbedColumn)).toHaveText('');
+
+			const download = await savePptxViaBackstage(page);
+			const savedPath = await download.path();
+			expect(savedPath, 'the browser should retain the split PPTX').not.toBeNull();
+			await loadDeck(page, savedPath!);
+			await expectRenderedRowCellCount(page, merge.absorbedRow, 4);
+			await expect(canvasCellAt(page, merge.absorbedRow, merge.absorbedColumn)).toHaveText('');
+		});
+	}
 
 	test('paints the header row and banded rows from the table style', async ({ page }) => {
 		await gotoSlide(page, 1);

--- a/packages/react/src/viewer/components/inspector/TableCellFormattingPanel.tsx
+++ b/packages/react/src/viewer/components/inspector/TableCellFormattingPanel.tsx
@@ -23,6 +23,7 @@ interface TableCellFormattingPanelProps {
 	tableEditorState: TableCellEditorState;
 	canEdit: boolean;
 	onUpdateTableData: (patch: Partial<PptxTableData>) => void;
+	onUpdateMergeRows: (rows: PptxTableData['rows']) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -34,6 +35,7 @@ export function TableCellFormattingPanel({
 	tableEditorState,
 	canEdit,
 	onUpdateTableData,
+	onUpdateMergeRows,
 }: TableCellFormattingPanelProps): React.ReactElement | null {
 	const { t } = useTranslation();
 	const { rowIndex, columnIndex } = tableEditorState;
@@ -232,7 +234,7 @@ export function TableCellFormattingPanel({
 						onClick={() => {
 							const newRows = computeMergeCellRight(td, rowIndex, columnIndex);
 							if (newRows) {
-								onUpdateTableData({ rows: newRows });
+								onUpdateMergeRows(newRows);
 							}
 						}}
 					>
@@ -245,7 +247,7 @@ export function TableCellFormattingPanel({
 						onClick={() => {
 							const newRows = computeMergeCellDown(td, rowIndex, columnIndex);
 							if (newRows) {
-								onUpdateTableData({ rows: newRows });
+								onUpdateMergeRows(newRows);
 							}
 						}}
 					>
@@ -258,7 +260,7 @@ export function TableCellFormattingPanel({
 						onClick={() => {
 							const newRows = computeSplitCell(td, rowIndex, columnIndex);
 							if (newRows) {
-								onUpdateTableData({ rows: newRows });
+								onUpdateMergeRows(newRows);
 							}
 						}}
 					>

--- a/packages/react/src/viewer/components/inspector/TablePropertiesPanel.test.tsx
+++ b/packages/react/src/viewer/components/inspector/TablePropertiesPanel.test.tsx
@@ -1,12 +1,19 @@
 // @vitest-environment happy-dom
 /* oxlint-disable eslint/one-var -- many independent it() blocks, each with
    its own short arrange/act/assert consts. */
-import type { ParsedTableStyleMap, PptxElement, TablePptxElement } from 'pptx-viewer-core';
+import type {
+	ParsedTableStyleMap,
+	PptxElement,
+	TablePptxElement,
+	XmlObject,
+} from 'pptx-viewer-core';
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { renderTableElement } from '../../utils/table-render';
 import { TablePropertiesPanel } from './TablePropertiesPanel';
 
 vi.mock(import('react-i18next'), () => ({
@@ -32,6 +39,54 @@ function table(): TablePptxElement {
 			],
 		},
 	} as unknown as TablePptxElement;
+}
+
+function loadedTable(): TablePptxElement {
+	const element = table();
+	element.rawXml = {
+		'a:graphic': {
+			'a:graphicData': {
+				'a:tbl': {
+					'a:tblGrid': { 'a:gridCol': [20, 30, 50].map((w) => ({ '@_w': w * 9525 })) },
+					'a:tr': element.tableData!.rows.map((row) => ({
+						'@_h': row.height! * 9525,
+						'a:tc': row.cells.map((cell) => ({
+							'a:txBody': {
+								'a:bodyPr': { '@_anchor': 'ctr' },
+								'a:p': {
+									'a:pPr': { '@_marL': '12700' },
+									'a:r': { 'a:rPr': { '@_b': '1' }, 'a:t': cell.text },
+								},
+							},
+							'a:tcPr': { '@_marL': '91440' },
+						})),
+					})),
+				},
+			},
+		},
+	};
+	return element;
+}
+
+function xmlCells(element: TablePptxElement, row: number): XmlObject[] {
+	const graphic = element.rawXml!['a:graphic'] as XmlObject;
+	const data = graphic['a:graphicData'] as XmlObject;
+	const tbl = data['a:tbl'] as XmlObject;
+	return (tbl['a:tr'] as XmlObject[])[row]['a:tc'] as XmlObject[];
+}
+
+function clickTableButton(key: string) {
+	const button = [...host.querySelectorAll('button')].find(
+		(item) => item.textContent === `pptx.table.${key}`,
+	);
+	expect(button).toBeDefined();
+	act(() => button!.click());
+}
+
+function renderedCells(element: TablePptxElement): HTMLTableCellElement[] {
+	const container = document.createElement('div');
+	container.innerHTML = renderToStaticMarkup(renderTableElement(element, {}));
+	return [...container.querySelectorAll<HTMLTableCellElement>('td')];
 }
 
 let host: HTMLDivElement;
@@ -66,6 +121,100 @@ function render(
 }
 
 describe('tablePropertiesPanel', () => {
+	it.each([
+		{
+			command: 'mergeRight',
+			span: 'gridSpan',
+			xmlSpan: '@_gridSpan',
+			htmlSpan: 'colspan',
+			row: 0,
+			col: 1,
+		},
+		{
+			command: 'mergeDown',
+			span: 'rowSpan',
+			xmlSpan: '@_rowSpan',
+			htmlSpan: 'rowspan',
+			row: 1,
+			col: 0,
+		},
+	] as const)(
+		'repaints loaded-table $command and split with one immutable update each',
+		({ command, span, xmlSpan, htmlSpan, row, col }) => {
+			const element = loadedTable();
+			const original = structuredClone(element);
+			const onUpdate = vi.fn();
+			render(element, onUpdate, { rowIndex: 0, columnIndex: 0 });
+			clickTableButton(command);
+
+			expect(onUpdate).toHaveBeenCalledOnce();
+			const patch = onUpdate.mock.calls[0][0] as Partial<TablePptxElement>;
+			const merged = { ...element, ...patch };
+			expect(merged.tableData!.rows[0].cells[0][span]).toBe(2);
+			expect(xmlCells(merged, 0)[0][xmlSpan]).toBe('2');
+			expect(merged.tableData!.rows[row].cells[col].text).toBe('');
+			const cells = renderedCells(merged);
+			expect(cells).toHaveLength(5);
+			expect(cells[0].getAttribute(htmlSpan)).toBe('2');
+			expect(cells.map((cell) => cell.textContent)).not.toContain(
+				original.tableData!.rows[row].cells[col].text,
+			);
+			// The synchronizer preserves the anchor and untouched rich XML, not just plain text.
+			expect(xmlCells(merged, 0)[0]['a:txBody']).toStrictEqual(
+				xmlCells(original, 0)[0]['a:txBody'],
+			);
+			expect(xmlCells(merged, 0)[2]).toStrictEqual(xmlCells(original, 0)[2]);
+			expect(element).toStrictEqual(original);
+
+			render(merged, onUpdate, { rowIndex: 0, columnIndex: 0 });
+			clickTableButton('split');
+			expect(onUpdate).toHaveBeenCalledTimes(2);
+			const split = { ...merged, ...onUpdate.mock.calls[1][0] } as TablePptxElement;
+			expect(xmlCells(split, 0)[0][xmlSpan]).toBeUndefined();
+			const splitCells = renderedCells(split);
+			expect(splitCells).toHaveLength(6);
+			expect(splitCells[row * 3 + col].textContent?.trim()).toBe('');
+			expect(xmlCells(split, 0)[0]['a:txBody']).toStrictEqual(xmlCells(original, 0)[0]['a:txBody']);
+			expect(merged.tableData!.rows[0].cells[0][span]).toBe(2);
+			expect(xmlCells(merged, 0)[0][xmlSpan]).toBe('2');
+		},
+	);
+
+	it.each([
+		{ command: 'mergeRight', rowIndex: 0, columnIndex: 2 },
+		{ command: 'mergeDown', rowIndex: 1, columnIndex: 0 },
+		{ command: 'split', rowIndex: 0, columnIndex: 0 },
+	])('does not emit updates for invalid $command', ({ command, rowIndex, columnIndex }) => {
+		const onUpdate = vi.fn();
+		render(loadedTable(), onUpdate, { rowIndex, columnIndex });
+		clickTableButton(command);
+		expect(onUpdate).not.toHaveBeenCalled();
+	});
+
+	it('keeps programmatic merges on the data-only renderer without adding rawXml', () => {
+		const element = table();
+		const onUpdate = vi.fn();
+		render(element, onUpdate, { rowIndex: 0, columnIndex: 0 });
+		clickTableButton('mergeRight');
+		const patch = onUpdate.mock.calls[0][0] as Partial<TablePptxElement>;
+		expect(patch).not.toHaveProperty('rawXml');
+		expect(renderedCells({ ...element, ...patch })[0].colSpan).toBe(2);
+	});
+
+	it('keeps ordinary cell styling on the generic data-only update path', () => {
+		const element = loadedTable();
+		const original = structuredClone(element);
+		const onUpdate = vi.fn();
+		render(element, onUpdate, { rowIndex: 0, columnIndex: 0 });
+		const bold = host.querySelector<HTMLButtonElement>('button.font-bold');
+		expect(bold).not.toBeNull();
+		act(() => bold!.click());
+		expect(onUpdate).toHaveBeenCalledOnce();
+		expect(onUpdate.mock.calls[0][0]).not.toHaveProperty('rawXml');
+		expect(onUpdate.mock.calls[0][0].tableData.rows[0].cells[0].style.bold).toBeTruthy();
+		expect(element).toStrictEqual(original);
+	});
+
 	it('sets a column to the exact requested width via the shared redistribution formula', () => {
 		const onUpdate = vi.fn();
 		render(table(), onUpdate);

--- a/packages/react/src/viewer/components/inspector/TablePropertiesPanel.tsx
+++ b/packages/react/src/viewer/components/inspector/TablePropertiesPanel.tsx
@@ -1,6 +1,7 @@
 /* oxlint-disable eslint/one-var -- independent, unrelated locals; merging them
    into one statement would hurt readability. */
 import type { ParsedTableStyleMap, PptxElement, TablePptxElement } from 'pptx-viewer-core';
+import { updateMergeAttrsInRawXml } from 'pptx-viewer-core';
 import {
 	applyTableStylePreset,
 	evenColumnWidths,
@@ -64,6 +65,15 @@ export function TablePropertiesPanel({
 		onUpdateElement({
 			tableData: { ...td, ...patch },
 		} as Partial<PptxElement>);
+	};
+	const updateMergeRows = (rows: typeof td.rows) => {
+		const tableData = { ...td, rows };
+		const updates: Partial<TablePptxElement> = { tableData };
+		const rawXml = updateMergeAttrsInRawXml(tableElement, tableData);
+		if (rawXml) {
+			updates.rawXml = rawXml;
+		}
+		onUpdateElement(updates);
 	};
 
 	return (
@@ -272,6 +282,7 @@ export function TablePropertiesPanel({
 					tableEditorState={tableEditorState}
 					canEdit={canEdit}
 					onUpdateTableData={updateTableData}
+					onUpdateMergeRows={updateMergeRows}
 				/>
 			)}
 		</>


### PR DESCRIPTION
## What does this change?

Fixes React's loaded-table inspector merge/split controls updating the data grid but leaving the slide's cell geometry stale until a save. With AutoSave off, merging R2C1 right leaves R2C2 visible and the original divider in place. AutoSave can hide this by synchronizing raw XML during serialization.

The inspector now uses the existing core `updateMergeAttrsInRawXml` helper, as the canvas merge handlers already do, and sends typed rows plus raw XML in one update. Only the three successful merge/split actions use this path. Generic formatting, cursor merge semantics, data-only tables and invalid-operation no-ops are unchanged.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

| Binding | Affected by stale merge geometry? | Checked |
| --- | --- | --- |
| React | Yes, fixed here | Loaded fixture with AutoSave off, right/down merges, split, undo/redo, download/reopen; newly inserted table control |
| Vue | No | AutoSave off; right/down merges, split, undo/redo |
| Angular | No | AutoSave off; right merge, split, undo/redo |
| Svelte | No | AutoSave off; right/down merges, split, undo/redo |
| Vanilla | No | AutoSave off; equivalent selected-cell merge, split, undo/redo |

React's loaded-table renderer reads merge flags from raw XML. The other bindings render these flags from typed table data. No new algorithm is needed: this reuses the core helper moved there in `66ee49b9`, retaining the rich-XML preservation and absorbed-cell fixes from #229 and #230.

Vanilla's selected-cell command has a different text-aggregation policy; its check is a geometry/history control, not a claim of identical pairwise behavior. An unrelated Angular cell-reselection inconsistency after history was observed; fresh merge/split/history controls passed and that issue is outside this fix.

- [x] Reproduced this defect or confirmed its absence in every binding above
- [x] Every binding affected by this defect is fixed here

## Testing

- [x] Regression tests added to existing `TablePropertiesPanel.test.tsx`; two fail without the fix
- [x] Framework-neutral right/down inspector cases added to existing `e2e/table-styling.spec.ts`
- [ ] New Playwright cases executed in the runner

Validation performed:

- 51 focused React component/helper/render tests passed.
- 37 core raw-XML merge and save tests passed.
- React package build and typecheck passed; changed-file lint/format, E2E typecheck/neutrality and whitespace checks passed.
- Actual browser controls listed above were operated through computer use. Independent code review and independent review of captured browser images found no blocking issue. The visual reviewer did not operate the browser.
- Saved the edited fixture, read back its ZIP/XML and reopened that exact downloaded file: horizontal split, cleared neighbor and vertical merge persisted. An untouched mixed-format cell's text XML was preserved exactly.

The new E2E runner remains unexecuted in this environment; its source checks and manual browser evidence are separate. Full repository suites and native PowerPoint validation are not claimed.

## Conventional Commits

- [x] Package-scoped Conventional Commits
