### PR TITLE
fix(core): preserve edited table column widths on save

### DIFF
--- a/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/table-sdk-save-roundtrip.test.ts
@@ -77,6 +77,69 @@ async function buildDeckWithAttributedTableCell(): Promise<Uint8Array> {
  * `SAVE_ELEMENT_SKIPPED` warning. The saved slide had an empty `p:spTree`.
  */
 describe('sDK-created table survives save round-trip', () => {
+	it.each([false, true])(
+		'preserves edited column widths and rich cells (frame resized: %s)',
+		async (resizeFrame) => {
+			const fixture = await buildDeckWithRichTableCell();
+			const fixtureZip = await JSZip.loadAsync(fixture);
+			const fixtureXml = await fixtureZip.file('ppt/slides/slide1.xml')!.async('string');
+			const originalGridTotal = [...fixtureXml.matchAll(/<a:gridCol\b[^>]*\bw="(\d+)"/g)].reduce(
+				(total, match) => total + Number(match[1]),
+				0,
+			);
+			const handler = new PptxHandler();
+			const loaded = await handler.load(fixture.buffer as ArrayBuffer);
+			const table = loaded.slides[0].elements.find(
+				(element) => element.type === 'table',
+			) as TablePptxElement;
+			expect(table.tableData!.columnWidths).toStrictEqual([0.5, 0.5]);
+			expect(originalGridTotal).toBeGreaterThan(0);
+			if (resizeFrame) {
+				// Resizing the frame must not change the authored grid's total extent.
+				table.width *= 2;
+				expect(originalGridTotal).not.toBe(Math.round(table.width * 9525));
+			}
+			const richRuns = structuredClone(table.tableData!.rows[1].cells[0].textRuns);
+			expect(richRuns).toStrictEqual([
+				{ text: 'Rich', bold: true },
+				{ text: '1', isField: true },
+				{ text: 'Text', italic: true },
+			]);
+			table.tableData!.columnWidths = [0.25, 0.75];
+
+			const saved = await handler.save(loaded.slides);
+			const zip = await JSZip.loadAsync(saved);
+			const xml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+			expect
+				.soft([...xml.matchAll(/<a:gridCol\b[^>]*\bw="(\d+)"/g)].map((match) => Number(match[1])))
+				.toStrictEqual([0.25, 0.75].map((ratio) => Math.round(originalGridTotal * ratio)));
+			expect(xml).toContain('<a:fld id="{AAAA0000-0000-4000-A000-000000000001}" type="slidenum">');
+
+			const reloader = new PptxHandler();
+			const reloaded = await reloader.load(saved.buffer as ArrayBuffer);
+			const reloadedTable = reloaded.slides[0].elements.find(
+				(element) => element.type === 'table',
+			) as TablePptxElement;
+			expect(reloadedTable.tableData!.rows[1].cells[0].textRuns).toStrictEqual(richRuns);
+			expect(reloadedTable.tableData!.columnWidths).toStrictEqual([0.25, 0.75]);
+
+			// A subsequent unrelated edit must not round or rescale these widths again.
+			reloadedTable.x += 1;
+			const savedAgain = await reloader.save(reloaded.slides);
+			const secondZip = await JSZip.loadAsync(savedAgain);
+			const secondXml = await secondZip.file('ppt/slides/slide1.xml')!.async('string');
+			expect(
+				[...secondXml.matchAll(/<a:gridCol\b[^>]*\bw="(\d+)"/g)].map((match) => Number(match[1])),
+			).toStrictEqual([0.25, 0.75].map((ratio) => Math.round(originalGridTotal * ratio)));
+			const secondReload = await new PptxHandler().load(savedAgain.buffer as ArrayBuffer);
+			const secondTable = secondReload.slides[0].elements.find(
+				(element) => element.type === 'table',
+			)!;
+			expect(secondTable.tableData!.columnWidths).toStrictEqual([0.25, 0.75]);
+			expect(secondTable.tableData!.rows[1].cells[0].textRuns).toStrictEqual(richRuns);
+		},
+	);
+
 	it('preserves attributed rich text after a non-text table edit', async () => {
 		let handler = new PptxHandler();
 		let loaded = await handler.load(

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveDataSerialization.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveDataSerialization.ts
@@ -97,6 +97,7 @@ import {
 	serializeCellMergeAttributes,
 	serializeTablePropertyFlags,
 } from './save-table-merge-helpers';
+import { writeTableColumnWidths } from './table-column-width-save';
 import { recordTableParagraphOrder } from './table-paragraph-save-order';
 import { rebuildTableXmlFromData } from './table-structural-ops';
 import { writeTablePropertiesOwnFillAndEffects } from './table-tblpr-save';
@@ -181,6 +182,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			}
 
 			// ── No structural change: update cells in place ──
+			writeTableColumnWidths(tbl as XmlObject, tableData.columnWidths);
 			for (let rIdx = 0; rIdx < Math.min(tableData.rows.length, xmlRows.length); rIdx++) {
 				const dataRow = tableData.rows[rIdx];
 				const xmlRow = xmlRows[rIdx] as XmlObject;

--- a/packages/core/src/core/core/runtime/save-table-merge-helpers.test.ts
+++ b/packages/core/src/core/core/runtime/save-table-merge-helpers.test.ts
@@ -7,6 +7,86 @@ import {
 	replaceFirstTextValueInTree,
 	buildChartPoints,
 } from './save-table-merge-helpers';
+import { writeTableColumnWidths } from './table-column-width-save';
+
+describe('writeTableColumnWidths', () => {
+	it('updates only widths while retaining column identities, extensions and cells', () => {
+		const columns = [
+			{ '@_w': '100', 'a:extLst': { 'a:ext': { 'a16:colId': { '@_val': '7' } } } },
+			{ '@_w': '100', 'a:extLst': { 'a:ext': { '@_uri': 'custom', 'custom:data': 'keep' } } },
+		];
+		const tbl: XmlObject = {
+			'a:tblGrid': { 'a:gridCol': columns },
+			'a:tr': { 'a:tc': 'untouched' },
+		};
+		const expected = structuredClone(tbl);
+		expected['a:tblGrid']['a:gridCol'][0]['@_w'] = '50';
+		expected['a:tblGrid']['a:gridCol'][1]['@_w'] = '150';
+		const proportions = [0.25, 0.75];
+		writeTableColumnWidths(tbl, proportions);
+		expect(tbl).toStrictEqual(expected);
+		expect(tbl['a:tblGrid']['a:gridCol']).toBe(columns);
+		expect(proportions).toStrictEqual([0.25, 0.75]);
+	});
+
+	it('retains the integer grid total through fractional edits and repeated writes', () => {
+		const columns = [3, 3, 4].map((width) => ({ '@_w': String(width) }));
+		const tbl: XmlObject = { 'a:tblGrid': { 'a:gridCol': columns } };
+		for (let save = 0; save < 3; save++) {
+			writeTableColumnWidths(tbl, [1 / 3, 1 / 3, 1 / 3]);
+			expect(columns.map((column) => Number(column['@_w']))).toStrictEqual([3, 4, 3]);
+		}
+		writeTableColumnWidths(tbl, [0, 0.5, 0.5]);
+		expect(columns.map((column) => column['@_w'])).toStrictEqual(['0', '5', '5']);
+	});
+
+	it('keeps a singleton column and unchanged authored widths byte-stable', () => {
+		const tbl: XmlObject = { 'a:tblGrid': { 'a:gridCol': { '@_w': '00100', 'a:extLst': '' } } };
+		const original = structuredClone(tbl);
+		writeTableColumnWidths(tbl, [1]);
+		expect(tbl).toStrictEqual(original);
+	});
+
+	it('keeps unchanged uneven multi-column EMUs and lexical widths', () => {
+		const widths = ['00101', '203', '0307'];
+		const tbl: XmlObject = {
+			'a:tblGrid': { 'a:gridCol': widths.map((width) => ({ '@_w': width })) },
+		};
+		const original = structuredClone(tbl);
+		writeTableColumnWidths(tbl, [101 / 611, 203 / 611, 307 / 611]);
+		expect(tbl).toStrictEqual(original);
+	});
+
+	it('does not make a trailing zero width negative from floating-point sum error', () => {
+		const columns = [Number.MAX_SAFE_INTEGER, 0].map((width) => ({ '@_w': String(width) }));
+		const tbl: XmlObject = { 'a:tblGrid': { 'a:gridCol': columns } };
+		const original = structuredClone(tbl);
+		writeTableColumnWidths(tbl, [1 + Number.EPSILON, 0]);
+		expect(tbl).toStrictEqual(original);
+	});
+
+	it.each([
+		{ source: ['100', '100'], ratios: [NaN, 0.5] },
+		{ source: ['100', '100'], ratios: [Infinity, 0] },
+		{ source: ['100', '100'], ratios: [-0.25, 1.25] },
+		{ source: ['100', '100'], ratios: [0, 0] },
+		{ source: ['100', '100'], ratios: [1, 3] },
+		{ source: ['100', '100'], ratios: [1] },
+		{ source: ['bad', '100'], ratios: [0.25, 0.75] },
+		{ source: ['', '100'], ratios: [0.25, 0.75] },
+		{ source: ['Infinity', '100'], ratios: [0.25, 0.75] },
+		{ source: ['-1', '100'], ratios: [0.25, 0.75] },
+		{ source: ['0', '0'], ratios: [0.25, 0.75] },
+		{ source: [], ratios: [] },
+	])('leaves an invalid grid or proportions unchanged: $source / $ratios', ({ source, ratios }) => {
+		const tbl: XmlObject = {
+			'a:tblGrid': { 'a:gridCol': source.map((width) => ({ '@_w': width })) },
+		};
+		const original = structuredClone(tbl);
+		writeTableColumnWidths(tbl, ratios);
+		expect(tbl).toStrictEqual(original);
+	});
+});
 
 describe('serializeCellMergeAttributes', () => {
 	it('should set gridSpan when > 1', () => {

--- a/packages/core/src/core/core/runtime/table-column-width-save.ts
+++ b/packages/core/src/core/core/runtime/table-column-width-save.ts
@@ -1,0 +1,49 @@
+import type { XmlObject } from '../../types';
+import { xmlChild, xmlChildren } from '../../utils/xml-access';
+
+/** Update an existing grid in place, retaining its total extent and column metadata. */
+export function writeTableColumnWidths(tbl: XmlObject, columnWidths: readonly number[]): void {
+	const columns = xmlChildren(xmlChild(tbl, 'a:tblGrid'), 'a:gridCol');
+	if (!columns.length || columns.length !== columnWidths.length) {
+		return;
+	}
+	const existingWidths = columns.map((column) => {
+		const value = column['@_w'];
+		return typeof value === 'number' || (typeof value === 'string' && value.trim() !== '')
+			? Number(value)
+			: NaN;
+	});
+	if (existingWidths.some((width) => !Number.isSafeInteger(width) || width < 0)) {
+		return;
+	}
+	const totalWidth = existingWidths.reduce((sum, width) => sum + width, 0);
+	if (!Number.isSafeInteger(totalWidth) || totalWidth <= 0) {
+		return;
+	}
+	if (columnWidths.some((width) => !Number.isFinite(width) || width < 0)) {
+		return;
+	}
+	// The model contains proportions, not arbitrary weights. Do not invent a
+	// normalization policy for invalid input; permit floating-point sum error.
+	const sum = columnWidths.reduce((total, width) => total + width, 0);
+	if (Math.abs(sum - 1) > Number.EPSILON * columnWidths.length * 4) {
+		return;
+	}
+
+	// Round boundaries rather than each width independently so repeated saves
+	// do not grow or shrink the grid by rounding individual column extents.
+	let cumulative = 0;
+	let previousBoundary = 0;
+	for (let index = 0; index < columns.length; index++) {
+		cumulative += columnWidths[index];
+		const boundary =
+			index === columns.length - 1
+				? totalWidth
+				: Math.min(totalWidth, Math.round(cumulative * totalWidth));
+		const width = boundary - previousBoundary;
+		if (width !== existingWidths[index]) {
+			columns[index]['@_w'] = String(width);
+		}
+		previousBoundary = boundary;
+	}
+}


### PR DESCRIPTION
## What does this change?

Preserves edited table column widths when saving a loaded PPTX without changing its row or column count. Previously the UI could show 40%/20%/20%/20%, but saving and reopening restored the original 25% columns.

The same-count serializer updates cells and row heights but omitted `a:gridCol@w`. This adds a small internal writer and one call at that boundary. It changes only width attributes, preserving existing column IDs, extensions and cell XML. Structural edits retain their existing path.

## Type of change

- [x] Bug fix (non-breaking)

## Scope and prior decisions

This is a shared core serialization defect, so React, Vue, Angular, Svelte and Vanilla inherit the fix without binding-specific code. The inspector's requested proportions are already intentional (see `cbd9fc78`); this does not change the editing policy.

Like the existing structural writer, the fix preserves the original grid's total width rather than substituting the graphic frame extent. Integer boundaries are rounded so repeated saves cannot grow or shrink the grid. Unchanged numeric widths retain their authored representation. Invalid inputs are left alone rather than introducing a new arbitrary-weight normalization policy.

The existing large serializer receives only an import and a call; the new implementation is in a 49-line internal helper. No unrelated chart refactor or public API is introduced.

## Testing

- [x] Tests added to existing core test files
- [x] Two regression cases fail before the fix and pass afterward
- [x] 143 focused tests passed across five files, including table creation and structural edits
- [x] Core build and typecheck passed; changed-file lint, formatting and whitespace checks passed
- [x] Independent code review approved; reviewer separately passed 73 tests

Coverage includes width-only edits, resized frames, actual saved XML and reload, a second dirty save/reload, rich runs and fields, IDs/extensions, awkward unchanged integer widths, singleton/zero-width columns, rounding stability and malformed-input no-ops.

Browser validation: edited the real Vue demo's first column from 25% to 40%, serialized through the viewer's public `getContent()` API using a temporary visible QA control, then reopened those exact bytes through normal File > Open. The reopened grid and controls show 40%/20%/20%/20%; saved XML is `[3251200,1625600,1625600,1625600]` EMU. The temporary control is removed and is not part of this PR. The file was also opened in React, Angular, Vanilla and Svelte as rendering controls.

An independent reviewer inspected captured browser output; they did not operate the browser. The in-app testing connection did not return the ordinary download, so a verified original download is not claimed. No new Playwright run, full repository suite, or native PowerPoint validation is claimed for this core-only change.

## Conventional Commits

- [x] Core-scoped Conventional Commit
