### PR TITLE
fix(react): repaint edited table column widths

### DIFF
--- a/packages/react/src/viewer/utils/table-data-parse.test.tsx
+++ b/packages/react/src/viewer/utils/table-data-parse.test.tsx
@@ -1,4 +1,5 @@
-import type { PptxElement } from 'pptx-viewer-core';
+import type { PptxElement, TablePptxElement } from 'pptx-viewer-core';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, it, expect } from 'vitest';
 
 import {
@@ -6,6 +7,89 @@ import {
 	getTableXmlFromElement,
 	parseTableElementData,
 } from './table-data-parse';
+import { renderTableElement } from './table-render';
+
+function loadedTable(columnWidths?: number[]): TablePptxElement {
+	return {
+		id: 'width-table',
+		type: 'table',
+		x: 0,
+		y: 0,
+		width: 400,
+		height: 80,
+		...(columnWidths
+			? { tableData: { columnWidths, rows: [{ cells: [{ text: 'A' }, { text: 'B' }] }] } }
+			: {}),
+		rawXml: {
+			'a:graphic': {
+				'a:graphicData': {
+					'a:tbl': {
+						'a:tblGrid': { 'a:gridCol': [{ '@_w': '3000' }, { '@_w': '7000' }] },
+						'a:tr': {
+							'a:tc': [
+								{ 'a:txBody': { 'a:p': { 'a:r': { 'a:rPr': { '@_b': '1' }, 'a:t': 'A' } } } },
+								{ 'a:txBody': { 'a:p': { 'a:r': { 'a:t': 'B' } } } },
+							],
+						},
+					},
+				},
+			},
+		},
+	} as TablePptxElement;
+}
+
+describe('loaded-table width edits', () => {
+	it.each([
+		[0.25, 0.75],
+		[0, 1],
+		[1 / 3, 2 / 3],
+	])('prefers valid model widths %s', (...widths) => {
+		const element = loadedTable(widths);
+		const original = structuredClone(element);
+		const before = parseTableElementData(loadedTable(), {})!;
+		const parsed = parseTableElementData(element, {})!;
+		expect(parsed.columnPercentages).toStrictEqual(widths.map((width) => width * 100));
+		expect(parsed.cells).toStrictEqual(before.cells);
+		expect(parsed.rows).toStrictEqual(before.rows);
+		expect(element).toStrictEqual(original);
+	});
+
+	it('repaints column widths and resize handles from each current history snapshot', () => {
+		const original = loadedTable([0.3, 0.7]);
+		const edited = { ...original, tableData: { ...original.tableData!, columnWidths: [0.4, 0.6] } };
+		for (const [element, width] of [
+			[original, 30],
+			[edited, 40],
+			[original, 30],
+			[edited, 40],
+		] as const) {
+			const markup = renderToStaticMarkup(renderTableElement(element, {}, { editable: true }));
+			expect(markup).toContain(`<col style="width:${width.toFixed(2)}%"`);
+			expect(markup).toContain(`<col style="width:${(100 - width).toFixed(2)}%"`);
+			expect(markup).toContain(`left:calc(${width}% - 3px)`);
+		}
+		expect(edited.rawXml).toBe(original.rawXml);
+		expect(parseTableElementData(loadedTable(), {})!.columnPercentages).toStrictEqual([30, 70]);
+	});
+
+	it.each([[], [1], [0.2, 0.3, 0.5], [NaN, 0.5], [Infinity, 0], [-0.2, 1.2], [0, 0], [1, 3]])(
+		'falls back to authored widths for invalid model widths %s',
+		(...widths) => {
+			expect(parseTableElementData(loadedTable(widths), {})!.columnPercentages).toStrictEqual([
+				30, 70,
+			]);
+		},
+	);
+
+	it('retains the data-only renderer for tables without raw XML', () => {
+		const element = loadedTable([0.4, 0.6]);
+		delete element.rawXml;
+		expect(parseTableElementData(element, {})).toBeNull();
+		const markup = renderToStaticMarkup(renderTableElement(element, {}, { editable: true }));
+		expect(markup).toContain('width:40.00%');
+		expect(markup).toContain('left:calc(40% - 3px)');
+	});
+});
 
 // ── getGraphicDataFromElement ─────────────────────────────────────────
 

--- a/packages/react/src/viewer/utils/table-data-parse.tsx
+++ b/packages/react/src/viewer/utils/table-data-parse.tsx
@@ -42,8 +42,20 @@ export function parseTableElementData(
 		return Number.isFinite(width) && width > 0 ? width : 0;
 	});
 	const totalColumnWidth = columnWidths.reduce((sum, width) => sum + width, 0);
-	const columnPercentages =
+	let columnPercentages =
 		totalColumnWidth > 0 ? columnWidths.map((width) => (width / totalColumnWidth) * 100) : [];
+	// Width edits live in tableData before save updates raw XML. Both the table
+	// columns and resize handles must use those current proportions together.
+	const modelWidths = element.type === 'table' ? element.tableData?.columnWidths : undefined;
+	if (
+		modelWidths?.length &&
+		modelWidths.length === gridColumns.length &&
+		modelWidths.every((width) => Number.isFinite(width) && width >= 0) &&
+		Math.abs(modelWidths.reduce((sum, width) => sum + width, 0) - 1) <=
+			Number.EPSILON * modelWidths.length * 4
+	) {
+		columnPercentages = modelWidths.map((width) => width * 100);
+	}
 
 	const cells: ParsedTableCell[] = [];
 	rows.forEach((row, rowIndex) => {


### PR DESCRIPTION
## What does this change?

Loaded React tables now repaint edited column widths immediately, including their
resize handles. Previously the inspector and drag handlers updated `tableData`,
but the raw-XML renderer kept showing the file's original grid widths until save.

This is a small render-only follow-up to the requested-percentage behavior in
cbd9fc78. Prefer valid matching model proportions in the existing parser; retain
raw cells, rich formatting and the authored-width fallback. No XML is modified.
File persistence is addressed separately in #247; this fix does not depend on it.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

| Binding | Affected? | Fixed here? | Checks |
| --- | --- | --- | --- |
| React | Yes | Yes | Loaded fixture, AutoSave off: slider, Even, handle drag, Undo/Redo |
| Vue | No | Not needed | Loaded fixture, Even immediately paints equal columns |
| Angular | No | Not needed | Loaded fixture, slider immediately paints updated proportions |
| Svelte | No | Not needed | Loaded fixture, expanded width controls immediately repaint |
| Vanilla | No | Not needed | Loaded fixture, width input immediately repaints |

The other four renderers already use model widths; React alone preferred the
original XML grid in this route. Both React columns and handles consume the same
parser result, so there is no separate geometry implementation.

- [x] Reproduced the bug or confirmed its absence in every binding above
- [x] Every affected binding is fixed here

## Testing

- Four regressions failed before the fix.
- 48 focused tests passed across six existing React test files.
- Independent code review passed; reviewer separately ran 43 tests.
- Tests cover valid, zero and fractional proportions, invalid/count-mismatched
  fallback, raw-cell preservation, data-only rendering, and successive render
  snapshots including both column styles and handle positions.
- Actual React browser Undo/Redo checked for both Even and direct dragging.
- Typecheck, changed-file lint, formatting and whitespace checks passed.

No new test file or E2E spec: this is a narrow existing-renderer fix, covered in
the existing parser/render test file plus the manual browser checks above. The
automated E2E runner and native PowerPoint were not run for this render-only fix.
An independent agent reviewed the saved before/after screenshots; browser
interaction itself was performed by the primary agent.

## Conventional Commits

- [x] Commit follows Conventional Commits
