### PR TITLE
fix(react): preserve embedded fonts in headless saves

### DIFF
--- a/packages/react/src/viewer/hooks/useViewerBuildingBlocks.test.ts
+++ b/packages/react/src/viewer/hooks/useViewerBuildingBlocks.test.ts
@@ -1,3 +1,4 @@
+import JSZip from 'jszip';
 import { PptxHandler } from 'pptx-viewer-core';
 // @vitest-environment happy-dom
 /**
@@ -24,6 +25,7 @@ import type { ViewerBuildingBlocksResult } from './useViewerBuildingBlocks';
 
 let fixtureBytes: Uint8Array;
 let twoSlideFixtureBytes: Uint8Array;
+let embeddedFixtureBytes: Uint8Array;
 
 const { autosaveInputs } = vi.hoisted(() => ({ autosaveInputs: [] as UseAutosaveInput[] }));
 
@@ -43,6 +45,13 @@ beforeAll(async () => {
 		initialSlideCount: 1,
 	});
 	fixtureBytes = await oneSlide.handler.save(oneSlide.data.slides);
+	// Match core's embedded-font-list round-trip fixture: a minimal sfnt header
+	// in a GUID-named part that the loader recognizes as an embedded font.
+	const rawFontData = new Uint8Array(64);
+	rawFontData.set([0, 1, 0, 0]);
+	embeddedFixtureBytes = await oneSlide.handler.save(oneSlide.data.slides, {
+		embeddedFonts: [{ name: 'Sample Font', dataUrl: '', rawFontData, format: 'truetype' }],
+	});
 	oneSlide.handler.dispose();
 
 	const twoSlides = await PptxHandler.create({
@@ -118,6 +127,53 @@ afterEach(() => {
 });
 
 describe('useViewerBuildingBlocks', () => {
+	it('preserves embedded fonts through getContent after switching decks', async () => {
+		const embeddedBytes = embeddedFixtureBytes;
+		const loader = new PptxHandler();
+		const parsed = await loader.load(embeddedBytes.buffer as ArrayBuffer);
+		expect(parsed.embeddedFonts?.map((font) => font.name)).toStrictEqual(['Sample Font']);
+		loader.dispose();
+		const original = await JSZip.loadAsync(embeddedBytes);
+		const fontPaths = Object.keys(original.files).filter((name) => name.endsWith('.fntdata'));
+		expect(fontPaths).toHaveLength(1);
+		const handle = createRef<PowerPointViewerHandle>();
+		async function loadAndSave(content: Uint8Array): Promise<JSZip> {
+			await act(async () => {
+				root.render(React.createElement(Harness, { content, handle }));
+			});
+			await flushUntil(() => latest?.loading === false);
+			expect(latest?.loading).toBeFalsy();
+			expect(latest?.error).toBeNull();
+			let savedBytes: Uint8Array | undefined;
+			await act(async () => {
+				savedBytes = await handle.current?.getContent();
+			});
+			expect(savedBytes).toBeDefined();
+			return JSZip.loadAsync(savedBytes!);
+		}
+		for (const content of [fixtureBytes, embeddedBytes, fixtureBytes, embeddedBytes]) {
+			const saved = await loadAndSave(content);
+			const expectedPaths = content === embeddedBytes ? fontPaths : [];
+			expect(
+				Object.keys(saved.files)
+					.filter((name) => name.endsWith('.fntdata'))
+					.sort(),
+			).toStrictEqual([...expectedPaths].sort());
+			const presentation = await saved.file('ppt/presentation.xml')!.async('string');
+			const relationships = await saved.file('ppt/_rels/presentation.xml.rels')!.async('string');
+			expect(presentation.includes('embeddedFontLst')).toBe(content === embeddedBytes);
+			expect([...relationships.matchAll(/Type="[^"]*\/font"/gu)]).toHaveLength(
+				expectedPaths.length,
+			);
+			for (const fontPath of expectedPaths) {
+				await expect(saved.file(fontPath)!.async('uint8array')).resolves.toStrictEqual(
+					await original.file(fontPath)!.async('uint8array'),
+				);
+				expect(relationships).toContain(`Target="${fontPath.substring(4)}"`);
+			}
+		}
+	}, 30_000);
+
 	it('loads a real PPTX buffer and produces working toolbar/canvas props', async () => {
 		await act(async () => {
 			root.render(React.createElement(Harness, { content: fixtureBytes }));

--- a/packages/react/src/viewer/hooks/useViewerBuildingBlocksState.ts
+++ b/packages/react/src/viewer/hooks/useViewerBuildingBlocksState.ts
@@ -143,6 +143,7 @@ export function useViewerBuildingBlocksState(
 		hasDigitalSignatures: state.hasDigitalSignatures,
 		isDirty: state.isDirty,
 		history,
+		embeddedFontFamilies: state.embeddedFonts.map((font) => font.name),
 	});
 
 	// Load-diagnostic state PowerPointViewer also seeds on every load. This


### PR DESCRIPTION
## What does this change?

Preserves recognized embedded fonts when saving through React's `useViewerBuildingBlocks` and `handle.getContent()`.

The full viewer passes loaded font families to `useViewerDialogs`, which uses them to initialize the existing embedding option. The headless composition omitted that argument, so it selected the no-font default and stripped the fonts on save. This adds the same argument as the full viewer, without changing the default policy or overriding an explicit opt-out.

The existing hook test now loads a recognized embedded-font fixture, saves through the public handle, and checks the font bytes, font list, and relationship. It also switches plain -> embedded -> plain -> embedded decks without remounting. The new regression fails without the production line and passes with it.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

The affected surface is React's alternate headless composition. The full React viewer already supplies the missing argument. Source review of Vue, Angular, Svelte and Vanilla found that their font defaults already use the loaded families; none has this specific omitted React-hook argument. No shared font policy is changed.

| Binding | Scope checked | Result |
| --- | --- | --- |
| React | Headless public-hook regression, serialization controls and manual headless browser flow; full-viewer wiring source review | Headless omission fixed; 8 tests pass |
| Vue | Existing font-save tests and default wiring source review | 2 tests pass; omission not found |
| Angular | Existing font-save/helper tests and default wiring source review | 5 tests pass; omission not found |
| Svelte | Existing font-save tests and default wiring source review | 3 tests pass; omission not found |
| Vanilla | Existing font-save tests and default wiring source review | 2 tests pass; omission not found |

- [x] Every identified affected surface is fixed here.
- Other bindings' source review is not a claim of browser execution in those bindings.

## Testing

- [x] Regression added to the existing hook test file and verified failing before the fix.
- [x] Headless and existing explicit-off serialization tests: 8 passed.
- [x] React typecheck, changed-file lint and formatting checks passed.
- [x] Other bindings' existing font-save/helper controls: 12 tests passed. Angular required its standard `inline-shared` generation step before the tests could import the shared source.
- [x] Manual browser check with a temporary public-hook/custom-toolbar harness: load the recognized-font fixture, invoke `getContent()` through a visible button, and inspect the returned PPTX. The original font-part SHA-256, relationship and font-list entry are preserved.
- [x] Independent code review and separate review of the browser artifact/save evidence.
- [ ] Full automated E2E suite (not run for this focused hook-wiring change).

The generated fixture contains a minimal synthetic sfnt payload, following the existing core round-trip test pattern. This checks font preservation, not glyph rendering. Preservation of font parts that the parser cannot recognize is separate and is not fixed here.

## Conventional Commits

- [x] Commit follows Conventional Commits.
