### PR TITLE
fix(vanilla): cancel SmartArt node edits without committing

### DIFF
--- a/e2e/smartart-insert-edit.spec.ts
+++ b/e2e/smartart-insert-edit.spec.ts
@@ -483,4 +483,84 @@ test.describe('smartart insert and edit', () => {
 		await exerciseDirectKeyboardNodeEdit(page, smartArt, 'Edited fallback node');
 		expect(runtimeErrors).toStrictEqual([]);
 	});
+
+	for (const trigger of ['Enter', 'blur'] as const) {
+		test(`commits an on-canvas node edit once on ${trigger} and can reopen it`, async ({
+			page,
+		}) => {
+			const runtimeErrors = collectRuntimeErrors(page);
+			await loadDeck(page);
+			await switchToInsertTab(page);
+			await insertSmartArtPreset(page);
+			const smartArt = currentSmartArt(page);
+			const original = await renderedNodeText(smartArt);
+			const { editor } = await openFocusedNodeEditor(page, smartArt);
+			await expect(editor).toHaveValue(original);
+			await editor.fill('Committed node text');
+			if (trigger === 'Enter') {
+				await editor.press('Enter');
+			} else {
+				await blurNodeEditor(page);
+			}
+			await expect(editor).toHaveCount(0);
+			await expect.poll(() => renderedNodeText(smartArt)).toBe('Committed node text');
+
+			const { editor: reopened } = await openFocusedNodeEditor(page, smartArt);
+			await expect(reopened).toHaveValue('Committed node text');
+			await reopened.press('Escape');
+			await expect(reopened).toHaveCount(0);
+			await clickHistory(page, 'Undo');
+			await expect.poll(() => renderedNodeText(smartArt)).toBe(original);
+			await clickHistory(page, 'Redo');
+			await expect.poll(() => renderedNodeText(smartArt)).toBe('Committed node text');
+
+			const download = await savePptxViaBackstage(page);
+			const savedPath = await download.path();
+			expect(savedPath).not.toBeNull();
+			await loadDeckFile(page, savedPath!);
+			await expect.poll(() => renderedNodeText(currentSmartArt(page))).toBe('Committed node text');
+			expect(runtimeErrors).toStrictEqual([]);
+		});
+	}
+
+	test('cancels an on-canvas node edit on Escape and can reopen it', async ({ page }) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await loadDeck(page);
+		await switchToInsertTab(page);
+		await insertSmartArtPreset(page);
+		const smartArt = currentSmartArt(page);
+		const original = await renderedNodeText(smartArt);
+		const { editor } = await openFocusedNodeEditor(page, smartArt);
+		await editor.fill('This edit must be cancelled');
+		await editor.press('Escape');
+		await expect(editor).toHaveCount(0);
+		await expect.poll(() => renderedNodeText(smartArt)).toBe(original);
+		const { editor: reopened } = await openFocusedNodeEditor(page, smartArt);
+		await expect(reopened).toHaveValue(original);
+		await reopened.press('Escape');
+		await expect(reopened).toHaveCount(0);
+		expect(runtimeErrors).toStrictEqual([]);
+	});
+
+	test('keeps Shift+Enter as a multiline edit and commits it on blur', async ({ page }) => {
+		const runtimeErrors = collectRuntimeErrors(page);
+		await loadDeck(page);
+		await switchToInsertTab(page);
+		await insertSmartArtPreset(page);
+		const smartArt = currentSmartArt(page);
+		const original = await renderedNodeText(smartArt);
+		const { editor } = await openFocusedNodeEditor(page, smartArt);
+		await editor.fill('Line one');
+		await editor.press('Shift+Enter');
+		await page.keyboard.type('Line two');
+		await expect(editor).toHaveValue('Line one\nLine two');
+		await expect(editor).toBeFocused();
+		await blurNodeEditor(page);
+		await expect
+			.poll(() => renderedNodeText(smartArt).then((text) => text.replace(/\s+/g, '')))
+			.toBe('LineoneLinetwo');
+		await clickHistory(page, 'Undo');
+		await expect.poll(() => renderedNodeText(smartArt)).toBe(original);
+		expect(runtimeErrors).toStrictEqual([]);
+	});
 });

--- a/packages/vanilla/src/viewer/render/elements/smartart-editable.ts
+++ b/packages/vanilla/src/viewer/render/elements/smartart-editable.ts
@@ -35,9 +35,13 @@ export function enableSmartArtEditing(
 	let editor: HTMLTextAreaElement | null = null;
 	let swatches: HTMLDivElement | null = null;
 
-	const closeEditor = (): void => {
-		editor?.remove();
+	const closeEditor = (input = editor): void => {
+		if (!input || input !== editor) {
+			return;
+		}
+		// Settle before removal can synchronously dispatch blur.
 		editor = null;
+		input.remove();
 	};
 
 	chrome.addEventListener('dblclick', (event) => {
@@ -56,7 +60,7 @@ export function enableSmartArtEditing(
 		}
 		closeEditor();
 		swatches?.remove();
-		editor = createEl(chrome.ownerDocument, 'textarea', 'pptxv-smartart-node-editor', {
+		const input = createEl(chrome.ownerDocument, 'textarea', 'pptxv-smartart-node-editor', {
 			position: 'absolute',
 			left: `${rect.left - 4}px`,
 			top: `${rect.top - 4}px`,
@@ -73,28 +77,30 @@ export function enableSmartArtEditing(
 			color: '#111827',
 			textAlign: 'center',
 		});
-		editor.value = findSmartArtNodeText(data, nodeId) ?? '';
+		editor = input;
+		input.value = findSmartArtNodeText(data, nodeId) ?? '';
 		const commit = (): void => {
-			if (!editor) {
+			if (input !== editor) {
 				return;
 			}
-			context.onSmartArtNodeTextChange?.(element, nodeId, editor.value);
-			closeEditor();
+			const value = input.value;
+			closeEditor(input);
+			context.onSmartArtNodeTextChange?.(element, nodeId, value);
 		};
-		editor.addEventListener('blur', commit, { once: true });
-		editor.addEventListener('keydown', (keyEvent) => {
+		input.addEventListener('blur', commit, { once: true });
+		input.addEventListener('keydown', (keyEvent) => {
 			if (keyEvent.key === 'Escape') {
 				keyEvent.preventDefault();
-				closeEditor();
+				closeEditor(input);
 			} else if (keyEvent.key === 'Enter' && !keyEvent.shiftKey) {
 				keyEvent.preventDefault();
 				commit();
 			}
 		});
-		editor.addEventListener('pointerdown', (pointerEvent) => pointerEvent.stopPropagation());
-		chrome.appendChild(editor);
-		editor.focus();
-		editor.select();
+		input.addEventListener('pointerdown', (pointerEvent) => pointerEvent.stopPropagation());
+		chrome.appendChild(input);
+		input.focus();
+		input.select();
 	});
 
 	chrome.addEventListener('mouseover', (event) => {

--- a/packages/vanilla/src/viewer/render/elements/smartart.test.ts
+++ b/packages/vanilla/src/viewer/render/elements/smartart.test.ts
@@ -96,6 +96,28 @@ function nodesOnlyElement(): PptxElement {
 	};
 }
 
+function openSmartArtNodeEditor(node: HTMLElement): HTMLTextAreaElement {
+	const group = node.querySelector<SVGGElement>('[data-smartart-node-id="n1"]')!;
+	Object.assign(group, {
+		getBBox: () => ({ x: 10, y: 20, width: 80, height: 30 }),
+		getCTM: () => ({ a: 2, b: 0, c: 0, d: 2, e: 5, f: 10 }),
+	});
+	group.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+	return node.querySelector<HTMLTextAreaElement>('.pptxv-smartart-node-editor')!;
+}
+
+/** Model the browser's synchronous blur when a focused editor is removed. */
+function blurDuringRemove(editor: HTMLTextAreaElement) {
+	const nativeRemove = editor.remove.bind(editor);
+	const remove = vi.spyOn(editor, 'remove').mockImplementation(() => {
+		if (remove.mock.calls.length === 1) {
+			editor.dispatchEvent(new FocusEvent('blur'));
+		}
+		nativeRemove();
+	});
+	return remove;
+}
+
 /**
  * Flush the mount promise chain: the dynamic `import('pptx-viewer-shared/
  * smartart-3d')` resolves asynchronously (real module graph load, even though
@@ -228,6 +250,166 @@ describe('renderSmartArtElement', () => {
 		editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
 		expect(onSmartArtNodeTextChange).toHaveBeenCalledWith(element, 'n1', 'Changed');
 		expect(node.querySelector('.pptxv-smartart-node-editor')).toBeNull();
+		node.remove();
+	});
+
+	it('commits once on Enter when the host synchronously blurs and rerenders', () => {
+		const element = drawingShapesElement();
+		let node: HTMLElement;
+		const onSmartArtNodeTextChange = vi.fn(() => {
+			if (onSmartArtNodeTextChange.mock.calls.length === 1) {
+				editor.dispatchEvent(new FocusEvent('blur'));
+				const replacement = renderSmartArtElement(
+					element,
+					0,
+					makeContext(false, { onSmartArtNodeTextChange }),
+				) as HTMLElement;
+				node.replaceWith(replacement);
+				node = replacement;
+			}
+		});
+		node = renderSmartArtElement(
+			element,
+			0,
+			makeContext(false, { onSmartArtNodeTextChange }),
+		) as HTMLElement;
+		document.body.appendChild(node);
+		const editor = openSmartArtNodeEditor(node);
+		editor.value = 'Committed once';
+
+		expect(() =>
+			editor.dispatchEvent(
+				new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+			),
+		).not.toThrow();
+		expect(onSmartArtNodeTextChange).toHaveBeenCalledExactlyOnceWith(
+			element,
+			'n1',
+			'Committed once',
+		);
+		expect(node.querySelector('.pptxv-smartart-node-editor')).toBeNull();
+		node.remove();
+	});
+
+	it.each([
+		['drawing-shape', drawingShapesElement],
+		['fallback-layout', nodesOnlyElement],
+	])(
+		'cancels on Escape for the %s renderer when removal synchronously fires blur',
+		(_, makeElement) => {
+			const onSmartArtNodeTextChange = vi.fn();
+			const element = makeElement();
+			const node = renderSmartArtElement(
+				element,
+				0,
+				makeContext(false, { onSmartArtNodeTextChange }),
+			) as HTMLElement;
+			document.body.appendChild(node);
+			const editor = openSmartArtNodeEditor(node);
+			editor.value = 'Discarded';
+			const remove = blurDuringRemove(editor);
+
+			expect(() =>
+				editor.dispatchEvent(
+					new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+				),
+			).not.toThrow();
+			expect(remove).toHaveBeenCalledOnce();
+			expect(onSmartArtNodeTextChange).not.toHaveBeenCalled();
+			expect(node.querySelector('.pptxv-smartart-node-editor')).toBeNull();
+			node.remove();
+		},
+	);
+
+	it('commits once on natural blur', () => {
+		const onSmartArtNodeTextChange = vi.fn();
+		const element = drawingShapesElement();
+		const node = renderSmartArtElement(
+			element,
+			0,
+			makeContext(false, { onSmartArtNodeTextChange }),
+		) as HTMLElement;
+		document.body.appendChild(node);
+		const editor = openSmartArtNodeEditor(node);
+		editor.value = 'Blurred value';
+
+		editor.dispatchEvent(new FocusEvent('blur'));
+
+		expect(onSmartArtNodeTextChange).toHaveBeenCalledExactlyOnceWith(
+			element,
+			'n1',
+			'Blurred value',
+		);
+		expect(node.querySelector('.pptxv-smartart-node-editor')).toBeNull();
+		node.remove();
+	});
+
+	it('ignores stale editor events after reopening and keeps the current editor active', () => {
+		const onSmartArtNodeTextChange = vi.fn();
+		const element = drawingShapesElement();
+		const node = renderSmartArtElement(
+			element,
+			0,
+			makeContext(false, { onSmartArtNodeTextChange }),
+		) as HTMLElement;
+		document.body.appendChild(node);
+		const oldEditor = openSmartArtNodeEditor(node);
+		oldEditor.value = 'Stale value';
+		const oldRemove = blurDuringRemove(oldEditor);
+
+		const currentEditor = openSmartArtNodeEditor(node);
+
+		expect(currentEditor).not.toBe(oldEditor);
+		expect(oldRemove).toHaveBeenCalledOnce();
+		expect(onSmartArtNodeTextChange).not.toHaveBeenCalled();
+		oldEditor.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+		);
+		oldEditor.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+		);
+		oldEditor.dispatchEvent(new FocusEvent('blur'));
+		expect(onSmartArtNodeTextChange).not.toHaveBeenCalled();
+		expect(node.querySelector('.pptxv-smartart-node-editor')).toBe(currentEditor);
+
+		currentEditor.value = 'Current value';
+		currentEditor.dispatchEvent(new FocusEvent('blur'));
+		expect(onSmartArtNodeTextChange).toHaveBeenCalledExactlyOnceWith(
+			element,
+			'n1',
+			'Current value',
+		);
+		expect(node.querySelector('.pptxv-smartart-node-editor')).toBeNull();
+		node.remove();
+	});
+
+	it('keeps Shift+Enter as a multiline edit and commits the full value on Enter', () => {
+		const onSmartArtNodeTextChange = vi.fn();
+		const element = drawingShapesElement();
+		const node = renderSmartArtElement(
+			element,
+			0,
+			makeContext(false, { onSmartArtNodeTextChange }),
+		) as HTMLElement;
+		document.body.appendChild(node);
+		const editor = openSmartArtNodeEditor(node);
+		const shiftEnter = new KeyboardEvent('keydown', {
+			key: 'Enter',
+			shiftKey: true,
+			bubbles: true,
+			cancelable: true,
+		});
+
+		editor.dispatchEvent(shiftEnter);
+
+		expect(shiftEnter.defaultPrevented).toBeFalsy();
+		expect(onSmartArtNodeTextChange).not.toHaveBeenCalled();
+		expect(node.querySelector('.pptxv-smartart-node-editor')).toBe(editor);
+		editor.value = 'First line\nSecond line';
+		editor.dispatchEvent(
+			new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+		);
+		expect(onSmartArtNodeTextChange).toHaveBeenCalledWith(element, 'n1', 'First line\nSecond line');
 		node.remove();
 	});
 


### PR DESCRIPTION
## What does this change?

Fix Vanilla SmartArt node editing so Escape discards the edit, and Enter/blur cannot commit twice during synchronous teardown. Previously, removing the focused textarea could trigger blur while the editor was still active, saving cancelled text and sometimes raising `NotFoundError` or adding duplicate history entries.

Each edit now retains its own textarea identity, clears the active reference before removal, and closes before invoking the host callback. Stale events cannot affect a newer edit. The three-file change preserves the existing keyboard contract, focus/select behavior, geometry, palette and no-drilldown locks; it introduces no public API.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

### Which bindings did you check, and what did you find?

| Binding | Affected? | Fixed here? | Evidence |
| --- | --- | --- | --- |
| React | No | Not needed | Historical neutral lifecycle controls passed |
| Vue | No | Not needed | Historical neutral lifecycle controls passed |
| Angular | No | Not needed | Historical neutral lifecycle controls passed |
| Svelte | No | Not needed | Historical neutral lifecycle controls passed after the separately merged focus fix, #240 |
| Vanilla | Yes | Yes | Before-fix Escape committed discarded text; patched lifecycle controls and regression tests pass |

The defect is Vanilla's imperative textarea removal/blur re-entry. Both cached drawing shapes and computed layouts use the corrected helper. The other bindings use reactive edit state or settled guards. SmartArt geometry dependency #245 is now merged and is not part of this standalone diff.

### UI fix

- [x] Reproduced the bug or confirmed its absence in every binding above, using the historical controls described below.
- [x] Every binding affected by this lifecycle defect is fixed here.

## Testing

- [x] Updated the existing Vanilla `smartart.test.ts` file.
- [x] Added regressions that fail without the fix: removal-triggered blur on Escape in both render paths, synchronous host rerender, and stale editor events. Natural blur and Shift+Enter remain controls.
- [x] Extended the existing framework-neutral `e2e/smartart-insert-edit.spec.ts`.
- [x] Named projects run: React, Angular, Vue, Vanilla and Svelte, with the timing qualification below.

**Current merge candidate, based on `33b03e2d`:** 26/26 focused Vanilla tests pass. Vanilla typecheck, changed-file lint/format, whitespace and E2E framework-neutrality checks pass. The merge preserves the existing geometry and cached-drawing coverage; the cancellation diff remains three files.

**Historical browser validation, based on `6bf15304`:** 45/45 scenarios passed across those five projects, with no skips, failures or flakes. These cover Enter/blur, Escape, reopen, one-step Undo/Redo, Shift+Enter and downloaded-file reload. This run predates integration with #245 and the current-main merge; it is not a fresh full browser run on this candidate.

A later CUA-operated smoke on the geometry-integrated cancellation branch confirmed that Escape retained Alpha without an Undo entry, reopening restored Alpha, Enter committed once, and one Undo/Redo restored the expected text. Screenshots were independently reviewed; browser actions were not independently replayed by that reviewer.

No current full-suite pass is claimed. Historical broad runs recorded an async 3D mount-test failure and two shared encryption-test timeouts; the relevant isolated reruns passed. Those unrelated tests were not changed here.

## Checks run locally

- [x] Targeted `bun run lint` and `bun run fmt:check` for the three changed files
- [x] Vanilla `bun run typecheck`
- [x] Vanilla `bun run test src/viewer/render/elements/smartart.test.ts` (26/26)
- [x] `bun run e2e:contract` and `git diff --check`

## Conventional Commits

- [x] Existing contribution commits follow Conventional Commits.

## Screenshots / recordings

Retained browser observations show the before-fix Escape commit and error, followed by successful cancellation/reopen/history checks after the fix. Static screenshots alone do not establish these lifecycle results. No native PowerPoint, mounted 3D-editor, or nested-node editing claim is made.
