### PR TITLE
fix(shared): apply list commands across viewer bindings

### DIFF
--- a/e2e/ribbon-control-effects.spec.ts
+++ b/e2e/ribbon-control-effects.spec.ts
@@ -26,9 +26,64 @@ import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 
-import { SAMPLE_DECK, inspector, loadDeck, slideElements, slideStage } from './support/deck';
+import {
+	SAMPLE_DECK,
+	fixture,
+	inspector,
+	loadDeck,
+	slideElements,
+	slideStage,
+} from './support/deck';
 
 test.describe.configure({ timeout: 120_000 });
+
+test.describe('paragraph list commands render their edits', () => {
+	for (const [name, marker] of [
+		['Bullet List', '•'],
+		['Numbered List', '1.'],
+	] as const) {
+		test(`${name} toggles a loaded text box and participates in history`, async ({ page }) => {
+			await loadDeck(page, fixture('text-style-emphasis.pptx'));
+			await openRibbonTab(page, 'Home');
+			const id = await slideElements(page)
+				.filter({ hasText: 'Emphasis Bold Target' })
+				.first()
+				.getAttribute('data-element-id');
+			expect(id).toBeTruthy();
+			const target = slideStage(page).locator(`[data-element-id="${id}"]`);
+			const commitTarget = slideElements(page)
+				.filter({ hasText: 'Text Style Emphasis Slide' })
+				.first();
+			await target.click();
+			const list = page.getByRole('button', { name: new RegExp(`^${name}$`, 'iu') }).first();
+			await list.click();
+			await expect(list).toHaveAttribute('aria-pressed', 'true');
+			await commitTarget.click();
+			await expect(target).toContainText(marker);
+			await expect(target).toContainText('Emphasis Bold Target');
+			await page
+				.getByRole('button', { name: /^Undo\b/u })
+				.first()
+				.click();
+			await expect(target).not.toContainText(marker);
+			await page
+				.getByRole('button', { name: /^Redo\b/u })
+				.first()
+				.click();
+			await expect(target).toContainText(marker);
+			await target.click();
+			await list.click();
+			await expect(list).toHaveAttribute('aria-pressed', 'false');
+			await commitTarget.click();
+			await expect(target).not.toContainText(marker);
+			await expect(target).toContainText('Emphasis Bold Target');
+			await target.click();
+			await list.click();
+			await commitTarget.click();
+			await expect(target).toContainText(marker);
+		});
+	}
+});
 
 interface ExportedSlide {
 	transition?: {

--- a/packages/angular/src/viewer/ribbon-content.component.ts
+++ b/packages/angular/src/viewer/ribbon-content.component.ts
@@ -135,6 +135,7 @@ import type { RibbonTab } from './ribbon-types';
 				/>
 				<span class="pptx-rb-sep"></span>
 				<pptx-ribbon-paragraph-controls
+					[canEdit]="canEdit()"
 					[slideIndex]="slideIndex()"
 					[selectedElement]="selectedElement()"
 				/>

--- a/packages/angular/src/viewer/ribbon-home-section.component.ts
+++ b/packages/angular/src/viewer/ribbon-home-section.component.ts
@@ -272,6 +272,7 @@ export function performResetSlide(
 		<div class="flex flex-col items-center gap-0.5">
 			<div class="flex items-center gap-1">
 				<pptx-ribbon-paragraph-controls
+					[canEdit]="canEdit()"
 					[slideIndex]="slideIndex()"
 					[selectedElement]="selectedElement()"
 				/>

--- a/packages/angular/src/viewer/ribbon-paragraph-controls.component.ts
+++ b/packages/angular/src/viewer/ribbon-paragraph-controls.component.ts
@@ -19,6 +19,7 @@ import {
 import { TranslatePipe } from '@ngx-translate/core';
 import type { PptxElement } from 'pptx-viewer-core';
 
+import { elementBulletKind } from '../internal/shared';
 import { EditorStateService } from './editor-state.service';
 import { isTextElement, patchTextStyle, textStyleOf } from './ribbon-text-helpers';
 
@@ -59,8 +60,9 @@ const COLUMN_OPTIONS = [1, 2, 3];
 			<button
 				type="button"
 				class="pptx-rb-gb"
-				[disabled]="!isText()"
-				[ngClass]="curStyle()?.listType === 'bullet' ? 'bg-accent' : ''"
+				[disabled]="!canEdit() || !isText()"
+				[ngClass]="listKind() === 'bullet' ? 'bg-accent' : ''"
+				[attr.aria-pressed]="listKind() === 'bullet'"
 				[title]="'pptx.ribbon.bulletList' | translate"
 				(click)="toggleList('bullet')"
 			>
@@ -69,8 +71,9 @@ const COLUMN_OPTIONS = [1, 2, 3];
 			<button
 				type="button"
 				class="pptx-rb-gl"
-				[disabled]="!isText()"
-				[ngClass]="curStyle()?.listType === 'numbered' ? 'bg-accent' : ''"
+				[disabled]="!canEdit() || !isText()"
+				[ngClass]="listKind() === 'numbered' ? 'bg-accent' : ''"
+				[attr.aria-pressed]="listKind() === 'numbered'"
 				[title]="'pptx.notes.numberedList' | translate"
 				(click)="toggleList('numbered')"
 			>
@@ -183,6 +186,7 @@ export class RibbonParagraphControlsComponent {
 
 	readonly slideIndex = input<number>(0);
 	readonly selectedElement = input<PptxElement | null>(null);
+	readonly canEdit = input<boolean>(false);
 
 	protected readonly lineSpacingOptions = LINE_SPACING_OPTIONS;
 	protected readonly textDirectionOptions = TEXT_DIRECTION_OPTIONS;
@@ -194,6 +198,10 @@ export class RibbonParagraphControlsComponent {
 
 	/** Current text style of the selection (for active-state highlighting). */
 	protected readonly curStyle = computed(() => textStyleOf(this.selectedElement()));
+	protected readonly listKind = computed(() => {
+		const element = this.selectedElement();
+		return element ? elementBulletKind(element) : 'none';
+	});
 
 	/** Current line spacing multiplier. */
 	protected curLineSpacing(): number {
@@ -210,7 +218,10 @@ export class RibbonParagraphControlsComponent {
 
 	/** Toggle the paragraph list style (bullet / numbered) off when already set. */
 	protected toggleList(kind: 'bullet' | 'numbered'): void {
-		this.patch({ listType: this.curStyle()?.listType === kind ? 'none' : kind });
+		if (!this.canEdit()) {
+			return;
+		}
+		this.patch({ listType: this.listKind() === kind ? 'none' : kind });
 	}
 	/** Step the paragraph left-indent by `deltaPx` (clamped at 0). */
 	protected changeIndent(deltaPx: number): void {

--- a/packages/angular/src/viewer/ribbon-text-helpers.test.ts
+++ b/packages/angular/src/viewer/ribbon-text-helpers.test.ts
@@ -1,8 +1,12 @@
+import { Injector, runInInjectionContext, signal } from '@angular/core';
+import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
+import { elementBulletKind } from '../internal/shared';
 import { EditorStateService } from './editor-state.service';
-import { transformSelectedTextCase } from './ribbon-text-helpers';
+import { RibbonParagraphControlsComponent } from './ribbon-paragraph-controls.component';
+import { patchTextStyle, transformSelectedTextCase } from './ribbon-text-helpers';
 
 function textElement(): PptxElement {
 	return {
@@ -27,6 +31,119 @@ function service(el: PptxElement): EditorStateService {
 	svc.setSlides([slide([el])]);
 	return svc;
 }
+
+describe('patchTextStyle list commands', () => {
+	it('guards list buttons in read-only mode even when a text selection remains', () => {
+		class Controls extends RibbonParagraphControlsComponent {
+			applyList(): void {
+				this.toggleList('bullet');
+			}
+		}
+		const original = textElement();
+		const svc = service(original);
+		const controls = runInInjectionContext(
+			Injector.create({ providers: [{ provide: EditorStateService, useValue: svc }] }),
+			() => new Controls(),
+		);
+		const editable = signal(false);
+		Object.defineProperty(controls, 'canEdit', { value: editable });
+		Object.defineProperty(controls, 'selectedElement', { value: signal(original) });
+		controls.applyList();
+		expect(svc.slides()[0].elements[0]).toStrictEqual(original);
+		editable.set(true);
+		controls.applyList();
+		expect(elementBulletKind(svc.slides()[0].elements[0])).toBe('bullet');
+	});
+
+	it('creates markers for plain multiline text without segments', () => {
+		const source = textElement();
+		if (!hasTextProperties(source)) {
+			throw new Error('expected text');
+		}
+		delete source.textSegments;
+		source.text = 'first\nsecond';
+		const svc = service(source);
+		patchTextStyle(svc, 0, source, { listType: 'bullet' });
+		const result = svc.slides()[0].elements[0];
+		if (!hasTextProperties(result)) {
+			throw new Error('expected text');
+		}
+		expect(result.textSegments?.filter((segment) => segment.bulletInfo?.char)).toHaveLength(2);
+		expect(
+			result.textSegments
+				?.filter((segment) => !segment.bulletInfo)
+				.map((segment) => segment.text)
+				.join(''),
+		).toBe('first\nsecond');
+	});
+
+	it.each(['bullet', 'numbered'] as const)('sets %s semantics with one undoable update', (kind) => {
+		const original = textElement();
+		const svc = service(original);
+		patchTextStyle(svc, 0, svc.slides()[0].elements[0], { listType: kind, bold: true });
+		const listed = svc.slides()[0].elements[0];
+		expect(elementBulletKind(listed)).toBe(kind);
+		if (!hasTextProperties(listed)) {
+			throw new Error('expected text');
+		}
+		expect(listed.textSegments?.[0].bulletInfo).toBeDefined();
+		expect(
+			listed.textSegments
+				?.slice(1)
+				.map((segment) => segment.text)
+				.join(''),
+		).toBe('hello world');
+		expect(listed.textStyle?.bold).toBeTruthy();
+		svc.undo();
+		expect(svc.slides()[0].elements[0]).toStrictEqual(original);
+		svc.redo();
+		expect(svc.slides()[0].elements[0]).toStrictEqual(listed);
+		patchTextStyle(svc, 0, listed, { listType: kind });
+		expect(svc.slides()[0].elements[0]).toStrictEqual(listed);
+		patchTextStyle(svc, 0, svc.slides()[0].elements[0], { listType: 'none' });
+		expect(elementBulletKind(svc.slides()[0].elements[0])).toBe('none');
+	});
+
+	it('keeps pending textarea content when creating a list', () => {
+		const editor = document.createElement('textarea');
+		editor.dataset.inlineEditor = '';
+		editor.value = 'hello world, typed more';
+		document.body.appendChild(editor);
+		try {
+			const svc = service(textElement());
+			patchTextStyle(svc, 0, svc.slides()[0].elements[0], { listType: 'bullet' });
+			const result = svc.slides()[0].elements[0];
+			if (!hasTextProperties(result)) {
+				throw new Error('expected text');
+			}
+			expect(result.text).toBe(editor.value);
+			expect(
+				result.textSegments
+					?.slice(1)
+					.map((segment) => segment.text)
+					.join(''),
+			).toBe(editor.value);
+		} finally {
+			editor.remove();
+		}
+	});
+
+	it('ignores absent selections and unsupported tables', () => {
+		const table: PptxElement = {
+			id: 'table',
+			type: 'table',
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 40,
+			tableData: { rows: [{ cells: [{ text: 'cell', style: {} }] }], columnWidths: [1] },
+		};
+		const svc = service(table);
+		patchTextStyle(svc, 0, null, { listType: 'bullet' });
+		patchTextStyle(svc, 0, table, { listType: 'bullet' });
+		expect(svc.slides()[0].elements[0]).toStrictEqual(table);
+	});
+});
 
 describe('transformSelectedTextCase', () => {
 	it('rewrites run text per a change-case mode', () => {

--- a/packages/angular/src/viewer/ribbon-text-helpers.ts
+++ b/packages/angular/src/viewer/ribbon-text-helpers.ts
@@ -7,6 +7,7 @@
 import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, TextStyle } from 'pptx-viewer-core';
 
+import { setElementBullets } from '../internal/shared';
 import { INLINE_EDITOR_SELECTOR } from '../internal/shared-src/render/context-menu-target';
 import { remapTextToSegments } from '../internal/shared-src/render/remap-text';
 import type { ChangeCaseMode } from '../internal/shared-src/render/text-case-transform';
@@ -47,6 +48,30 @@ export function patchTextStyle(
 	patch: Partial<TextStyle>,
 ): void {
 	if (!el || !hasTextProperties(el)) {
+		return;
+	}
+	const { listType, ...stylePatch } = patch;
+	if (listType !== undefined) {
+		const liveText = currentInlineEditorText();
+		const base =
+			liveText === undefined
+				? el
+				: {
+						...el,
+						text: liveText,
+						textSegments: el.textSegments
+							? remapTextToSegments(liveText, el.textSegments, el.textStyle)
+							: undefined,
+					};
+		const listed = { ...base, ...setElementBullets(base, listType) };
+		if (!hasTextProperties(listed)) {
+			return;
+		}
+		editor.updateElement(slideIndex, el.id, {
+			...(liveText !== undefined ? { text: liveText } : {}),
+			textSegments: listed.textSegments,
+			textStyle: { ...listed.textStyle, ...stylePatch },
+		});
 		return;
 	}
 	editor.updateElement(slideIndex, el.id, {

--- a/packages/core/src/core/core/index.ts
+++ b/packages/core/src/core/core/index.ts
@@ -38,6 +38,13 @@ export {
 } from './runtime/table-structural-ops';
 export { DEFAULT_POWERPOINT_TABLE_STYLE_ID } from './runtime/table-style-defaults';
 
+// Use the same list ordinals when authoring in a viewer as when parsing a deck.
+export {
+	createAutoNumberSequence,
+	nextAutoNumber,
+	breakAutoNumberRun,
+} from './runtime/auto-number-sequence';
+
 // Table-STYLE (ppt/tableStyles.xml) editing: create/delete a style entry on
 // a ParsedTableStyleMap, and the section-name vocabulary + GUID normaliser
 // needed to target one of the 13 CT_TableStyle parts (W3-E). Save-time

--- a/packages/react/src/viewer/components/toolbar/TextSection.tsx
+++ b/packages/react/src/viewer/components/toolbar/TextSection.tsx
@@ -2,6 +2,8 @@ import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, PptxThemeColorRef, TextStyle } from 'pptx-viewer-core';
 import {
 	CHARACTER_SPACING_OPTIONS,
+	getInlineEditorSelection,
+	selectedParagraphBulletKind,
 	OFFICE_COLOR_SWATCHES,
 	textFontSizePtToPx,
 } from 'pptx-viewer-shared';
@@ -26,6 +28,7 @@ import { ThemeColorSwatchGrid } from '../inspector/ThemeColorSwatchGrid';
 import { ColumnsDropdown, LineSpacingDropdown, TextDirectionDropdown } from './ParagraphDropdowns';
 import { RibbonMenu } from './RibbonMenu';
 import { gB, gL, grp, FMT, ATXT, pill, ic, sep } from './toolbar-constants';
+import { useParagraphListKind } from './useParagraphListKind';
 
 /**
  * Returns the text style currently in effect for toolbar toggles:
@@ -87,6 +90,15 @@ export function TextSection(p: TextSectionProps): React.ReactElement {
 	// Enable formatting for text elements AND table cells
 	const canFormat = isTextEl || isTable;
 	const effectiveTs = getEffectiveTextStyle(p.selectedElement, p.tableEditorState);
+	const listKind = useParagraphListKind(p.selectedElement);
+	const toggleList = (kind: 'bullet' | 'numbered') => {
+		if (!p.canEdit || !p.selectedElement || !hasTextProperties(p.selectedElement)) {
+			return;
+		}
+		const selection = getInlineEditorSelection(p.selectedElement.textSegments);
+		const current = selectedParagraphBulletKind(p.selectedElement, selection);
+		p.onUpdateTextStyle({ listType: current === kind ? 'none' : kind });
+	};
 
 	const currentColor =
 		isTextEl && p.selectedElement && hasTextProperties(p.selectedElement)
@@ -565,35 +577,23 @@ export function TextSection(p: TextSectionProps): React.ReactElement {
 					<div className={grp}>
 						<button
 							type='button'
-							disabled={!canMut}
+							disabled={!canMut || !isTextEl}
 							onMouseDown={(e) => e.preventDefault()}
-							onClick={() => {
-								if (!canFormat || !p.selectedElement) {
-									return;
-								}
-								p.onUpdateTextStyle({
-									listType: effectiveTs?.listType === 'bullet' ? 'none' : 'bullet',
-								});
-							}}
+							onClick={() => toggleList('bullet')}
 							className={gB}
 							title={t('pptx.text.bulletList')}
+							aria-pressed={listKind === 'bullet'}
 						>
 							<LuList className={ic} />
 						</button>
 						<button
 							type='button'
-							disabled={!canMut}
+							disabled={!canMut || !isTextEl}
 							onMouseDown={(e) => e.preventDefault()}
-							onClick={() => {
-								if (!canFormat || !p.selectedElement) {
-									return;
-								}
-								p.onUpdateTextStyle({
-									listType: effectiveTs?.listType === 'numbered' ? 'none' : 'numbered',
-								});
-							}}
+							onClick={() => toggleList('numbered')}
 							className={gL}
 							title={t('pptx.text.numberedList')}
+							aria-pressed={listKind === 'numbered'}
 						>
 							<LuListOrdered className={ic} />
 						</button>

--- a/packages/react/src/viewer/components/toolbar/ribbon-accessible-names.test.tsx
+++ b/packages/react/src/viewer/components/toolbar/ribbon-accessible-names.test.tsx
@@ -1,5 +1,8 @@
+// @vitest-environment happy-dom
+import type { PptxElement } from 'pptx-viewer-core';
 import { keyToLabel, translationsEn } from 'pptx-viewer-shared/i18n';
-import React from 'react';
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
 /**
  * Ribbon controls that are addressable by an accessible NAME.
  *
@@ -35,10 +38,124 @@ vi.mock<typeof import('react-i18next')>(import('react-i18next'), () => ({
 const { HomeSection } = await import('./HomeSection');
 const { AnimationsSection } = await import('./AnimationsSection');
 const { HelpSection } = await import('./HelpSection');
+const { TextSection } = await import('./TextSection');
 
 function render(el: React.ReactElement): string {
 	return renderToStaticMarkup(el);
 }
+
+describe('list command state', () => {
+	const renderLists = (selectedElement: PptxElement | null, canEdit = true): string =>
+		render(
+			React.createElement(TextSection, {
+				selectedElement,
+				canEdit,
+				onUpdateTextStyle: vi.fn(),
+				onTransformTextCase: vi.fn(),
+			}),
+		);
+	const button = (html: string, name: string): string =>
+		html.match(new RegExp(`<button[^>]*title="${name}"[^>]*>`))?.[0] ?? '';
+	const listed: PptxElement = {
+		type: 'text',
+		id: 'text',
+		x: 0,
+		y: 0,
+		width: 100,
+		height: 80,
+		textSegments: [
+			{ text: '◆ ', style: {}, bulletInfo: { char: '◆' } },
+			{ text: 'Item', style: {} },
+		],
+	};
+
+	it('announces loaded semantic bullets without a legacy listType flag', () => {
+		const html = renderLists(listed);
+		expect(button(html, 'Bullet List')).toContain('aria-pressed="true"');
+		expect(button(html, 'Numbered List')).toContain('aria-pressed="false"');
+	});
+
+	it('disables list commands for missing selection, read-only mode and table cells', () => {
+		for (const html of [
+			renderLists(null),
+			renderLists(listed, false),
+			renderLists({ type: 'table', id: 'table', x: 0, y: 0, width: 100, height: 80 }),
+		]) {
+			expect(button(html, 'Bullet List')).toContain('disabled=""');
+			expect(button(html, 'Numbered List')).toContain('disabled=""');
+		}
+	});
+
+	it('tracks real selection changes and uses the selected paragraph for state and click intent', async () => {
+		const mixed: PptxElement = {
+			...listed,
+			textSegments: [
+				{ text: 'Plain', style: {} },
+				{ text: '\n', style: {}, isParagraphBreak: true },
+				{ text: '◆ ', style: {}, bulletInfo: { char: '◆' } },
+				{ text: 'Listed', style: {} },
+			],
+		};
+		const target = document.createElement('div');
+		const editor = document.createElement('div');
+		editor.dataset.inlineEditor = '';
+		editor.innerHTML =
+			'<span data-seg-idx="0">Plain</span><span data-seg-idx="1">\n</span><span data-seg-idx="2">◆ </span><span data-seg-idx="3">Listed</span>';
+		document.body.append(target, editor);
+		const root = createRoot(target);
+		const update = vi.fn();
+		const draw = async (element: PptxElement | null, canEdit = true) => {
+			await act(async () =>
+				root.render(
+					React.createElement(TextSection, {
+						selectedElement: element,
+						canEdit,
+						onUpdateTextStyle: update,
+						onTransformTextCase: vi.fn(),
+					}),
+				),
+			);
+		};
+		const select = async (index: number) => {
+			const node = editor.querySelector(`[data-seg-idx="${index}"]`)!.firstChild!;
+			const range = document.createRange();
+			range.setStart(node, 0);
+			range.setEnd(node, 2);
+			await act(async () => {
+				window.getSelection()!.removeAllRanges();
+				window.getSelection()!.addRange(range);
+				document.dispatchEvent(new Event('selectionchange'));
+			});
+		};
+		try {
+			await draw(mixed);
+			const bullet = target.querySelector<HTMLButtonElement>('button[title="Bullet List"]')!;
+			expect(bullet.getAttribute('aria-pressed')).toBe('false');
+			await select(3);
+			expect(bullet.getAttribute('aria-pressed')).toBe('true');
+			await act(async () => bullet.click());
+			expect(update).toHaveBeenLastCalledWith({ listType: 'none' });
+			await select(0);
+			expect(bullet.getAttribute('aria-pressed')).toBe('false');
+			await act(async () => bullet.click());
+			expect(update).toHaveBeenLastCalledWith({ listType: 'bullet' });
+			update.mockClear();
+			await draw(mixed, false);
+			await select(3);
+			expect(bullet.disabled).toBeTruthy();
+			await act(async () => bullet.click());
+			expect(update).not.toHaveBeenCalled();
+			await draw(null);
+			expect(bullet.disabled).toBeTruthy();
+			expect(bullet.getAttribute('aria-pressed')).toBe('false');
+		} finally {
+			await act(async () => root.unmount());
+			window.getSelection()?.removeAllRanges();
+			target.remove();
+			editor.remove();
+		}
+	});
+});
 
 describe('home tab font controls', () => {
 	const html = render(

--- a/packages/react/src/viewer/components/toolbar/useParagraphListKind.ts
+++ b/packages/react/src/viewer/components/toolbar/useParagraphListKind.ts
@@ -1,0 +1,26 @@
+import type { PptxElement } from 'pptx-viewer-core';
+import { hasTextProperties } from 'pptx-viewer-core';
+import {
+	elementBulletKind,
+	getInlineEditorSelection,
+	selectedParagraphBulletKind,
+} from 'pptx-viewer-shared';
+import type { ParagraphBulletKind } from 'pptx-viewer-shared';
+import { useCallback, useSyncExternalStore } from 'react';
+
+function subscribe(onChange: () => void): () => void {
+	document.addEventListener('selectionchange', onChange);
+	return () => document.removeEventListener('selectionchange', onChange);
+}
+
+/** Match list-button state to the same paragraph scope used by its command. */
+export function useParagraphListKind(element: PptxElement | null): ParagraphBulletKind {
+	const read = useCallback(() => {
+		if (!element || !hasTextProperties(element)) {
+			return 'none' as const;
+		}
+		return selectedParagraphBulletKind(element, getInlineEditorSelection(element.textSegments));
+	}, [element]);
+	const readServer = useCallback(() => (element ? elementBulletKind(element) : 'none'), [element]);
+	return useSyncExternalStore(subscribe, read, readServer);
+}

--- a/packages/react/src/viewer/hooks/useElementOperations.inline-edit-race.test.tsx
+++ b/packages/react/src/viewer/hooks/useElementOperations.inline-edit-race.test.tsx
@@ -18,6 +18,7 @@
  * LIVE `inlineEditingText`, not the stale model segments.
  */
 import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
+import { buildParagraphs, elementBulletKind } from 'pptx-viewer-shared';
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
@@ -104,6 +105,39 @@ function mount(inlineEditingElementId: string | null, inlineEditingText: string)
 }
 
 describe('updateSelectedTextStyle mid-edit race', () => {
+	it('authors real bullets and keeps a repeated explicit setter on', () => {
+		const harness = mount(null, '');
+		for (let call = 0; call < 2; call++) {
+			act(() => harness.ops().updateSelectedTextStyle({ listType: 'bullet' }));
+			const element = harness.slides()[0].elements[0];
+			expect(elementBulletKind(element)).toBe('bullet');
+			expect(buildParagraphs(element)[0].bulletMarker).toBe('•');
+			expect(
+				buildParagraphs(element)[0]
+					.runs.map((run) => run.text)
+					.join(''),
+			).toBe('Hello');
+		}
+		act(() => harness.ops().updateSelectedTextStyle({ listType: 'none' }));
+		expect(elementBulletKind(harness.slides()[0].elements[0])).toBe('none');
+	});
+
+	it('lists the current typed paragraphs and applies accompanying character formatting', () => {
+		const harness = mount('shape-1', 'Hello there\nNext item');
+		act(() => harness.ops().updateSelectedTextStyle({ listType: 'numbered', bold: true }));
+		const element = harness.slides()[0].elements[0];
+		const paragraphs = buildParagraphs(element);
+		expect(paragraphs.map((paragraph) => paragraph.bulletMarker)).toStrictEqual(['1.', '2.']);
+		expect(
+			paragraphs.map((paragraph) => paragraph.runs.map((run) => run.text).join('')),
+		).toStrictEqual(['Hello there', 'Next item']);
+		expect(
+			paragraphs
+				.flatMap((paragraph) => paragraph.runs)
+				.every((run) => run.style.fontWeight === 'bold'),
+		).toBeTruthy();
+	});
+
 	it('applies to the live typed text, not the stale model segments, while inline-editing', () => {
 		const harness = mount('shape-1', 'Hello there, world');
 		act(() => {

--- a/packages/react/src/viewer/hooks/useElementOperations.ts
+++ b/packages/react/src/viewer/hooks/useElementOperations.ts
@@ -10,6 +10,7 @@ import type {
 	TextStyle,
 } from 'pptx-viewer-core';
 import {
+	applyListStyleUpdate,
 	masterViewElements as resolveMasterViewElements,
 	remapTextToSegments,
 	replaceMasterViewElements,
@@ -274,6 +275,19 @@ export function useElementOperations(input: UseElementOperationsInput): ElementO
 
 			// Check if there's an active text selection in the inline editor
 			const inlineSel = getInlineEditorSelection(currentSegments);
+			if (updates.listType) {
+				const result = applyListStyleUpdate(
+					{ ...selectedElement, textSegments: currentSegments },
+					updates,
+					inlineSel,
+				);
+				setPendingSelectionRestore(result.selection);
+				updateSelectedElement({
+					...result.patch,
+					...(isLiveEditing ? { text: inlineEditingText } : {}),
+				});
+				return;
+			}
 			if (inlineSel && currentSegments) {
 				// Apply formatting only to the selected segment range
 				const { newSegments, newSelection } = applyStyleToSelectedSegments(

--- a/packages/react/src/viewer/utils/inline-selection-utils.test.ts
+++ b/packages/react/src/viewer/utils/inline-selection-utils.test.ts
@@ -1,5 +1,10 @@
 // @vitest-environment happy-dom
-import type { TextSegment, TextStyle } from 'pptx-viewer-core';
+import type { PptxElement, TextSegment, TextStyle } from 'pptx-viewer-core';
+import {
+	applyListStyleUpdate,
+	buildParagraphs,
+	selectedParagraphBulletKind,
+} from 'pptx-viewer-shared';
 import { describe, it, expect } from 'vitest';
 
 import { applyStyleToSelectedSegments, getInlineEditorSelection } from './inline-selection-utils';
@@ -12,6 +17,137 @@ function seg(text: string, style: Partial<TextStyle> = {}): TextSegment {
 function paraBrk(style: Partial<TextStyle> = {}): TextSegment {
 	return { text: '\n', style: style as TextStyle, isParagraphBreak: true };
 }
+
+describe('paragraph lists with an inline character selection', () => {
+	const element = (textSegments: TextSegment[]): PptxElement => ({
+		type: 'text',
+		id: 'list',
+		x: 0,
+		y: 0,
+		width: 200,
+		height: 100,
+		textSegments,
+		textStyle: { fontSize: 18 },
+	});
+
+	it('changes only the selected paragraph and keeps its selected characters', () => {
+		const source = element([seg('AAA'), paraBrk(), seg('BBB'), paraBrk(), seg('CCC')]);
+		const result = applyListStyleUpdate(
+			source,
+			{ listType: 'bullet' },
+			{
+				startSegIdx: 2,
+				startOffset: 1,
+				endSegIdx: 2,
+				endOffset: 2,
+			},
+		);
+		const next = { ...source, ...result.patch } as PptxElement;
+		expect(buildParagraphs(next).map((paragraph) => paragraph.bulletMarker)).toStrictEqual([
+			undefined,
+			'•',
+			undefined,
+		]);
+		expect(result.selection).toStrictEqual({
+			startSegIdx: 3,
+			startOffset: 1,
+			endSegIdx: 3,
+			endOffset: 2,
+		});
+		expect(selectedParagraphBulletKind(next, result.selection)).toBe('bullet');
+		const off = applyListStyleUpdate(next, { listType: 'none' }, result.selection);
+		expect(off.selection).toStrictEqual({
+			startSegIdx: 2,
+			startOffset: 1,
+			endSegIdx: 2,
+			endOffset: 2,
+		});
+	});
+
+	it('does not include the next paragraph when selection ends at its start', () => {
+		const source = element([seg('AAA'), paraBrk(), seg('BBB'), paraBrk(), seg('CCC')]);
+		const result = applyListStyleUpdate(
+			source,
+			{ listType: 'numbered' },
+			{
+				startSegIdx: 0,
+				startOffset: 1,
+				endSegIdx: 4,
+				endOffset: 0,
+			},
+		);
+		expect(
+			buildParagraphs({ ...source, ...result.patch } as PptxElement).map(
+				(paragraph) => paragraph.bulletMarker,
+			),
+		).toStrictEqual(['1.', '2.', undefined]);
+	});
+
+	it('includes a selected separator-only blank paragraph before the end boundary', () => {
+		const source = element([seg('A'), paraBrk(), paraBrk(), seg('C')]);
+		const result = applyListStyleUpdate(
+			source,
+			{ listType: 'bullet' },
+			{
+				startSegIdx: 0,
+				startOffset: 0,
+				endSegIdx: 3,
+				endOffset: 0,
+			},
+		);
+		const segments = result.patch.textSegments as TextSegment[];
+		const paragraphs: TextSegment[][] = [[]];
+		for (const segment of segments) {
+			if (segment.isParagraphBreak) {
+				paragraphs.push([]);
+			} else {
+				paragraphs[paragraphs.length - 1].push(segment);
+			}
+		}
+		expect(paragraphs.map((paragraph) => paragraph[0]?.bulletInfo?.char)).toStrictEqual([
+			'•',
+			'•',
+			undefined,
+		]);
+	});
+
+	it('retains paragraph spacing while accompanying bold affects only selected characters', () => {
+		const source = element([
+			{
+				...seg('Hello'),
+				paragraphProperties: { paragraphSpacingBefore: 6, paragraphSpacingAfter: 12 },
+				paragraphLevel: 1,
+			},
+		]);
+		const result = applyListStyleUpdate(
+			source,
+			{ listType: 'bullet', bold: true },
+			{
+				startSegIdx: 0,
+				startOffset: 1,
+				endSegIdx: 0,
+				endOffset: 4,
+			},
+		);
+		const segments = (result.patch as { textSegments: TextSegment[] }).textSegments;
+		expect(segments[0].paragraphProperties).toStrictEqual({
+			paragraphSpacingBefore: 6,
+			paragraphSpacingAfter: 12,
+		});
+		expect(segments[0].paragraphLevel).toBe(1);
+		expect(segments.slice(1).map((run) => [run.text, Boolean(run.style.bold)])).toStrictEqual([
+			['H', false],
+			['ell', true],
+			['o', false],
+		]);
+		expect(result.selection).toStrictEqual({
+			startSegIdx: 2,
+			startOffset: 0,
+			endSegIdx: 2,
+			endOffset: 3,
+		});
+	});
+});
 
 describe('applyStyleToSelectedSegments', () => {
 	it('should apply style to a single fully-selected segment', () => {

--- a/packages/shared/src/render/bullet-toggle.test.ts
+++ b/packages/shared/src/render/bullet-toggle.test.ts
@@ -4,6 +4,8 @@
  * `TextStyle.listType` every binding used to write.
  */
 
+import JSZip from 'jszip';
+import { PptxHandler } from 'pptx-viewer-core';
 import type { PptxElement, TextSegment } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
@@ -104,7 +106,7 @@ describe('toggleParagraphBullet', () => {
 		const next = toggleParagraphBullet(loadedBullet('Item'), 'none');
 		expect(next).toHaveLength(1);
 		expect(next[0].text).toBe('Item');
-		expect(next[0].bulletInfo).toStrictEqual({ none: true });
+		expect(next[0].bulletInfo).toStrictEqual({ char: '•', none: true });
 		expect(paragraphBulletKind(next)).toBe('none');
 	});
 
@@ -128,6 +130,250 @@ describe('toggleParagraphBullet', () => {
 });
 
 describe('setElementBullets / toggleElementBullets', () => {
+	it('keeps same-kind marker styling and authored percentage/body size through live off/on', async () => {
+		const paragraphProperties = {
+			paragraphSpacingBefore: 6,
+			paragraphSpacingAfter: 14,
+			lineSpacing: 1.25,
+		};
+		const seed = {
+			...textElement([
+				seg('Item', {
+					style: { fontSize: 22 },
+					bulletInfo: { char: '◆', sizePercent: 75 },
+					paragraphProperties,
+				}),
+			]),
+			textStyle: { fontSize: 22 },
+		};
+		const { handler, data } = await PptxHandler.create({ initialSlideCount: 1 });
+		const bytes = await handler.save([{ ...data.slides[0], elements: [seed], isDirty: true }]);
+		const loaded = await new PptxHandler().load(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+		);
+		const el = loaded.slides[0].elements[0];
+		const before = buildParagraphs(el)[0].bulletStyle.fontSize;
+		const on = { ...el, ...setElementBullets(el, 'bullet') } as PptxElement;
+		expect(buildParagraphs(on)[0].bulletStyle.fontSize).toBe(before);
+		const off = { ...on, ...setElementBullets(on, 'none') } as PptxElement;
+		const back = { ...off, ...setElementBullets(off, 'bullet') } as PptxElement;
+		expect((back as { textSegments: TextSegment[] }).textSegments[0].bulletInfo?.sizePercent).toBe(
+			75,
+		);
+		expect(
+			buildParagraphs(back)[0]
+				.runs.filter((run) => run.text)
+				.map((run) => [run.text, run.style.fontSize]),
+		).toStrictEqual([['Item', '22px']]);
+		expect(
+			(back as { textSegments: TextSegment[] }).textSegments[0].paragraphProperties,
+		).toStrictEqual(paragraphProperties);
+	});
+
+	it('preserves an authored glyph and formatting across explicit set and live off/on', () => {
+		const info = { char: '»', fontFamily: 'Wingdings', sizePercent: 80, color: '#AABBCC' };
+		const el = textElement([seg('» ', { bulletInfo: info }), seg('Item')]);
+		const on = { ...el, ...setElementBullets(el, 'bullet') } as PptxElement;
+		expect(buildParagraphs(on)[0].bulletMarker).toBe('»');
+		const off = { ...on, ...setElementBullets(on, 'none') } as PptxElement;
+		const back = { ...off, ...setElementBullets(off, 'bullet') } as PptxElement;
+		expect((back as { textSegments: TextSegment[] }).textSegments[0].bulletInfo).toStrictEqual(
+			info,
+		);
+		expect(setElementBullets(back, 'bullet')).toStrictEqual(setElementBullets(on, 'bullet'));
+	});
+
+	it('does not remove literal numbered text without a runtime marker index', () => {
+		const para = [seg('1.', { bulletInfo: { autoNumType: 'arabicPeriod' } }), seg(' Item')];
+		expect(toggleParagraphBullet(para, 'none').map((s) => s.text)).toStrictEqual(['1.', ' Item']);
+	});
+
+	it('removes only the leading synthetic marker, not marker-like later content', () => {
+		const para = [...loadedBullet('Item'), seg('• ', { bulletInfo: { char: '•' } })];
+		expect(toggleParagraphBullet(para, 'none').map((s) => s.text)).toStrictEqual(['Item', '• ']);
+	});
+
+	it('recognizes a suppressed marker without losing its authored glyph', () => {
+		const para = [
+			seg('» ', { bulletInfo: { char: '»' }, style: { listType: 'none' } }),
+			seg('Item'),
+		];
+		expect(toggleParagraphBullet(para, 'bullet').map((s) => s.text)).toStrictEqual(['» ', 'Item']);
+	});
+
+	it('retains picture bullets and removes their loaded display placeholder on disable', () => {
+		const info = {
+			imageRelId: 'rId7',
+			imageDataUrl: 'data:image/png;base64,AA==',
+			imageBlipFillXml: { 'a:blip': { '@_r:embed': 'rId7' }, 'a:stretch': {} },
+		};
+		const para = [seg('📎 ', { bulletInfo: info }), seg('Item')];
+		const on = toggleParagraphBullet(para, 'bullet');
+		expect(on[0].bulletInfo).toStrictEqual(info);
+		expect(on.map((s) => s.text)).toStrictEqual(['Item']);
+		expect(buildParagraphs(textElement(on))[0].runs.map((run) => run.text)).toStrictEqual(['Item']);
+		expect(toggleParagraphBullet(on, 'none').map((s) => s.text)).toStrictEqual(['Item']);
+	});
+
+	it('turns off a marker-only paragraph while retaining its paragraph metadata', () => {
+		const para = [
+			seg('• ', {
+				bulletInfo: { char: '•' },
+				paragraphLevel: 2,
+				paragraphProperties: { paragraphSpacingAfter: 12 },
+			}),
+		];
+		const next = toggleParagraphBullet(para, 'none');
+		expect(next[0].text).toBe('');
+		expect(next[0].bulletInfo?.none).toBeTruthy();
+		expect(next[0].paragraphLevel).toBe(2);
+		expect(next[0].paragraphProperties).toStrictEqual({ paragraphSpacingAfter: 12 });
+	});
+
+	it('uses the core per-level numbering sequence instead of a flat ordinal', () => {
+		const el = textElement([
+			seg('A', { paragraphLevel: 0 }),
+			brk(),
+			seg('B', { paragraphLevel: 1 }),
+			brk(),
+			seg('C', { paragraphLevel: 1 }),
+			brk(),
+			seg('D', { paragraphLevel: 0 }),
+		]);
+		const next = { ...el, ...setElementBullets(el, 'numbered') } as PptxElement;
+		expect(buildParagraphs(next).map((p) => p.bulletMarker)).toStrictEqual([
+			'1.',
+			'1.',
+			'2.',
+			'2.',
+		]);
+	});
+
+	it('preserves a numbered list scheme and custom start on explicit set', () => {
+		const el = textElement([
+			seg('IV.', {
+				bulletInfo: { autoNumType: 'romanUcPeriod', autoNumStartAt: 4, paragraphIndex: 0 },
+			}),
+			seg('Item'),
+		]);
+		const next = { ...el, ...setElementBullets(el, 'numbered') } as PptxElement;
+		expect(buildParagraphs(next)[0].bulletMarker).toBe('IV.');
+	});
+
+	it('does not add text properties to a non-text element', () => {
+		expect(setElementBullets({ type: 'image', id: 'i' } as PptxElement, 'bullet')).toStrictEqual(
+			{},
+		);
+	});
+
+	it('only changes requested paragraphs but updates downstream derived numbering', () => {
+		const plain = textElement([seg('A'), brk(), seg('B'), brk(), seg('C')]);
+		const numbered = { ...plain, ...setElementBullets(plain, 'numbered') } as PptxElement;
+		const off = {
+			...numbered,
+			...setElementBullets(numbered, 'none', { startParagraph: 1, endParagraph: 1 }),
+		} as PptxElement;
+		expect(buildParagraphs(off).map((p) => p.bulletMarker)).toStrictEqual(['1.', undefined, '1.']);
+		const on = {
+			...off,
+			...setElementBullets(off, 'numbered', { startParagraph: 1, endParagraph: 1 }),
+		} as PptxElement;
+		expect(buildParagraphs(on).map((p) => p.bulletMarker)).toStrictEqual(['1.', '2.', '3.']);
+		expect(buildParagraphs(on).map((p) => p.runs.map((r) => r.text).join(''))).toStrictEqual([
+			'A',
+			'B',
+			'C',
+		]);
+	});
+
+	it('keeps unselected paragraph properties and run identity for ordinary bullet edits', () => {
+		const before = seg('Untouched', { paragraphProperties: { paragraphSpacingBefore: 8 } });
+		const after = seg('Also untouched');
+		const el = textElement([before, brk(), seg('Edit'), brk(), after]);
+		const patch = setElementBullets(el, 'bullet', { startParagraph: 1, endParagraph: 1 }) as {
+			textSegments: TextSegment[];
+		};
+		expect(patch.textSegments[0]).toBe(before);
+		expect(patch.textSegments.at(-1)).toBe(after);
+		expect(
+			buildParagraphs({ ...el, ...patch } as PptxElement).map((p) => p.bulletMarker),
+		).toStrictEqual([undefined, '•', undefined]);
+	});
+
+	it('retains soft breaks, empty paragraphs and separator-carried geometry', () => {
+		const empty = {
+			...brk(),
+			paragraphLevel: 2,
+			paragraphProperties: { paragraphSpacingAfter: 10 },
+		};
+		const el = textElement([
+			seg('First'),
+			seg('\n', { isLineBreak: true }),
+			seg('line'),
+			brk(),
+			empty,
+			seg('Last'),
+			brk(),
+		]);
+		const patch = setElementBullets(el, 'bullet') as { textSegments: TextSegment[] };
+		expect(patch.textSegments.filter((s) => s.isParagraphBreak)).toHaveLength(3);
+		expect(patch.textSegments.filter((s) => s.isLineBreak)).toHaveLength(1);
+		const carrier = patch.textSegments.find((s) => s.text === '• ' && s.paragraphLevel === 2);
+		expect(carrier?.paragraphProperties).toStrictEqual({ paragraphSpacingAfter: 10 });
+		expect(patch.textSegments.filter((s) => s.text === '• ')).toHaveLength(4);
+	});
+
+	it('does not mutate source runs or their bullet definitions', () => {
+		const info = Object.freeze({ char: '»', sizePercent: 80 });
+		const marker = Object.freeze(seg('» ', { bulletInfo: info }));
+		const body = Object.freeze(seg('Item'));
+		const el = textElement([marker, body]);
+		setElementBullets(el, 'none');
+		expect(marker.bulletInfo).toBe(info);
+		expect(info).toStrictEqual({ char: '»', sizePercent: 80 });
+	});
+
+	it('writes native custom bullets and buNone without display glyphs in saved body text', async () => {
+		const { handler, data } = await PptxHandler.create({ initialSlideCount: 1 });
+		const el = textElement([
+			seg('» ', {
+				bulletInfo: { char: '»', fontFamily: 'Arial', sizePercent: 90 },
+				paragraphProperties: { paragraphSpacingAfter: 12 },
+			}),
+			seg('Item'),
+		]);
+		let current = { ...el, ...setElementBullets(el, 'bullet') } as PptxElement;
+		async function saveAndReload(): Promise<{ xml: string; element: PptxElement }> {
+			const bytes = await handler.save([{ ...data.slides[0], isDirty: true, elements: [current] }]);
+			const zip = await JSZip.loadAsync(bytes);
+			const xml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+			const loaded = await new PptxHandler().load(
+				bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+			);
+			return {
+				xml,
+				element:
+					loaded.slides[0].elements.find((candidate) => candidate.id === 't1') ??
+					loaded.slides[0].elements[0],
+			};
+		}
+		const on = await saveAndReload();
+		expect(on.xml).toContain('<a:buChar char="»"');
+		expect(on.xml).toContain('<a:t>Item</a:t>');
+		expect(on.xml).not.toContain('<a:t>»');
+		expect(buildParagraphs(on.element)[0].bulletMarker).toBe('»');
+		current = { ...current, ...setElementBullets(current, 'none') } as PptxElement;
+		const off = await saveAndReload();
+		expect(off.xml).toContain('<a:buNone');
+		expect(off.xml).not.toContain('<a:buChar');
+		expect(buildParagraphs(off.element)[0].bulletMarker).toBeUndefined();
+		expect(
+			buildParagraphs(off.element)[0]
+				.runs.map((r) => r.text)
+				.join(''),
+		).toBe('Item');
+	});
+
 	it('numbers every paragraph consecutively and clears the element listType', () => {
 		const el = textElement([seg('A'), brk(), seg('B'), brk(), seg('C')], 'none');
 		const patch = setElementBullets(el, 'numbered');

--- a/packages/shared/src/render/bullet-toggle.ts
+++ b/packages/shared/src/render/bullet-toggle.ts
@@ -1,176 +1,179 @@
 /**
- * Bullet / numbered-list toggling for the ribbon's paragraph buttons.
- *
- * The renderer (`resolveParagraphBullet`) and the save writer
- * (`applyBulletProperties`) both read a paragraph's list state from the
- * `bulletInfo` of its FIRST segment; `TextStyle.listType` is consulted for
- * nothing but the `'none'` suppression. Every binding's Bullets / Numbering
- * button used to write `listType: 'bullet' | 'numbered'` onto the element's
- * `textStyle`, a field nothing downstream reads, so the buttons were dead.
- *
- * These helpers author the real thing: a `BulletInfo` on each paragraph's
- * first segment (`a:buChar` / `a:buAutoNum` / `a:buNone` on save), with the
- * inert `listType` cleared so a stale `'none'` cannot suppress the new marker.
- *
- * On load core prefixes a display-only marker segment (text "• " / "1.") to a
- * listed paragraph; the renderer drops it when its text matches the marker it
- * would draw, and the save writer drops it because the paragraph properties
- * already express it. Switching a bullet to a number (or off) would leave the
- * old glyph behind as literal text, so the previous marker is removed and a
- * fresh one authored in the same shape core uses.
+ * List commands author first-segment bulletInfo, which render and save consume.
+ * Bindings apply these patches through their existing update/history operations.
  */
-
 import type { BulletInfo, PptxElement, TextSegment, TextStyle } from 'pptx-viewer-core';
-import { hasTextProperties } from 'pptx-viewer-core';
+import {
+	breakAutoNumberRun,
+	createAutoNumberSequence,
+	hasTextProperties,
+	nextAutoNumber,
+} from 'pptx-viewer-core';
 
 import { formatAutoNumber } from './bullet-autonum';
 import { resolveParagraphBullet } from './bullet-list';
+import { isParagraphSeparatorSegment } from './text-segment-paragraph-break';
 
-/** The list state of a paragraph as the ribbon buttons see it. */
 export type ParagraphBulletKind = 'bullet' | 'numbered' | 'none';
-
-/** The default character bullet PowerPoint inserts (`a:buChar char="•"`). */
 export const DEFAULT_BULLET_CHAR = '•';
-
-/** The default numbering scheme PowerPoint inserts (`a:buAutoNum type="arabicPeriod"`). */
 export const DEFAULT_AUTONUM_TYPE = 'arabicPeriod';
 
-/**
- * The `BulletInfo` that authors `kind`.
- *
- * @param ordinal - Zero-based position of the paragraph within its numbered
- *   run, published as `paragraphIndex` so the renderer counts "1. 2. 3." (see
- *   `BulletInfo.paragraphIndex`). Ignored for the other kinds.
- */
-export function bulletInfoForKind(kind: ParagraphBulletKind, ordinal: number = 0): BulletInfo {
-	switch (kind) {
-		case 'bullet':
-			return { char: DEFAULT_BULLET_CHAR };
-		case 'numbered':
-			return { autoNumType: DEFAULT_AUTONUM_TYPE, autoNumStartAt: 1, paragraphIndex: ordinal };
-		case 'none':
-			return { none: true };
+export function bulletInfoForKind(kind: ParagraphBulletKind, ordinal = 0): BulletInfo {
+	if (kind === 'none') {
+		return { none: true };
 	}
+	if (kind === 'bullet') {
+		return { char: DEFAULT_BULLET_CHAR };
+	}
+	return { autoNumType: DEFAULT_AUTONUM_TYPE, autoNumStartAt: 1, paragraphIndex: ordinal };
 }
 
-/**
- * Whether a segment is the display-only marker core inserts on load (mirrors
- * the save writer's `isRenderedBulletMarker`): it carries `bulletInfo` and its
- * text is exactly the glyph the renderer would draw for that info.
- */
+/** Matches core's synthetic prefix, including picture and suppressed markers. */
 export function isBulletMarkerSegment(segment: TextSegment): boolean {
-	const bullet = segment.bulletInfo;
-	if (!bullet || bullet.none) {
+	const info = segment.bulletInfo;
+	if (!info || info.none || segment.fieldType || segment.isLineBreak) {
 		return false;
 	}
-	const resolved = resolveParagraphBullet(segment);
-	if (!resolved) {
+	if (
+		!info.char &&
+		!info.autoNumType &&
+		!info.imageRelId &&
+		!info.imageDataUrl &&
+		!info.imageBlipFillXml
+	) {
 		return false;
 	}
-	return segment.text.trim() === resolved.marker.trim() && segment.text.trim().length > 0;
+	if (info.autoNumType) {
+		// Without this runtime field, a literal "1." is authored content (PR 204).
+		if (info.paragraphIndex === undefined) {
+			return false;
+		}
+		const marker = markerText(info);
+		return segment.text === marker || segment.text === `${marker} `;
+	}
+	return segment.text === markerText(info);
 }
 
-/**
- * The current list state of one paragraph (its segments, separators excluded),
- * derived from the resolved bullet of its first segment so an inherited
- * (master / layout) bullet that core resolved on load counts as `'bullet'`.
- */
 export function paragraphBulletKind(paragraph: readonly TextSegment[]): ParagraphBulletKind {
 	const resolved = resolveParagraphBullet(paragraph[0]);
-	if (!resolved) {
-		return 'none';
-	}
-	return resolved.isNumbered ? 'numbered' : 'bullet';
+	return resolved ? (resolved.isNumbered ? 'numbered' : 'bullet') : 'none';
 }
 
-/** Copy of `style` without the inert `listType` flag. */
 function withoutListType(style: TextStyle | undefined): TextStyle {
-	const next: TextStyle = { ...(style ?? {}) };
+	const next = { ...style };
 	delete next.listType;
 	return next;
 }
 
-/**
- * The paragraph-level fields that ride a paragraph's FIRST segment (the save
- * writer captures them from that segment only), so they must move with
- * whichever segment ends up first.
- */
-type ParagraphMeta = Pick<
-	TextSegment,
-	'paragraphLevel' | 'paragraphProperties' | 'endParaRunProperties'
->;
-
-function paragraphMeta(segment: TextSegment | undefined): ParagraphMeta {
-	const meta: ParagraphMeta = {};
-	if (segment?.paragraphLevel !== undefined) {
-		meta.paragraphLevel = segment.paragraphLevel;
-	}
-	if (segment?.paragraphProperties !== undefined) {
-		meta.paragraphProperties = segment.paragraphProperties;
-	}
-	if (segment?.endParaRunProperties !== undefined) {
-		meta.endParaRunProperties = segment.endParaRunProperties;
-	}
-	return meta;
-}
-
-/** The display text of the marker segment for a bullet / numbered `info`. */
 function markerText(info: BulletInfo): string {
-	if (info.char) {
-		return `${info.char} `;
+	if (info.imageRelId || info.imageDataUrl || info.imageBlipFillXml) {
+		return '📎 ';
 	}
-	const ordinal = (info.autoNumStartAt ?? 1) + (info.paragraphIndex ?? 0);
-	return formatAutoNumber(info.autoNumType ?? DEFAULT_AUTONUM_TYPE, ordinal);
+	if (info.autoNumType) {
+		return formatAutoNumber(
+			info.autoNumType,
+			Math.max(1, (info.autoNumStartAt ?? 1) + (info.paragraphIndex ?? 0)),
+		);
+	}
+	return `${info.char ?? DEFAULT_BULLET_CHAR} `;
 }
 
-/**
- * Set one paragraph's list state to `kind`, returning the paragraph's new
- * segments.
- *
- * The result uses the same shape core produces on load, so the renderer and
- * the save writer treat an authored list exactly like a parsed one: for
- * `'bullet'` / `'numbered'` a display-only marker segment carrying the new
- * `bulletInfo` (and the paragraph-level fields) is placed first, followed by
- * the content runs with any previous marker removed; for `'none'` the marker
- * is dropped and the first content segment carries `{ none: true }`. The
- * inert `style.listType` is cleared on the touched segments. An empty
- * paragraph is returned unchanged since there is no run to carry the state.
- *
- * @param ordinal - Zero-based position within a numbered run; see
- *   {@link bulletInfoForKind}.
- */
+function infoForParagraph(
+	previous: BulletInfo | undefined,
+	kind: ParagraphBulletKind,
+	ordinal?: number,
+): BulletInfo {
+	if (kind === 'none') {
+		return { ...previous, none: true };
+	}
+	const sameKind =
+		previous &&
+		(kind === 'numbered'
+			? Boolean(previous.autoNumType)
+			: Boolean(
+					previous.char ||
+					previous.imageRelId ||
+					previous.imageDataUrl ||
+					previous.imageBlipFillXml,
+				) && !previous.autoNumType);
+	const info = sameKind ? { ...previous } : bulletInfoForKind(kind, ordinal);
+	delete info.none;
+	if (kind === 'numbered' && ordinal !== undefined) {
+		info.paragraphIndex = ordinal;
+	}
+	return info;
+}
+
+/** Explicit set, despite the historical name. Only the leading marker is removed. */
 export function toggleParagraphBullet(
 	paragraph: readonly TextSegment[],
 	kind: ParagraphBulletKind,
-	ordinal: number = 0,
+	ordinal?: number,
 ): TextSegment[] {
-	const content = paragraph.filter((segment) => !isBulletMarkerSegment(segment));
-	const first = content[0];
-	if (!first) {
-		return [...paragraph];
+	const source = paragraph[0];
+	if (!source) {
+		return [];
 	}
-	const meta = paragraphMeta(paragraph[0]);
-	const info = bulletInfoForKind(kind, ordinal);
-	const rest = content.slice(1);
-	if (kind === 'none') {
-		return [{ ...first, ...meta, style: withoutListType(first.style), bulletInfo: info }, ...rest];
-	}
-	const marker: TextSegment = {
-		text: markerText(info),
-		style: withoutListType(first.style),
-		...meta,
-		bulletInfo: info,
+	const content = isBulletMarkerSegment(source) ? paragraph.slice(1) : [...paragraph];
+	const first = content[0] ?? { text: '', style: source.style };
+	const meta = {
+		...(source.paragraphLevel !== undefined ? { paragraphLevel: source.paragraphLevel } : {}),
+		...(source.paragraphProperties ? { paragraphProperties: source.paragraphProperties } : {}),
+		...(source.endParaRunProperties ? { endParaRunProperties: source.endParaRunProperties } : {}),
 	};
-	const body: TextSegment = { ...first, style: withoutListType(first.style) };
+	const info = infoForParagraph(source.bulletInfo, kind, ordinal);
+	const body = { ...first, ...meta, style: withoutListType(first.style) };
+	const rest = content.slice(1).map((segment) => {
+		if (!segment.bulletInfo) {
+			return segment;
+		}
+		const run = { ...segment };
+		delete run.bulletInfo;
+		return run;
+	});
+	// Picture markers render separately; never insert their textual fallback as body.
+	if (kind === 'none' || info.imageRelId || info.imageDataUrl || info.imageBlipFillXml) {
+		return [{ ...body, bulletInfo: info }, ...rest];
+	}
 	delete body.bulletInfo;
-	return [marker, body, ...rest];
+	const markerStyle =
+		isBulletMarkerSegment(source) && paragraphBulletKind([source]) === kind
+			? source.style
+			: first.style;
+	return [
+		{ text: markerText(info), style: withoutListType(markerStyle), ...meta, bulletInfo: info },
+		body,
+		...rest,
+	];
 }
 
-function isParagraphSeparator(segment: TextSegment): boolean {
-	return Boolean(segment.isParagraphBreak) || (segment.text === '\n' && !segment.isLineBreak);
+/** Inclusive paragraph indices; omitted means the entire text element. */
+export interface BulletParagraphRange {
+	startParagraph: number;
+	endParagraph: number;
 }
 
-/** Split a segment list into paragraphs, keeping each paragraph's terminator. */
+/** Only text properties change; unsupported elements return an empty patch. */
+export interface ElementBulletPatch {
+	textSegments?: TextSegment[];
+	textStyle?: TextStyle;
+}
+
+function elementSegments(element: PptxElement): TextSegment[] {
+	if (!hasTextProperties(element)) {
+		return [];
+	}
+	if (element.textSegments?.length) {
+		return element.textSegments;
+	}
+	return (element.text ?? '')
+		.split('\n')
+		.flatMap((text, index) => [
+			...(index ? [{ text: '\n', style: { ...element.textStyle }, isParagraphBreak: true }] : []),
+			{ text, style: { ...element.textStyle } },
+		]);
+}
+
 function splitParagraphs(
 	segments: readonly TextSegment[],
 ): Array<{ segments: TextSegment[]; terminator?: TextSegment }> {
@@ -178,42 +181,20 @@ function splitParagraphs(
 		{ segments: [] },
 	];
 	for (const segment of segments) {
-		if (isParagraphSeparator(segment)) {
+		if (isParagraphSeparatorSegment(segment)) {
 			paragraphs[paragraphs.length - 1].terminator = segment;
 			paragraphs.push({ segments: [] });
-			continue;
+		} else {
+			paragraphs[paragraphs.length - 1].segments.push(segment);
 		}
-		paragraphs[paragraphs.length - 1].segments.push(segment);
 	}
 	return paragraphs;
 }
 
-/** The element's segments, synthesised from `text` when it carries none. */
-function elementSegments(element: PptxElement): TextSegment[] {
-	if (!hasTextProperties(element)) {
-		return [];
-	}
-	if (element.textSegments && element.textSegments.length > 0) {
-		return element.textSegments;
-	}
-	const style: TextStyle = { ...(element.textStyle ?? {}) };
-	const segments: TextSegment[] = [];
-	for (const [index, line] of (element.text ?? '').split('\n').entries()) {
-		if (index > 0) {
-			segments.push({ text: '\n', style: { ...style }, isParagraphBreak: true });
-		}
-		segments.push({ text: line, style: { ...style } });
-	}
-	return segments;
-}
-
-/**
- * The list state an element's ribbon buttons should show: the kind of its
- * first non-empty paragraph, since that is what a toggle would act on.
- */
+/** Existing element-wide toggle convention: use its first nonempty paragraph. */
 export function elementBulletKind(element: PptxElement): ParagraphBulletKind {
 	for (const paragraph of splitParagraphs(elementSegments(element))) {
-		if (paragraph.segments.length > 0) {
+		if (paragraph.segments.length) {
 			return paragraphBulletKind(paragraph.segments);
 		}
 	}
@@ -221,39 +202,75 @@ export function elementBulletKind(element: PptxElement): ParagraphBulletKind {
 }
 
 /**
- * Set every paragraph of an element to `kind`, returning the element patch
- * (`textSegments` rewritten; `textStyle.listType` cleared so the element-level
- * flag can no longer suppress or lie about the state). Numbered paragraphs are
- * counted consecutively so the renderer shows "1. 2. 3.".
+ * Explicitly set the touched paragraphs. Existing same-kind definitions survive;
+ * defaults are only for new lists. Retained buNone metadata supports live off/on,
+ * not restoration of a deleted definition after a save/reload.
  */
 export function setElementBullets(
 	element: PptxElement,
 	kind: ParagraphBulletKind,
-): Partial<PptxElement> {
-	const textStyle = withoutListType(hasTextProperties(element) ? element.textStyle : undefined);
+	range?: BulletParagraphRange,
+): ElementBulletPatch {
+	if (!hasTextProperties(element)) {
+		return {};
+	}
+	if (
+		range &&
+		(!Number.isInteger(range.startParagraph) ||
+			!Number.isInteger(range.endParagraph) ||
+			range.startParagraph < 0 ||
+			range.endParagraph < range.startParagraph)
+	) {
+		return {};
+	}
+	const paragraphs = splitParagraphs(elementSegments(element));
+	if (range && range.startParagraph >= paragraphs.length) {
+		return {};
+	}
 	const next: TextSegment[] = [];
-	let ordinal = 0;
-	for (const paragraph of splitParagraphs(elementSegments(element))) {
-		if (paragraph.segments.length > 0) {
-			next.push(...toggleParagraphBullet(paragraph.segments, kind, ordinal));
-			ordinal += 1;
+	const sequence = createAutoNumberSequence();
+	for (const [index, paragraph] of paragraphs.entries()) {
+		const selected = !range || (index >= range.startParagraph && index <= range.endParagraph);
+		let segments = paragraph.segments;
+		if (selected) {
+			const empty = {
+				...paragraph.terminator,
+				text: '',
+				style: { ...paragraph.terminator?.style },
+			};
+			delete empty.isParagraphBreak;
+			delete empty.isLineBreak;
+			segments = toggleParagraphBullet(segments.length ? segments : [empty], kind);
 		}
+		const first = segments[0] ?? paragraph.terminator;
+		const info = first?.bulletInfo;
+		const level = first?.paragraphLevel ?? 0;
+		if (info?.autoNumType && paragraphBulletKind(segments) === 'numbered') {
+			const startAt = info.autoNumStartAt ?? 1;
+			const ordinal = nextAutoNumber(sequence, level, info.autoNumType, startAt) - startAt;
+			// List membership changes also renumber following items. Only this
+			// derived ordinal changes outside the selected paragraphs.
+			if (info.paragraphIndex !== ordinal) {
+				segments = toggleParagraphBullet(segments, 'numbered', ordinal);
+			}
+		} else {
+			breakAutoNumberRun(sequence, level);
+		}
+		next.push(...segments);
 		if (paragraph.terminator) {
 			next.push(paragraph.terminator);
 		}
 	}
-	return { textSegments: next, textStyle } as Partial<PptxElement>;
+	return {
+		textSegments: next,
+		textStyle: withoutListType(element.textStyle),
+	};
 }
 
-/**
- * The ribbon button behaviour: pressing Bullets (or Numbering) on an element
- * already in that state turns its lists off, otherwise it applies that kind
- * to every paragraph. Returns the element patch to apply through the
- * binding's update-element operation.
- */
+/** Button intent, unlike the explicit style setter above. */
 export function toggleElementBullets(
 	element: PptxElement,
 	kind: Exclude<ParagraphBulletKind, 'none'>,
-): Partial<PptxElement> {
+): ElementBulletPatch {
 	return setElementBullets(element, elementBulletKind(element) === kind ? 'none' : kind);
 }

--- a/packages/shared/src/render/index.ts
+++ b/packages/shared/src/render/index.ts
@@ -573,6 +573,7 @@ export * from './bullet-autonum';
 export * from './bullet-list';
 // Ribbon Bullets / Numbering toggle: authors real `bulletInfo`, not `listType`.
 export * from './bullet-toggle';
+export * from './text-list-style-update';
 // Rich speaker-notes editor: segment/paragraph maths, contentEditable HTML
 // serialise/parse, caret-aware toolbar commands, and the print-notes document
 // builder. The view layer (contentEditable + textarea fallback) stays per

--- a/packages/shared/src/render/text-list-style-update.ts
+++ b/packages/shared/src/render/text-list-style-update.ts
@@ -1,0 +1,169 @@
+import type { PptxElement, TextSegment, TextStyle } from 'pptx-viewer-core';
+import { hasTextProperties } from 'pptx-viewer-core';
+
+import {
+	elementBulletKind,
+	isBulletMarkerSegment,
+	paragraphBulletKind,
+	setElementBullets,
+} from './bullet-toggle';
+import type { ParagraphBulletKind } from './bullet-toggle';
+import { applyStyleToSelectedSegments } from './inline-selection-utils';
+import type { InlineTextSelection } from './inline-selection-utils';
+import { isParagraphSeparatorSegment as isParagraphBreak } from './text-segment-paragraph-break';
+
+/** Body offsets ignore only the leading display marker of each paragraph. */
+function positions(segments: readonly TextSegment[]): Array<{
+	start: number;
+	end: number;
+	paragraph: number;
+	editable: boolean;
+}> {
+	let offset = 0;
+	let paragraph = 0;
+	let first = true;
+	return segments.map((segment) => {
+		const marker = first && isBulletMarkerSegment(segment);
+		const start = offset;
+		if (!marker) {
+			offset += segment.text.length;
+		}
+		const entry = {
+			start,
+			end: offset,
+			paragraph,
+			editable: !marker && !isParagraphBreak(segment),
+		};
+		first = isParagraphBreak(segment);
+		if (first) {
+			paragraph += 1;
+		}
+		return entry;
+	});
+}
+
+function restorePoint(
+	segments: readonly TextSegment[],
+	offset: number,
+	end: boolean,
+): { index: number; offset: number } {
+	const entries = positions(segments);
+	let fallback = { index: 0, offset: 0 };
+	for (const [index, entry] of entries.entries()) {
+		if (!entry.editable) {
+			continue;
+		}
+		fallback = { index, offset: segments[index].text.length };
+		if (end ? offset <= entry.end : offset < entry.end) {
+			return { index, offset: Math.max(0, offset - entry.start) };
+		}
+	}
+	return fallback;
+}
+
+/** Keep paragraph metadata on the first run when character styling splits it. */
+function restoreParagraphMetadata(original: TextSegment[], updated: TextSegment[]): TextSegment[] {
+	const firstRuns = original.filter(
+		(_, index) => index === 0 || isParagraphBreak(original[index - 1]),
+	);
+	let paragraph = 0;
+	return updated.map((segment, index) => {
+		const first = index === 0 || isParagraphBreak(updated[index - 1]);
+		if (!first) {
+			return segment;
+		}
+		const source = firstRuns[paragraph++];
+		if (!source) {
+			return segment;
+		}
+		return {
+			...segment,
+			bulletInfo: source.bulletInfo,
+			paragraphLevel: source.paragraphLevel,
+			paragraphProperties: source.paragraphProperties,
+			endParaRunProperties: source.endParaRunProperties,
+		};
+	});
+}
+
+/** Current kind at the first selected paragraph; otherwise the element default. */
+export function selectedParagraphBulletKind(
+	element: PptxElement,
+	selection: InlineTextSelection | null,
+): ParagraphBulletKind {
+	if (!selection || !hasTextProperties(element) || !element.textSegments) {
+		return elementBulletKind(element);
+	}
+	let first = selection.startSegIdx;
+	while (first > 0 && !isParagraphBreak(element.textSegments[first - 1])) {
+		first -= 1;
+	}
+	return paragraphBulletKind(element.textSegments.slice(first));
+}
+
+/**
+ * Apply a list request to touched paragraphs, while accompanying character
+ * styles retain their existing selection scope. A null selection means the
+ * whole element, matching the existing editor contract.
+ */
+export function applyListStyleUpdate(
+	element: PptxElement,
+	updates: Partial<TextStyle>,
+	selection: InlineTextSelection | null,
+): { patch: Partial<PptxElement>; selection: InlineTextSelection | null } {
+	if (!hasTextProperties(element) || !updates.listType) {
+		return { patch: {}, selection };
+	}
+	const { listType, ...characterStyle } = updates;
+	let segments = element.textSegments;
+	let workingSelection = selection;
+	if (segments && Object.keys(characterStyle).length > 0) {
+		if (selection) {
+			const styled = applyStyleToSelectedSegments(segments, selection, characterStyle);
+			segments = restoreParagraphMetadata(segments, styled.newSegments);
+			workingSelection = styled.newSelection;
+		} else {
+			segments = segments.map((segment) => ({
+				...segment,
+				style: { ...segment.style, ...characterStyle },
+			}));
+		}
+	}
+	const working = {
+		...element,
+		textSegments: segments,
+		textStyle: selection ? element.textStyle : { ...element.textStyle, ...characterStyle },
+	};
+	if (!workingSelection || !segments) {
+		return { patch: setElementBullets(working, listType), selection: null };
+	}
+	const entries = positions(segments);
+	const startEntry = entries[workingSelection.startSegIdx];
+	const endEntry = entries[workingSelection.endSegIdx];
+	if (!startEntry || !endEntry) {
+		return { patch: {}, selection: null };
+	}
+	const startOffset = startEntry.start + workingSelection.startOffset;
+	const endOffset = endEntry.start + workingSelection.endOffset;
+	const lastSelected = [...entries].reverse().find((entry) => entry.start < endOffset);
+	const patch = setElementBullets(working, listType, {
+		startParagraph: startEntry.paragraph,
+		endParagraph: lastSelected?.paragraph ?? endEntry.paragraph,
+	});
+	const next = { ...working, ...patch };
+	const nextSegments = hasTextProperties(next) ? next.textSegments : undefined;
+	if (!nextSegments) {
+		return { patch, selection: null };
+	}
+	const start = restorePoint(nextSegments, startOffset, false);
+	const end = restorePoint(nextSegments, endOffset, true);
+	return {
+		patch,
+		selection: {
+			startSegIdx: start.index,
+			startOffset: start.offset,
+			endSegIdx: end.index,
+			endOffset: end.offset,
+		},
+	};
+}

--- a/packages/svelte/src/viewer/components/ribbon/home/ParagraphGroup.svelte
+++ b/packages/svelte/src/viewer/components/ribbon/home/ParagraphGroup.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 	/**
 	 * ParagraphGroup: bullet / numbered list, indent, alignment, and line
-	 * spacing for the Home tab's Paragraph group. Reads/writes the element's
-	 * `textStyle` (the base every paragraph inherits from), matching
-	 * `editor-paragraph-mutations.ts`'s convention. Disabled whenever the
-	 * selection has no text properties.
+	 * spacing for the Home tab's Paragraph group. List state comes from semantic
+	 * paragraph bullets; other formatting uses the element's base text style.
 	 */
 	import type { PptxElement, TextStyle } from 'pptx-viewer-core';
 	import { hasTextProperties } from 'pptx-viewer-core';
-	import { LINE_SPACING_OPTIONS } from 'pptx-viewer-shared';
+	import { elementBulletKind, LINE_SPACING_OPTIONS } from 'pptx-viewer-shared';
 
 	import { useTranslator } from '../../../../i18n/context';
 	import type { EditorState } from '../../../editor/editor-state.svelte';
@@ -23,8 +21,9 @@
 	const t = useTranslator();
 
 	const el = $derived(editor.selectedElement);
-	const active = $derived(el !== undefined && hasTextProperties(el));
+	const active = $derived(editor.editable && el !== undefined && hasTextProperties(el));
 	const style = $derived<TextStyle>(el && hasTextProperties(el) ? (el.textStyle ?? {}) : {});
+	const listKind = $derived(el && hasTextProperties(el) ? elementBulletKind(el) : 'none');
 
 	function apply(patch: Partial<PptxElement>): void {
 		editor.patchSelected(patch);
@@ -42,9 +41,9 @@
 	<button
 		type="button"
 		class="pptx-svelte-para-btn"
-		class:pptx-svelte-para-on={style.listType === 'bullet'}
+		class:pptx-svelte-para-on={listKind === 'bullet'}
 		disabled={!active}
-		aria-pressed={style.listType === 'bullet'}
+		aria-pressed={listKind === 'bullet'}
 		aria-label={t('pptx.text.bulletList')}
 		title={t('pptx.text.bulletList')}
 		onclick={() => el && apply(toggleListTypePatch(el, 'bullet'))}
@@ -54,9 +53,9 @@
 	<button
 		type="button"
 		class="pptx-svelte-para-btn"
-		class:pptx-svelte-para-on={style.listType === 'numbered'}
+		class:pptx-svelte-para-on={listKind === 'numbered'}
 		disabled={!active}
-		aria-pressed={style.listType === 'numbered'}
+		aria-pressed={listKind === 'numbered'}
 		aria-label={t('pptx.text.numberedList')}
 		title={t('pptx.text.numberedList')}
 		onclick={() => el && apply(toggleListTypePatch(el, 'numbered'))}

--- a/packages/svelte/src/viewer/editor/editor-paragraph-mutations.test.ts
+++ b/packages/svelte/src/viewer/editor/editor-paragraph-mutations.test.ts
@@ -1,5 +1,6 @@
 import type { PptxElement } from 'pptx-viewer-core';
-import { describe, expect, it } from 'vitest';
+import { buildParagraphs, elementBulletKind } from 'pptx-viewer-shared';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import {
 	adjustIndentPatch,
@@ -23,19 +24,58 @@ function textEl(textStyle: PptxElement['textStyle'] = {}): PptxElement {
 }
 
 describe('editor-paragraph-mutations toggleListTypePatch', () => {
-	it('turns bullet on from none', () => {
-		const patch = toggleListTypePatch(textEl(), 'bullet');
-		expect(patch.textStyle?.listType).toBe('bullet');
+	afterEach(() => {
+		document.body.innerHTML = '';
 	});
 
-	it('turns the same list type back off', () => {
-		const patch = toggleListTypePatch(textEl({ listType: 'bullet' }), 'bullet');
-		expect(patch.textStyle?.listType).toBe('none');
+	it('renders a bullet on, off, and on without changing the body', () => {
+		let el = textEl();
+		for (const marker of ['•', undefined, '•']) {
+			el = { ...el, ...toggleListTypePatch(el, 'bullet') } as PptxElement;
+			const paragraphs = buildParagraphs(el);
+			expect(paragraphs[0].bulletMarker).toBe(marker);
+			expect(paragraphs[0].runs.map((run) => run.text).join('')).toBe('hi');
+			expect(elementBulletKind(el)).toBe(marker ? 'bullet' : 'none');
+		}
 	});
 
-	it('switches from bullet to numbered', () => {
-		const patch = toggleListTypePatch(textEl({ listType: 'bullet' }), 'numbered');
-		expect(patch.textStyle?.listType).toBe('numbered');
+	it('switches a loaded semantic bullet to rendered numbering', () => {
+		const el = {
+			...textEl(),
+			textSegments: [
+				{ text: '» ', style: {}, bulletInfo: { char: '»' } },
+				{ text: 'hi', style: { bold: true } },
+			],
+		} as PptxElement;
+		const next = { ...el, ...toggleListTypePatch(el, 'numbered') } as PptxElement;
+		expect(buildParagraphs(next)[0].bulletMarker).toBe('1.');
+		expect(
+			buildParagraphs(next)[0]
+				.runs.map((run) => run.text)
+				.join(''),
+		).toBe('hi');
+		expect(elementBulletKind(next)).toBe('numbered');
+	});
+
+	it('reconciles pending inline text before adding semantic bullets', () => {
+		const surface = document.createElement('div');
+		surface.dataset.inlineEditor = '';
+		surface.textContent = 'pending body';
+		document.body.append(surface);
+		const el = textEl();
+		const next = { ...el, ...toggleListTypePatch(el, 'bullet') } as PptxElement;
+		expect('text' in next && next.text).toBe('pending body');
+		expect(
+			buildParagraphs(next)[0]
+				.runs.map((run) => run.text)
+				.join(''),
+		).toBe('pending body');
+		expect(buildParagraphs(next)[0].bulletMarker).toBe('•');
+	});
+
+	it('does not add text to unsupported elements', () => {
+		const table = { type: 'table', id: 't', x: 0, y: 0, width: 1, height: 1 } as PptxElement;
+		expect(toggleListTypePatch(table, 'bullet')).toStrictEqual({});
 	});
 });
 

--- a/packages/svelte/src/viewer/editor/editor-paragraph-mutations.ts
+++ b/packages/svelte/src/viewer/editor/editor-paragraph-mutations.ts
@@ -1,11 +1,12 @@
 import type { PptxElement, TextStyle } from 'pptx-viewer-core';
 import { hasTextProperties } from 'pptx-viewer-core';
+import { readEditableText, remapTextToSegments, toggleElementBullets } from 'pptx-viewer-shared';
 
 /**
- * Pure paragraph-level patch builders for the Home tab's Paragraph group:
- * bullet/numbered list, indent, alignment, and line spacing. Formatting is
- * applied at the element `textStyle` level (the base every run/paragraph
- * inherits from), matching the convention in `editor-format-mutations.ts`.
+ * Paragraph-level patch builders for the Home tab's Paragraph group:
+ * bullet/numbered list, indent, alignment, and line spacing.
+ * Lists author semantic paragraph bullets; other formatting uses the element
+ * `textStyle` base, matching `editor-format-mutations.ts`.
  */
 
 /** Indent step (px) applied per increase/decrease-indent click. */
@@ -20,9 +21,26 @@ export function toggleListTypePatch(
 	el: PptxElement,
 	kind: 'bullet' | 'numbered',
 ): Partial<PptxElement> {
-	const base = textStyleBase(el);
-	const next = base.listType === kind ? 'none' : kind;
-	return { textStyle: { ...base, listType: next } } as Partial<PptxElement>;
+	if (!hasTextProperties(el)) {
+		return {};
+	}
+	const surface =
+		typeof document === 'undefined'
+			? null
+			: document.querySelector<HTMLElement>('[data-inline-editor]');
+	const liveText = surface ? readEditableText(surface) : undefined;
+	const current =
+		liveText === undefined
+			? el
+			: {
+					...el,
+					text: liveText,
+					textSegments: remapTextToSegments(liveText, el.textSegments, el.textStyle),
+				};
+	return {
+		...(liveText === undefined ? {} : { text: liveText }),
+		...toggleElementBullets(current, kind),
+	};
 }
 
 /** Increase or decrease the paragraph left margin by one indent step. */

--- a/packages/svelte/src/viewer/editor/editor-state.svelte.test.ts
+++ b/packages/svelte/src/viewer/editor/editor-state.svelte.test.ts
@@ -6,8 +6,11 @@ import type {
 	PptxSlide,
 	PptxSlideMaster,
 } from 'pptx-viewer-core';
+import { buildParagraphs } from 'pptx-viewer-shared';
+import { flushSync, mount, unmount } from 'svelte';
 import { describe, expect, it, vi } from 'vitest';
 
+import ParagraphGroup from '../components/ribbon/home/ParagraphGroup.svelte';
 import { EditorState } from './editor-state.svelte';
 
 /**
@@ -98,6 +101,49 @@ describe('editorState selection + geometry', () => {
 });
 
 describe('editorState history-tracked mutations', () => {
+	it('toggles loaded bullets from the real ribbon with one undo/redo entry', async () => {
+		const { editor } = make();
+		const loaded = shape('e1', {
+			textSegments: [
+				{ text: '» ', style: {}, bulletInfo: { char: '»' } },
+				{ text: 'hi', style: {} },
+			],
+		});
+		editor.setSlides([slide('a', [loaded, shape('e2')])]);
+		editor.select('e1');
+		const target = document.createElement('div');
+		document.body.append(target);
+		const mounted = mount(ParagraphGroup, { target, props: { editor } });
+		try {
+			flushSync();
+			const button = target.querySelector<HTMLButtonElement>('button')!;
+			expect(button.getAttribute('aria-pressed')).toBe('true');
+			button.click();
+			flushSync();
+			expect(button.getAttribute('aria-pressed')).toBe('false');
+			expect(buildParagraphs(editor.selectedElement!)[0].bulletMarker).toBeUndefined();
+			expect(
+				buildParagraphs(editor.selectedElement!)[0]
+					.runs.map((run) => run.text)
+					.join(''),
+			).toBe('hi');
+			expect(editor.slides[0].elements[1]).toStrictEqual(shape('e2'));
+			expect(editor.canUndo).toBeTruthy();
+			editor.undo();
+			flushSync();
+			expect(buildParagraphs(editor.slides[0].elements[0])[0].bulletMarker).toBe('»');
+			expect(editor.canUndo).toBeFalsy();
+			editor.redo();
+			expect(buildParagraphs(editor.slides[0].elements[0])[0].bulletMarker).toBeUndefined();
+			editor.editable = false;
+			flushSync();
+			expect(button.disabled).toBeTruthy();
+		} finally {
+			await unmount(mounted);
+			target.remove();
+		}
+	});
+
 	it('reopens an existing equation and updates its OMML in place', () => {
 		const { editor } = make();
 		const original = { 'm:oMath': { 'm:r': { 'm:t': 'x' } } };

--- a/packages/vanilla/src/viewer/editor/editor-edit-ops.test.ts
+++ b/packages/vanilla/src/viewer/editor/editor-edit-ops.test.ts
@@ -1,6 +1,7 @@
 /* oxlint-disable eslint/one-var -- many independent `it()` blocks, each with
    its own short arrange/act/assert consts. */
 import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
+import { buildParagraphs } from 'pptx-viewer-shared';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createTranslator } from '../i18n';
@@ -58,6 +59,37 @@ function elementById(
 }
 
 describe('createEditActions formatting', () => {
+	it('records one semantic list command and restores markers and body through undo/redo', () => {
+		const { store, ops, actions } = setup();
+		const original = structuredClone(store.get().slides);
+		actions.toggleBulletList();
+		const listed = elementById(store, 'a')!;
+		expect(buildParagraphs(listed)[0].bulletMarker).toBe('•');
+		expect(
+			buildParagraphs(listed)[0]
+				.runs.map((run) => run.text)
+				.join(''),
+		).toBe('hi');
+		expect(elementById(store, 'b')).toStrictEqual(original[0].elements[1]);
+		expect(ops.canUndo()).toBeTruthy();
+		ops.undo();
+		expect(store.get().slides).toStrictEqual(original);
+		expect(ops.canUndo()).toBeFalsy();
+		ops.redo();
+		expect(elementById(store, 'a')).toStrictEqual(listed);
+	});
+
+	it.each([{ editable: false }, { selectedElementId: null }])(
+		'does not record a list command without edit permission and selection: %j',
+		(overrides) => {
+			const { store, ops, actions } = setup(overrides);
+			const before = structuredClone(store.get().slides);
+			actions.toggleBulletList();
+			expect(store.get().slides).toStrictEqual(before);
+			expect(ops.canUndo()).toBeFalsy();
+		},
+	);
+
 	it('toggles bold with history, and undo reverts it', () => {
 		const { store, ops, actions } = setup();
 		actions.toggleBold();

--- a/packages/vanilla/src/viewer/editor/editor-format-mutations.ts
+++ b/packages/vanilla/src/viewer/editor/editor-format-mutations.ts
@@ -11,6 +11,7 @@ import { hasShapeProperties, hasTextProperties } from 'pptx-viewer-core';
 import type { ChangeCaseMode } from 'pptx-viewer-shared';
 import {
 	applyCaseTransformToSegments,
+	elementBulletKind,
 	remapTextToSegments,
 	textFontSizePtToPx,
 	textFontSizePxToPt,
@@ -114,7 +115,7 @@ export function readTextFormatState(el: PptxElement | undefined): TextFormatStat
 		colorRef: ts?.colorRef ?? firstRun?.colorRef,
 		highlightColor: ts?.highlightColor ?? firstRun?.highlightColor,
 		characterSpacing: ts?.characterSpacing ?? firstRun?.characterSpacing ?? 0,
-		listType: ts?.listType ?? firstRun?.listType,
+		listType: canFormatText(el) ? elementBulletKind(el) : 'none',
 		align: ts?.align ?? firstRun?.align,
 		paragraphMarginLeft: ts?.paragraphMarginLeft ?? firstRun?.paragraphMarginLeft ?? 0,
 		lineSpacing: ts?.lineSpacing ?? firstRun?.lineSpacing,

--- a/packages/vanilla/src/viewer/editor/editor-paragraph-mutations.test.ts
+++ b/packages/vanilla/src/viewer/editor/editor-paragraph-mutations.test.ts
@@ -1,6 +1,9 @@
 import type { PptxElement } from 'pptx-viewer-core';
-import { describe, expect, it } from 'vitest';
+import { buildParagraphs } from 'pptx-viewer-shared';
+import { afterEach, describe, expect, it } from 'vitest';
 
+import { renderTextBlock } from '../render/elements/text-block';
+import { readTextFormatState } from './editor-format-mutations';
 import {
 	adjustIndent,
 	setLineSpacing,
@@ -23,21 +26,56 @@ function textElement(): PptxElement {
 }
 
 describe('editor-paragraph-mutations', () => {
-	it('toggles bullet list on then off', () => {
-		const on = toggleListType(textElement(), 'bullet') as { textStyle: { listType?: string } };
-		expect(on.textStyle.listType).toBe('bullet');
-
-		const el = textElement() as PptxElement & { textStyle: { listType?: string } };
-		el.textStyle.listType = 'bullet';
-		const off = toggleListType(el, 'bullet') as { textStyle: { listType?: string } };
-		expect(off.textStyle.listType).toBe('none');
+	afterEach(() => {
+		document.body.innerHTML = '';
 	});
 
-	it('switches from bullet to numbered directly', () => {
-		const el = textElement() as PptxElement & { textStyle: { listType?: string } };
-		el.textStyle.listType = 'bullet';
-		const patch = toggleListType(el, 'numbered') as { textStyle: { listType?: string } };
-		expect(patch.textStyle.listType).toBe('numbered');
+	it('toggles one rendered bullet on, off, and on without changing its body', () => {
+		let el = textElement();
+		for (const marker of ['•', undefined, '•']) {
+			el = { ...el, ...toggleListType(el, 'bullet') } as PptxElement;
+			const paragraphs = buildParagraphs(el);
+			expect(paragraphs[0].bulletMarker).toBe(marker);
+			expect(paragraphs[0].runs.map((run) => run.text).join('')).toBe('hi');
+			const rendered = renderTextBlock(document, paragraphs, {});
+			expect(rendered.querySelectorAll('.pptxv-bullet')).toHaveLength(marker ? 1 : 0);
+			expect(readTextFormatState(el).listType).toBe(marker ? 'bullet' : 'none');
+		}
+	});
+
+	it('reads loaded semantic bullets and switches directly to rendered numbering', () => {
+		const el = {
+			...textElement(),
+			textSegments: [
+				{ text: '» ', style: {}, bulletInfo: { char: '»' } },
+				{ text: 'hi', style: { bold: true } },
+			],
+		} as PptxElement;
+		expect(readTextFormatState(el).listType).toBe('bullet');
+		const next = { ...el, ...toggleListType(el, 'numbered') } as PptxElement;
+		expect(buildParagraphs(next)[0].bulletMarker).toBe('1.');
+		expect(
+			buildParagraphs(next)[0]
+				.runs.map((run) => run.text)
+				.join(''),
+		).toBe('hi');
+		expect(readTextFormatState(next).listType).toBe('numbered');
+	});
+
+	it('keeps pending inline text when the ribbon command runs before blur', () => {
+		const surface = document.createElement('div');
+		surface.dataset.inlineEditor = '';
+		surface.textContent = 'pending body';
+		document.body.append(surface);
+		const el = textElement();
+		const next = { ...el, ...toggleListType(el, 'bullet') } as PptxElement;
+		expect('text' in next && next.text).toBe('pending body');
+		expect(
+			buildParagraphs(next)[0]
+				.runs.map((run) => run.text)
+				.join(''),
+		).toBe('pending body');
+		expect(buildParagraphs(next)[0].bulletMarker).toBe('•');
 	});
 
 	it('increases and clamps indent at zero', () => {

--- a/packages/vanilla/src/viewer/editor/editor-paragraph-mutations.ts
+++ b/packages/vanilla/src/viewer/editor/editor-paragraph-mutations.ts
@@ -1,9 +1,11 @@
 import type { PptxElement, TextSegment, TextStyle } from 'pptx-viewer-core';
+import { remapTextToSegments, toggleElementBullets } from 'pptx-viewer-shared';
 
 import { canFormatText, readTextFormatState } from './editor-format-mutations';
+import { currentInlineEditorText } from './inline-text-editor';
 
 /**
- * Pure paragraph-level formatting-patch builders for the vanilla editor
+ * Paragraph-level formatting-patch builders for the vanilla editor
  * (list type, indent, alignment, line spacing). Split out of
  * `editor-format-mutations.ts` (character-level formatting) to keep both
  * files within the project's file-size budget; same whole-element scope note
@@ -31,8 +33,22 @@ export function toggleListType(
 	el: PptxElement,
 	kind: Exclude<TextStyle['listType'], 'none' | undefined>,
 ): Partial<PptxElement> {
-	const current = readTextFormatState(el).listType;
-	return patchTextStyle(el, { listType: current === kind ? 'none' : kind });
+	if (!canFormatText(el)) {
+		return {};
+	}
+	const liveText = currentInlineEditorText();
+	const current =
+		liveText === undefined
+			? el
+			: {
+					...el,
+					text: liveText,
+					textSegments: remapTextToSegments(liveText, el.textSegments, el.textStyle),
+				};
+	return {
+		...(liveText === undefined ? {} : { text: liveText }),
+		...toggleElementBullets(current, kind),
+	};
 }
 
 /** Step the paragraph left margin (indent) by `deltaSteps` * {@link INDENT_STEP_PX}, clamped >= 0. */

--- a/packages/vanilla/src/viewer/ui/ribbon/home/paragraph-group.test.ts
+++ b/packages/vanilla/src/viewer/ui/ribbon/home/paragraph-group.test.ts
@@ -1,5 +1,9 @@
+import type { PptxElement } from 'pptx-viewer-core';
+import { buildParagraphs } from 'pptx-viewer-shared';
 import { describe, expect, it, vi } from 'vitest';
 
+import { readTextFormatState } from '../../../editor/editor-format-mutations';
+import { toggleListType } from '../../../editor/editor-paragraph-mutations';
 import { createTranslator } from '../../../i18n';
 import { createEditingGroup } from './editing-group';
 import { createParagraphGroup } from './paragraph-group';
@@ -30,6 +34,46 @@ function trigger(el: HTMLElement, label: string): HTMLButtonElement {
 const formattable = { canFormat: true, editable: true, text: {} as never };
 
 describe('createParagraphGroup', () => {
+	it('reads loaded bullets and updates real markers and pressed state on clicks', () => {
+		let element = {
+			type: 'text',
+			id: 't',
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 50,
+			text: 'Body',
+			textSegments: [
+				{ text: '» ', style: {}, bulletInfo: { char: '»' } },
+				{ text: 'Body', style: {} },
+			],
+		} as PptxElement;
+		const t = createTranslator();
+		const group = createParagraphGroup(document, t, {
+			...paragraphHandlers(),
+			toggleBulletList: () => {
+				element = { ...element, ...toggleListType(element, 'bullet') } as PptxElement;
+				group.update({ ...formattable, text: readTextFormatState(element) });
+			},
+		});
+		group.update({ ...formattable, text: readTextFormatState(element) });
+		const button = trigger(group.el, t('pptx.text.bulletList'));
+		expect(button.getAttribute('aria-pressed')).toBe('true');
+		button.click();
+		expect(button.getAttribute('aria-pressed')).toBe('false');
+		expect(buildParagraphs(element)[0].bulletMarker).toBeUndefined();
+		button.click();
+		expect(button.getAttribute('aria-pressed')).toBe('true');
+		expect(buildParagraphs(element)[0].bulletMarker).toBe('»');
+		expect(
+			buildParagraphs(element)[0]
+				.runs.map((run) => run.text)
+				.join(''),
+		).toBe('Body');
+		group.update({ ...formattable, editable: false, text: readTextFormatState(element) });
+		expect(button.disabled).toBeTruthy();
+	});
+
 	it('offers the Text Direction and Columns menus React puts in this group', () => {
 		const t = createTranslator();
 		const group = createParagraphGroup(document, t, paragraphHandlers());

--- a/packages/vue/src/viewer/components/ribbon/TextSection.test.ts
+++ b/packages/vue/src/viewer/components/ribbon/TextSection.test.ts
@@ -104,3 +104,48 @@ describe('textSection font-size stepper', () => {
 		expect(onUpdateTextStyle.mock.lastCall?.[0]?.fontSize).toBeCloseTo(20 * (96 / 72));
 	});
 });
+
+describe('textSection list controls', () => {
+	it.each(['bullet', 'numbered'] as const)(
+		'reads loaded %s state and toggles it off',
+		async (kind) => {
+			const onUpdateTextStyle = vi.fn();
+			const bulletInfo =
+				kind === 'bullet' ? { char: '◆' } : { autoNumType: 'romanUcPeriod', paragraphIndex: 0 };
+			const wrapper = mountSection({
+				onUpdateTextStyle,
+				selectedElement: textShape({
+					textSegments: [{ text: 'body', style: {}, bulletInfo }],
+				}),
+			});
+			const button = wrapper.find(
+				`button[title="${kind === 'bullet' ? 'Bullet List' : 'Numbered List'}"]`,
+			);
+			expect(button.attributes('aria-pressed')).toBe('true');
+			await button.trigger('click');
+			expect(onUpdateTextStyle).toHaveBeenCalledWith({ listType: 'none' });
+			await wrapper.setProps({ selectedElement: textShape() });
+			expect(button.attributes('aria-pressed')).toBe('false');
+			await button.trigger('click');
+			expect(onUpdateTextStyle).toHaveBeenLastCalledWith({ listType: kind });
+		},
+	);
+
+	it('disables unsupported table list commands without disabling ordinary cell formatting', () => {
+		const wrapper = mountSection({
+			selectedElement: {
+				id: 'table',
+				type: 'table',
+				x: 0,
+				y: 0,
+				width: 100,
+				height: 40,
+				tableData: { rows: [{ cells: [{ text: 'cell', style: {} }] }], columnWidths: [1] },
+			},
+			tableEditorState: { elementId: 'table', rowIndex: 0, columnIndex: 0 },
+		});
+		expect(wrapper.find('button[title="Bullet List"]').attributes('disabled')).toBeDefined();
+		expect(wrapper.find('button[title="Numbered List"]').attributes('disabled')).toBeDefined();
+		expect(wrapper.find('button[title="Bold"]').attributes('disabled')).toBeUndefined();
+	});
+});

--- a/packages/vue/src/viewer/components/ribbon/TextSection.vue
+++ b/packages/vue/src/viewer/components/ribbon/TextSection.vue
@@ -23,7 +23,11 @@ import {
 import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, PptxThemeColorRef, TextStyle } from 'pptx-viewer-core';
 import type { ChangeCaseMode } from 'pptx-viewer-shared';
-import { OFFICE_COLOR_SWATCH_HEXES, textFontSizePtToPx } from 'pptx-viewer-shared';
+import {
+	elementBulletKind,
+	OFFICE_COLOR_SWATCH_HEXES,
+	textFontSizePtToPx,
+} from 'pptx-viewer-shared';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -98,6 +102,9 @@ const isTextEl = computed(
 const isTable = computed(() => hasSel.value && props.selectedElement?.type === 'table');
 // Enable formatting for text elements AND table cells
 const canFormat = computed(() => isTextEl.value || isTable.value);
+const listKind = computed(() =>
+	props.selectedElement ? elementBulletKind(props.selectedElement) : 'none',
+);
 const effectiveTs = computed(() =>
 	getEffectiveTextStyle(props.selectedElement, props.tableEditorState),
 );
@@ -193,20 +200,20 @@ function handleClearFormatting(): void {
 }
 
 function handleBulletList(): void {
-	if (!canFormat.value || !props.selectedElement) {
+	if (!canMut.value || !isTextEl.value) {
 		return;
 	}
 	props.onUpdateTextStyle({
-		listType: effectiveTs.value?.listType === 'bullet' ? 'none' : 'bullet',
+		listType: listKind.value === 'bullet' ? 'none' : 'bullet',
 	});
 }
 
 function handleNumberedList(): void {
-	if (!canFormat.value || !props.selectedElement) {
+	if (!canMut.value || !isTextEl.value) {
 		return;
 	}
 	props.onUpdateTextStyle({
-		listType: effectiveTs.value?.listType === 'numbered' ? 'none' : 'numbered',
+		listType: listKind.value === 'numbered' ? 'none' : 'numbered',
 	});
 }
 
@@ -496,8 +503,9 @@ function handleChangeCase(value: string): void {
 			<div :class="grp">
 				<button
 					type="button"
-					:disabled="!canMut"
-					:class="gB"
+					:disabled="!canMut || !isTextEl"
+					:class="[gB, listKind === 'bullet' ? 'bg-accent' : '']"
+					:aria-pressed="listKind === 'bullet'"
 					:title="t('pptx.text.bulletList')"
 					@mousedown.prevent
 					@click="handleBulletList"
@@ -506,8 +514,9 @@ function handleChangeCase(value: string): void {
 				</button>
 				<button
 					type="button"
-					:disabled="!canMut"
-					:class="gL"
+					:disabled="!canMut || !isTextEl"
+					:class="[gL, listKind === 'numbered' ? 'bg-accent' : '']"
+					:aria-pressed="listKind === 'numbered'"
 					:title="t('pptx.text.numberedList')"
 					@mousedown.prevent
 					@click="handleNumberedList"

--- a/packages/vue/src/viewer/composables/useRibbonActions.test.ts
+++ b/packages/vue/src/viewer/composables/useRibbonActions.test.ts
@@ -1,4 +1,6 @@
+import { hasTextProperties } from 'pptx-viewer-core';
 import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
+import { elementBulletKind } from 'pptx-viewer-shared';
 import { describe, expect, it, vi } from 'vitest';
 import { computed, ref } from 'vue';
 
@@ -23,33 +25,139 @@ function slideWith(element: PptxElement): PptxSlide {
 	return { id: 's1', rId: 's1', slideNumber: 1, elements: [element] };
 }
 
-function useHarness(element: PptxElement) {
-	let currentSlide = slideWith(element);
+function useHarness(element: PptxElement, canEdit = true) {
+	const currentSlide = ref(slideWith(element));
 	const updateElement = vi.fn((elementId: string, updates: Partial<PptxElement>) => {
-		currentSlide = {
-			...currentSlide,
-			elements: currentSlide.elements.map((el) =>
+		currentSlide.value = {
+			...currentSlide.value,
+			elements: currentSlide.value.elements.map((el) =>
 				el.id === elementId ? ({ ...el, ...updates } as PptxElement) : el,
 			),
 		};
 	});
 
 	const actions = useRibbonActions({
-		canEdit: () => true,
+		canEdit: () => canEdit,
 		presenting: ref(false),
 		showMasterView: ref(false),
-		tableSelection: ref(null),
-		selectedElements: computed(() => currentSlide.elements),
+		tableSelection: ref(
+			element.type === 'table' ? { elementId: element.id, rowIndex: 0, columnIndex: 0 } : null,
+		),
+		selectedElements: computed(() => currentSlide.value.elements),
 		selectedElementIds: ref([element.id]),
-		activeSlide: computed(() => currentSlide),
+		activeSlide: computed(() => currentSlide.value),
 		activeSlideIndex: ref(0),
-		slides: ref([currentSlide]),
+		slides: ref([currentSlide.value]),
 		pushHistory: vi.fn(),
 		ops: { updateElement } as unknown as EditorOperations,
 	});
 
-	return { actions, element: () => currentSlide.elements[0] };
+	return { actions, element: () => currentSlide.value.elements[0], updateElement };
 }
+
+describe('ribbonUpdateTextStyle list commands', () => {
+	it('creates markers for plain multiline text without segments', () => {
+		const source = textElement();
+		if (!hasTextProperties(source)) {
+			throw new Error('expected text');
+		}
+		delete source.textSegments;
+		source.text = 'first\nsecond';
+		const { actions, element } = useHarness(source);
+		actions.ribbonUpdateTextStyle({ listType: 'bullet' });
+		const result = element();
+		if (!hasTextProperties(result)) {
+			throw new Error('expected text');
+		}
+		expect(result.textSegments?.filter((segment) => segment.bulletInfo?.char)).toHaveLength(2);
+		expect(
+			result.textSegments
+				?.filter((segment) => !segment.bulletInfo)
+				.map((segment) => segment.text)
+				.join(''),
+		).toBe('first\nsecond');
+	});
+
+	it.each(['bullet', 'numbered'] as const)(
+		'sets %s semantics and preserves accompanying formatting',
+		(kind) => {
+			const source = textElement();
+			const { actions, element, updateElement } = useHarness(source);
+			actions.ribbonUpdateTextStyle({ listType: kind, bold: true });
+			expect(elementBulletKind(element())).toBe(kind);
+			const first = element();
+			if (!hasTextProperties(first)) {
+				throw new Error('expected text');
+			}
+			expect(first.textSegments?.[0].bulletInfo).toBeDefined();
+			expect(
+				first.textSegments
+					?.slice(1)
+					.map((segment) => segment.text)
+					.join(''),
+			).toBe('hello world');
+			expect(first.textSegments?.at(-1)?.style.bold).toBeTruthy();
+			expect(updateElement).toHaveBeenCalledOnce();
+			actions.ribbonUpdateTextStyle({ listType: kind });
+			expect(element()).toStrictEqual(first);
+			actions.ribbonUpdateTextStyle({ listType: 'none' });
+			expect(elementBulletKind(element())).toBe('none');
+			expect(source).toStrictEqual(textElement());
+		},
+	);
+
+	it('preserves uncommitted inline text when adding a list', () => {
+		const editor = document.createElement('div');
+		editor.dataset.inlineEditor = '';
+		editor.textContent = 'hello world, typed more';
+		document.body.appendChild(editor);
+		try {
+			const { actions, element } = useHarness(textElement());
+			actions.ribbonUpdateTextStyle({ listType: 'bullet' });
+			const result = element();
+			if (!hasTextProperties(result)) {
+				throw new Error('expected text');
+			}
+			expect(result.text).toBe(editor.textContent);
+			expect(
+				result.textSegments
+					?.slice(1)
+					.map((segment) => segment.text)
+					.join(''),
+			).toBe(editor.textContent);
+		} finally {
+			editor.remove();
+		}
+	});
+
+	it('does not change read-only selections', () => {
+		const { actions, updateElement } = useHarness(textElement(), false);
+		actions.ribbonUpdateTextStyle({ listType: 'bullet' });
+		expect(updateElement).not.toHaveBeenCalled();
+	});
+
+	it('ignores unsupported table lists while applying other requested cell styles', () => {
+		const table: PptxElement = {
+			id: 'table',
+			type: 'table',
+			x: 0,
+			y: 0,
+			width: 100,
+			height: 40,
+			tableData: { rows: [{ cells: [{ text: 'cell', style: {} }] }], columnWidths: [1] },
+		};
+		const { actions, element, updateElement } = useHarness(table);
+		actions.ribbonUpdateTextStyle({ listType: 'bullet' });
+		expect(updateElement).not.toHaveBeenCalled();
+		actions.ribbonUpdateTextStyle({ listType: 'bullet', bold: true });
+		const result = element();
+		if (result.type !== 'table') {
+			throw new Error('expected table');
+		}
+		expect(result.tableData?.rows[0].cells[0].style).toStrictEqual({ bold: true });
+		expect('textSegments' in result).toBeFalsy();
+	});
+});
 
 describe('ribbonUpdateTextCase', () => {
 	it('rewrites run text per a change-case mode', () => {

--- a/packages/vue/src/viewer/composables/useRibbonActions.ts
+++ b/packages/vue/src/viewer/composables/useRibbonActions.ts
@@ -7,7 +7,12 @@ import type {
 	TextStyle,
 } from 'pptx-viewer-core';
 import type { AlignEdge, ChangeCaseMode } from 'pptx-viewer-shared';
-import { readEditableText, remapTextToSegments, transformTextCase } from 'pptx-viewer-shared';
+import {
+	readEditableText,
+	remapTextToSegments,
+	setElementBullets,
+	transformTextCase,
+} from 'pptx-viewer-shared';
 import { computed } from 'vue';
 import type { ComputedRef, Ref } from 'vue';
 
@@ -117,30 +122,55 @@ export function useRibbonActions(input: UseRibbonActionsInput) {
 
 	function ribbonUpdateTextStyle(updates: Partial<TextStyle>): void {
 		const id = selectedElementIds.value[0];
-		if (!id) {
+		if (!id || !canEdit()) {
 			return;
 		}
 		const el = activeSlide.value?.elements.find((e) => e.id === id);
 		if (!el) {
 			return;
 		}
-		// Tables route to the selected cell's style; other elements to their textStyle.
+		const { listType, ...styleUpdates } = updates;
+		// Table cells have no shape-text bullet model; other cell formatting stays supported.
 		if (el.type === 'table') {
-			applyCellTextStyle(el, updates);
+			if (Object.keys(styleUpdates).length > 0) {
+				applyCellTextStyle(el, styleUpdates);
+			}
 			return;
 		}
 		if (!hasTextProperties(el)) {
 			return;
 		}
-		const textStyle = { ...el.textStyle, ...updates };
+		// Reconcile uncontrolled inline text before the paragraph command, as Change Case does.
+		const liveEditor =
+			listType !== undefined && typeof document !== 'undefined'
+				? document.querySelector<HTMLElement>('[data-inline-editor]')
+				: null;
+		const liveText = liveEditor ? readEditableText(liveEditor) : undefined;
+		const base =
+			liveText === undefined
+				? el
+				: {
+						...el,
+						text: liveText,
+						textSegments: el.textSegments
+							? remapTextToSegments(liveText, el.textSegments, el.textStyle)
+							: undefined,
+					};
+		const listed =
+			listType === undefined ? base : { ...base, ...setElementBullets(base, listType) };
+		if (!hasTextProperties(listed)) {
+			return;
+		}
+		const textStyle = { ...listed.textStyle, ...styleUpdates };
 		const segments =
-			el.textSegments && el.textSegments.length > 0
-				? el.textSegments.map((s) => ({ ...s, style: { ...s.style, ...updates } }))
+			listed.textSegments && listed.textSegments.length > 0
+				? listed.textSegments.map((s) => ({ ...s, style: { ...s.style, ...styleUpdates } }))
 				: undefined;
-		ops.updateElement(
-			id,
-			(segments ? { textStyle, textSegments: segments } : { textStyle }) as Partial<PptxElement>,
-		);
+		ops.updateElement(id, {
+			...(liveText !== undefined ? { text: liveText } : {}),
+			textStyle,
+			...(segments ? { textSegments: segments } : {}),
+		});
 	}
 
 	/**


### PR DESCRIPTION
## What does this change?

Wire the existing Bullets and Numbering commands to first-segment `bulletInfo`, which the renderer and PPTX writer actually consume. The previous handlers changed `textStyle.listType`, so an enabled control could leave the slide and saved file unchanged.

This builds on the shared helper introduced in bffc2b38 instead of duplicating list logic in each binding. It retains the literal-number safeguards from #204, paragraph metadata preservation from #206, and core per-level numbering rules. Direct style requests remain setters; ribbon buttons remain toggles.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

| Binding | Affected? | Fixed here? | Validation |
| --- | --- | --- | --- |
| React | Yes | Yes | Command/hook tests, selected-range state tests, actual demo interactions |
| Vue | Yes | Yes | Command/component tests, actual demo interactions and public serialization/reopen |
| Angular | Yes | Yes | Command/read-only tests, actual demo interactions and public serialization/reopen |
| Svelte | Yes | Yes | Command/editor-state tests and actual demo interactions |
| Vanilla | Yes | Yes | Command/editor-state/mounted-button tests and actual demo interactions |

- [x] Confirmed the ineffective command in every affected binding using regression tests against the previous handlers.
- [x] Every affected binding is fixed here, using shared logic and existing update/history paths.

Existing custom glyphs, picture definitions, fonts, colors, percentage sizes, numbering schemes/starts, paragraph levels and spacing are retained. React keeps its existing selected-character scope, expanding the list change to touched paragraphs; other bindings keep their existing element-wide scope. Unsupported table list controls are disabled instead of writing another ineffective flag. No new UI labels or translations.

## Testing

- [x] Regression tests in existing shared and binding test files, including tests that failed before the change.
- [x] Framework-neutral tests added to `e2e/ribbon-control-effects.spec.ts`; neutrality contract passes.
- [ ] Full automated Playwright suite. Not run; the following interactions were executed through browser control instead.

Actual browser checks in all five demos: plain text to bullet/numbered list, off/on, one-step Undo/Redo, custom diamond restoration, nested Roman numbering starting at III, literal `1.` body text, and an empty middle paragraph. Vue and Angular public `getContent()` bytes were captured through temporary visible demo controls, inspected as native ZIP/XML, and reopened through File > Open. A genuinely new bullet was present in the saved XML; untouched custom text bodies, numbering, and spacing were preserved. Temporary controls are excluded from this PR. This checks public serialization, not the browser's download delivery or native PowerPoint rendering.

Final focused suites: shared 109, React 36, Vue 16, Angular 8, Svelte 34 and Vanilla 33 tests. Core numbering/native-bullet round-trip controls also passed. Package typechecks, changed-file lint/format checks and `git diff --check` passed; these are scoped checks, not claims that the entire repository test suite ran.

Independent code reviews checked all bindings and the shared selection logic. A separate reviewer inspected screenshots and saved XML. Browser execution was performed by the primary agent; independent browser sessions were unavailable.

## Scope and remaining work

- This fixes committed list commands, not live Enter marker insertion or a rich-editor replacement.
- Live off/on retains a custom definition in memory. Turning it off, saving and reloading does not promise to recover a definition removed from the file.
- Testing exposed a separate parser discrepancy for percentage-sized bullets with a first text run differing from paragraph defaults. The percentage and body formatting survive these commands; correcting the initial parser size is a separate change.
- New shared logic is in small files. Existing oversized binding files are kept narrowly scoped rather than mixed with a broad unrelated refactor.

## Conventional Commits

- [x] Package-scoped Conventional Commits with personal-account signed commits.
