### PR TITLE
fix(core): size percentage bullets from the first text run

### DIFF
--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.test.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.test.ts
@@ -5,7 +5,8 @@ import { describe, it, expect } from 'vitest';
 
 import { requireFixture } from '../../../__tests__/require-fixture';
 import { PptxHandler } from '../../PptxHandler';
-import type { TextSegment, XmlObject } from '../../types';
+import type { TextSegment, TextStyle, XmlObject } from '../../types';
+import { PptxRuntimeDependencyFactory } from '../factories/PptxRuntimeDependencyFactory';
 import {
 	breakAutoNumberRun,
 	createAutoNumberSequence,
@@ -525,8 +526,9 @@ class ParagraphContentRuntime extends PptxHandlerRuntime {
 		pIdx: number,
 		paraCount: number,
 		sequence = createAutoNumberSequence(),
+		defaultStyle: TextStyle = {},
 	) {
-		return this.collectShapeParagraphContent(p, pIdx, paraCount, 'left', {}, {
+		return this.collectShapeParagraphContent(p, pIdx, paraCount, 'left', defaultStyle, {
 			txBody: undefined,
 			inheritedTxBody: undefined,
 			bodyDefaultRunStyle: {},
@@ -546,6 +548,120 @@ const pictureBulletParagraph: XmlObject = {
 };
 
 describe('collectShapeParagraphContent - bullet markers (real runtime)', () => {
+	it.each([
+		{
+			name: 'a leading field before a later run',
+			content:
+				'<a:fld><a:rPr sz="1200"/><a:t>First</a:t></a:fld>' +
+				'<a:r><a:rPr sz="3000"/><a:t> later</a:t></a:r>',
+			expectedSize: 16,
+		},
+		{
+			name: 'an inherited first field before an explicitly sized run',
+			content: '<a:fld><a:t>First</a:t></a:fld><a:r><a:rPr sz="3000"/><a:t> later</a:t></a:r>',
+			expectedSize: 24,
+		},
+		{
+			name: 'an inherited first run before an explicitly sized field',
+			content: '<a:r><a:t>First</a:t></a:r><a:fld><a:rPr sz="3000"/><a:t> later</a:t></a:fld>',
+			expectedSize: 24,
+		},
+		{
+			name: 'a first run with unrelated properties before an explicitly sized field',
+			content:
+				'<a:r><a:rPr lang="en-US"/><a:t>First</a:t></a:r>' +
+				'<a:fld><a:rPr sz="3000"/><a:t> later</a:t></a:fld>',
+			expectedSize: 24,
+		},
+	])('uses $name as the percentage bullet base', ({ content, expectedSize }) => {
+		const xml =
+			'<p:txBody><a:p><a:pPr><a:buChar char="◆"/><a:buSzPct val="75000"/>' +
+			`</a:pPr>${content}</a:p></p:txBody>`;
+		const parsed = new PptxRuntimeDependencyFactory().createParser().parse(xml) as XmlObject;
+		const paragraph = (parsed['p:txBody'] as XmlObject)['a:p'] as XmlObject;
+		const { segments } = new ParagraphContentRuntime().collect(paragraph, 0, 1, undefined, {
+			fontSize: 24,
+		});
+		expect(segments[0].style.fontSize).toBe(expectedSize);
+		expect(segments[0].bulletInfo?.sizePercent).toBe(75);
+		expect(segments[1].text).toBe('First');
+		expect(segments[1].style.fontSize).toBe(expectedSize);
+		expect(segments[2].style.fontSize).toBe(40);
+	});
+
+	it.each(['a:r', 'a:fld'])('bases percentage bullets on the first %s font size', (tag) => {
+		const { segments } = new ParagraphContentRuntime().collect(
+			{
+				'a:pPr': { 'a:buChar': { '@_char': '◆' }, 'a:buSzPct': { '@_val': '75000' } },
+				[tag]: { 'a:rPr': { '@_sz': '1650' }, 'a:t': 'Item' },
+			},
+			0,
+			1,
+			undefined,
+			{ fontSize: 24 },
+		);
+		expect(segments[0].style.fontSize).toBe(22);
+		expect(segments[0].bulletInfo?.sizePercent).toBe(75);
+		expect(segments[1].style.fontSize).toBe(22);
+	});
+
+	it('uses the first run for percentage numbering without changing later run sizes', () => {
+		const { segments } = new ParagraphContentRuntime().collect(
+			{
+				'a:pPr': {
+					'a:buAutoNum': { '@_type': 'romanUcPeriod' },
+					'a:buSzPct': { '@_val': '125000' },
+				},
+				'a:r': [
+					{ 'a:rPr': { '@_sz': '1200' }, 'a:t': 'First' },
+					{ 'a:rPr': { '@_sz': '3000' }, 'a:t': ' larger' },
+				],
+			},
+			0,
+			1,
+			undefined,
+			{ fontSize: 24 },
+		);
+		expect(segments[0].style.fontSize).toBe(16);
+		expect(segments[0].bulletInfo?.sizePercent).toBe(125);
+		expect(segments[1].style.fontSize).toBe(16);
+		expect(segments[2].style.fontSize).toBe(40);
+	});
+
+	it.each([{ 'a:r': { 'a:t': 'Inherited size' } }, {}])(
+		'keeps the resolved paragraph default when no run authors a size: %j',
+		(content) => {
+			const { segments } = new ParagraphContentRuntime().collect(
+				{
+					'a:pPr': { 'a:buChar': { '@_char': '◆' }, 'a:buSzPct': { '@_val': '75000' } },
+					...content,
+				},
+				0,
+				1,
+				undefined,
+				{ fontSize: 24 },
+			);
+			expect(segments[0].style.fontSize).toBe(24);
+			expect(segments[0].bulletInfo?.sizePercent).toBe(75);
+		},
+	);
+
+	it('keeps absolute bullet sizing independent of the body font size', () => {
+		const { segments } = new ParagraphContentRuntime().collect(
+			{
+				'a:pPr': { 'a:buChar': { '@_char': '◆' }, 'a:buSzPts': { '@_val': '900' } },
+				'a:r': { 'a:rPr': { '@_sz': '1650' }, 'a:t': 'Item' },
+			},
+			0,
+			1,
+			undefined,
+			{ fontSize: 24 },
+		);
+		expect(segments[0].style.fontSize).toBe(24);
+		expect(segments[0].bulletInfo?.sizePts).toBe(9);
+		expect(segments[1].style.fontSize).toBe(22);
+	});
+
 	it('stamps no display glyph for a picture bullet, only the bullet metadata', () => {
 		const { segments, parts } = new ParagraphContentRuntime().collect(pictureBulletParagraph, 0, 1);
 

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParagraphContentParsing.ts
@@ -129,17 +129,11 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			} else {
 				bulletText = '• ';
 			}
-			// With no `a:buSzPct` / `a:buSzPts`, PowerPoint draws the bullet at
-			// 100% of the FIRST TEXT RUN's size, not at the text body's default.
-			// Using `mergedDefaultRunStyle` alone made a bullet on an 8pt run
-			// render at the 18pt body default - a ~2.2x oversized glyph, and
-			// visibly inconsistent between paragraphs (one that happened to carry
-			// an `a:endParaRPr sz` picked the right size up by accident).
+			// Unsized bullets and `a:buSzPct` use the FIRST TEXT RUN's size as
+			// their base, not the text body's default. The renderer applies the
+			// percentage; `a:buSzPts` is absolute and does not use this base.
 			const bulletStyle = { ...mergedDefaultRunStyle } as TextStyle;
-			if (
-				paragraphBulletInfo.sizePercent === undefined &&
-				paragraphBulletInfo.sizePts === undefined
-			) {
+			if (paragraphBulletInfo.sizePts === undefined) {
 				const firstRunSize = this.resolveFirstRunFontSize(p, paraAlign, ctx);
 				if (firstRunSize !== undefined) {
 					bulletStyle.fontSize = firstRunSize;
@@ -468,31 +462,26 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 
 	/**
 	 * Font size (px) of the first text run in a paragraph, or `undefined` when
-	 * the paragraph has no run that declares one.
+	 * that first run inherits its size.
 	 *
-	 * Used to size an unsized bullet the way PowerPoint does: `a:buChar` /
-	 * `a:buAutoNum` with no `a:buSzPct`/`a:buSzPts` inherits the first run's
-	 * size. Only `a:r` and `a:fld` carry renderable text; `a:br` does not.
+	 * Used as the base for unsized and percentage-sized bullets. Only `a:r`
+	 * and `a:fld` carry renderable text; `a:br` does not.
 	 */
 	protected resolveFirstRunFontSize(
 		p: XmlObject,
 		paraAlign: TextStyle['align'],
 		ctx: ShapeTextParsingContext,
 	): number | undefined {
-		for (const key of ['a:r', 'a:fld'] as const) {
-			const node = p[key];
-			if (!node) {
+		for (const [tag, node] of paragraphContentEntries(p, PARAGRAPH_CONTENT_TAGS).entries) {
+			if (tag !== 'a:r' && tag !== 'a:fld') {
 				continue;
 			}
-			const first = (this.ensureArray(node) as XmlObject[])[0];
-			const runProps = first?.['a:rPr'] as XmlObject | undefined;
+			const runProps = (node as XmlObject | undefined)?.['a:rPr'] as XmlObject | undefined;
 			if (!runProps) {
-				continue;
+				return undefined;
 			}
 			const style = this.extractTextRunStyle(runProps, paraAlign, ctx.slideRelationshipMap);
-			if (typeof style.fontSize === 'number') {
-				return style.fontSize;
-			}
+			return typeof style.fontSize === 'number' ? style.fontSize : undefined;
 		}
 		return undefined;
 	}


### PR DESCRIPTION
## What does this change?

Size percentage-based bullets relative to the first text run, rather than the text body's default font size. A paragraph with a 24px default, 22px first run and 75% bullet currently renders an 18px bullet instead of 16.5px.

This extends the first-run sizing correction in 76079961 to `a:buSzPct`; absolute `a:buSzPts` remains unchanged. It also reuses the existing authored-order reader from beb2067f so a leading field is not skipped in favor of a later regular run, and an inherited first-run size does not fall through to a later explicit size.

[Microsoft's Open XML reference](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.bulletsizepercentage?view=openxml-3.0.1) defines percentage bullet size relative to the surrounding text. The renderer already applies that percentage, so this changes only the parser's base size, not body formatting or the saved percentage.

## Type of change

- [x] Bug fix (non-breaking)

## Scope

Two files: the core paragraph parser and its existing test suite. All five viewer bindings consume the resulting marker style through shared rendering; no separate binding implementation is required. No new metadata fields, synthetic storage runs, serializer changes or absolute-size conversion.

## Testing

- [x] Ten regression/control cases added to the existing real-runtime test file: percentage run/field sizes, mixed Roman runs, inherited/default and empty-paragraph fallbacks, absolute sizes, authored field/run order and inherited first-run size.
- [x] Test-first failures: three percentage cases failed before the percentage correction; four mixed-order/inherited cases failed before the ordering correction.
- [x] 73 focused tests passed across the paragraph runtime, existing small-text fidelity integration, inherited bullet controls and authored-order helper.
- [x] Core typecheck, changed-file lint/format and `git diff --check` passed.
- [ ] Full repository test/e2e suite not run.

Actual browser validation used the React demo with this core parser and #251's list commands: two custom 75% diamond bullets render at 16.5px on initial load and remain 16.5px after off/on, with the same glyph and color. The prior parser rendered 18px initially. The temporary preview adapter only exposed existing numbering utilities needed by #251 and is not part of this PR. This is one browser surface plus core/shared-path coverage, not a claim of five new browser runs or native PowerPoint verification.

An independent code reviewer checked the author history, inherited and mixed-run cases, reran the 73 tests, and inspected the browser evidence. The primary agent performed browser execution.

## Conventional Commits

- [x] Package-scoped Conventional Commit, signed with my personal account.
