### PR TITLE
fix(shared): preserve paragraph formatting after insertion or deletion

### DIFF
--- a/e2e/desktop-manipulation.spec.ts
+++ b/e2e/desktop-manipulation.spec.ts
@@ -31,8 +31,11 @@
  *
  * Run: bunx playwright test desktop-manipulation
  */
+import { readFile, writeFile } from 'node:fs/promises';
+
 import { expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
+import JSZip from 'jszip';
 
 import { goToSlide } from './support/context-menu';
 import {
@@ -104,6 +107,78 @@ async function rotationOf(target: Locator): Promise<number | null> {
 }
 
 test.describe('desktop manipulation (mouse)', () => {
+	for (const [operation, body] of [
+		['middle insertion', 'First\nInserted\nLast'],
+		['first paragraph deletion', 'Last'],
+	] as const) {
+		test(`inline ${operation} preserves the unchanged last paragraph's spacing`, async ({
+			page,
+		}, testInfo) => {
+			// Reuse the existing two-shape deck; author distinguishable paragraph
+			// spacing in its TARGET, without a new fixture or binding-only hook.
+			const zip = await JSZip.loadAsync(await readFile(SHAPES_DECK));
+			const path = 'ppt/slides/slide1.xml';
+			const xml = await zip.file(path)!.async('string');
+			const paragraphs = (['First', 'Last'] as const)
+				.map(
+					(text, index) =>
+						`<a:p><a:pPr><a:spcAft><a:spcPts val="${index ? 750 : 1500}"/></a:spcAft></a:pPr>` +
+						`<a:r><a:rPr sz="1800"/><a:t>${text}</a:t></a:r></a:p>`,
+				)
+				.join('');
+			zip.file(
+				path,
+				xml.replace(/<p:sp>[\s\S]*?<\/p:sp>/gu, (shape) =>
+					shape.includes('>TARGET<') ? shape.replace(/<a:p>[\s\S]*?<\/a:p>/u, paragraphs) : shape,
+				),
+			);
+			const deckPath = testInfo.outputPath('paragraph-spacing.pptx');
+			await writeFile(deckPath, await zip.generateAsync({ type: 'nodebuffer' }));
+			await loadDeck(page, deckPath);
+			const target = slideElements(page).filter({ hasText: 'Last' }).first();
+			const source = slideElements(page).filter({ hasText: 'SOURCE' }).first();
+			const spacing = () =>
+				target.evaluate((element) =>
+					Math.max(
+						0,
+						...[...element.querySelectorAll<HTMLElement>('*')]
+							.filter(
+								(node) =>
+									node.textContent?.includes('Last') &&
+									!node.textContent.includes('First') &&
+									!node.textContent.includes('Inserted'),
+							)
+							.map((node) => Number.parseFloat(getComputedStyle(node).marginBottom) || 0),
+					),
+				);
+			await expect.poll(spacing).toBe(10);
+			await target.dblclick();
+			const editor = page.locator('[data-inline-editor]');
+			await expect(editor).toBeVisible();
+			await editor.fill(body);
+			await source.click();
+			await expect(editor).toBeHidden();
+			await expect.poll(spacing).toBe(10);
+			await expect(target).toContainText('Last');
+			if (operation === 'middle insertion') {
+				await expect(target).toContainText('Inserted');
+			} else {
+				await expect(target).not.toContainText('First');
+			}
+			await page.keyboard.press('Control+z');
+			await expect(target).toContainText('First');
+			await expect(target).not.toContainText('Inserted');
+			await expect.poll(spacing).toBe(10);
+			await page.keyboard.press('Control+y');
+			await expect.poll(spacing).toBe(10);
+			if (operation === 'middle insertion') {
+				await expect(target).toContainText('Inserted');
+			} else {
+				await expect(target).not.toContainText('First');
+			}
+		});
+	}
+
 	test('resize: dragging the SE corner handle grows the shape, Ctrl+Z restores it', async ({
 		page,
 	}) => {

--- a/packages/angular/src/viewer/editor-state.service.test.ts
+++ b/packages/angular/src/viewer/editor-state.service.test.ts
@@ -1,7 +1,7 @@
 import type { PptxElement, PptxSlide } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
-import { SLIDE_TEMPLATES } from '../internal/shared';
+import { buildInlineTextCommitPatch, SLIDE_TEMPLATES } from '../internal/shared';
 import { EditorStateService } from './editor-state.service';
 
 function element(id: string, x = 0, y = 0): PptxElement {
@@ -32,6 +32,41 @@ function service(): EditorStateService {
 }
 
 describe('editorStateService', () => {
+	it.each(['First\nInserted\nLast', 'Last'])(
+		'keeps suffix spacing through the inline commit/history composition for %s',
+		(text) => {
+			const last = {
+				text: 'Last',
+				style: { color: '#006600' },
+				paragraphProperties: { paragraphSpacingAfter: 10 },
+			};
+			const target = {
+				...element('a'),
+				text: 'First\nLast',
+				textSegments: [
+					{ text: 'First', style: {}, paragraphProperties: { paragraphSpacingAfter: 20 } },
+					{ text: '\n', style: {}, isParagraphBreak: true },
+					last,
+				],
+			} as PptxElement;
+			const svc = new EditorStateService();
+			svc.setSlides([slide('s1', [target])]);
+			// The canvas controller composes this shared patch with updateElement.
+			svc.updateElement(0, 'a', buildInlineTextCommitPatch(target, text)!);
+			expect(svc.slides()[0].elements[0]).toMatchObject({
+				text,
+				textSegments: expect.arrayContaining([last]),
+			});
+			svc.undo();
+			expect(svc.slides()[0].elements[0]).toMatchObject({ text: 'First\nLast' });
+			svc.redo();
+			expect(svc.slides()[0].elements[0]).toMatchObject({
+				text,
+				textSegments: expect.arrayContaining([last]),
+			});
+		},
+	);
+
 	it('manages sections as undoable editor state', () => {
 		const svc = new EditorStateService();
 		svc.setSlides([slide('s1', []), slide('s2', []), slide('s3', [])]);

--- a/packages/core/src/core/core/index.ts
+++ b/packages/core/src/core/core/index.ts
@@ -38,6 +38,13 @@ export {
 } from './runtime/table-structural-ops';
 export { DEFAULT_POWERPOINT_TABLE_STYLE_ID } from './runtime/table-style-defaults';
 
+// Use the same list ordinals when authoring in a viewer as when parsing a deck.
+export {
+	createAutoNumberSequence,
+	nextAutoNumber,
+	breakAutoNumberRun,
+} from './runtime/auto-number-sequence';
+
 // Table-STYLE (ppt/tableStyles.xml) editing: create/delete a style entry on
 // a ParsedTableStyleMap, and the section-name vocabulary + GUID normaliser
 // needed to target one of the 13 CT_TableStyle parts (W3-E). Save-time

--- a/packages/react/src/viewer/hooks/useElementOperations.inline-edit-race.test.tsx
+++ b/packages/react/src/viewer/hooks/useElementOperations.inline-edit-race.test.tsx
@@ -65,10 +65,12 @@ interface Harness {
  * in-progress edit session where the user has typed past what `textSegments`
  * on the model still reflects.
  */
-function mount(inlineEditingElementId: string | null, inlineEditingText: string): Harness {
-	let slides: PptxSlide[] = [
-		{ id: 'slide-1', rId: 'rId2', slideNumber: 1, elements: [textElement()] },
-	];
+function mount(
+	inlineEditingElementId: string | null,
+	inlineEditingText: string,
+	element = textElement(),
+): Harness {
+	let slides: PptxSlide[] = [{ id: 'slide-1', rId: 'rId2', slideNumber: 1, elements: [element] }];
 	let latest: ElementOperations | undefined;
 
 	function Probe(): null {
@@ -104,6 +106,29 @@ function mount(inlineEditingElementId: string | null, inlineEditingText: string)
 }
 
 describe('updateSelectedTextStyle mid-edit race', () => {
+	it('preserves an unchanged suffix when Bold reconciles a pending paragraph insertion', () => {
+		const last = {
+			text: 'Last',
+			style: { color: '#006600' },
+			paragraphProperties: { paragraphSpacingAfter: 10 },
+		};
+		const element = {
+			...textElement(),
+			text: 'First\nLast',
+			textSegments: [
+				{ text: 'First', style: {}, paragraphProperties: { paragraphSpacingAfter: 20 } },
+				{ text: '\n', style: {}, isParagraphBreak: true },
+				last,
+			],
+		} as PptxElement;
+		const harness = mount('shape-1', 'First\nInserted\nLast', element);
+		act(() => harness.ops().updateSelectedTextStyle({ bold: true }));
+		expect(harness.slides()[0].elements[0]).toMatchObject({
+			text: 'First\nInserted\nLast',
+			textSegments: expect.arrayContaining([{ ...last, style: { ...last.style, bold: true } }]),
+		});
+	});
+
 	it('applies to the live typed text, not the stale model segments, while inline-editing', () => {
 		const harness = mount('shape-1', 'Hello there, world');
 		act(() => {

--- a/packages/react/src/viewer/utils/remap-text.test.ts
+++ b/packages/react/src/viewer/utils/remap-text.test.ts
@@ -26,6 +26,25 @@ function breakSeg(style: TextStyle = {}): TextSegment {
 // ---------------------------------------------------------------------------
 
 describe('remapTextToSegments', () => {
+	it.each(['First\nInserted\nLast', 'Last'])('keeps suffix metadata when committing %s', (text) => {
+		const last: TextSegment = {
+			text: 'Last',
+			style: { color: '#006600' },
+			bulletInfo: { char: '◆' },
+			paragraphProperties: { paragraphSpacingAfter: 10 },
+		};
+		const result = remapTextToSegments(
+			text,
+			[
+				{ text: 'First', style: {}, paragraphProperties: { paragraphSpacingAfter: 20 } },
+				breakSeg(),
+				last,
+			],
+			{},
+		);
+		expect(result.at(-1)).toStrictEqual(last);
+		expect(result.map((item) => item.text).join('')).toBe(text);
+	});
 	describe('fallback behaviour', () => {
 		it('should return single segment with fallback style when no original segments', () => {
 			const result = remapTextToSegments('Hello', undefined, { bold: true });

--- a/packages/shared/src/render/inline-text-commit.test.ts
+++ b/packages/shared/src/render/inline-text-commit.test.ts
@@ -1,7 +1,10 @@
-import type { PptxElement } from 'pptx-viewer-core';
+import type { PptxElement, TextSegment } from 'pptx-viewer-core';
 import { describe, expect, it } from 'vitest';
 
 import { buildInlineTextCommitPatch } from './inline-text-commit';
+import { applyAutoCorrect } from './options/autocorrect';
+import { DEFAULT_VIEWER_OPTIONS } from './options/viewer-options';
+import { buildParagraphs } from './text-paragraphs';
 
 function textElement(overrides: Partial<PptxElement> = {}): PptxElement {
 	return {
@@ -17,6 +20,51 @@ function textElement(overrides: Partial<PptxElement> = {}): PptxElement {
 }
 
 describe('buildInlineTextCommitPatch', () => {
+	it('preserves exact middle paragraphs when default AutoCorrect also changes the final body', () => {
+		const bodies = ['Roman parent third', 'Nested third', 'Nested fourth', '1. literal body'];
+		const levels = [0, 1, 1, 0];
+		const original: TextSegment[] = bodies.flatMap((body, index) => [
+			...(index ? [{ text: '\n', style: {}, isParagraphBreak: true }] : []),
+			{
+				text: body,
+				style: { fontSize: 22 },
+				paragraphLevel: levels[index],
+				bulletInfo: {
+					autoNumType: 'romanUcPeriod',
+					autoNumStartAt: 3,
+					paragraphIndex: index > 1 ? 1 : 0,
+				},
+				paragraphProperties: { paragraphSpacingAfter: 10 + index },
+			},
+		]);
+		const element = textElement({ text: bodies.join('\n'), textSegments: original });
+		const text = applyAutoCorrect(
+			[bodies[0], 'Inserted parent', ...bodies.slice(1)].join('\n'),
+			DEFAULT_VIEWER_OPTIONS.proofing,
+		);
+		expect(text).toContain('1. Literal body');
+		const patch = buildInlineTextCommitPatch(element, text)!;
+		const result = { ...element, ...patch };
+		const segments = result.textSegments!.filter((segment) => !segment.isParagraphBreak);
+		expect(segments.map((segment) => segment.paragraphLevel)).toStrictEqual([
+			0,
+			undefined,
+			1,
+			1,
+			0,
+		]);
+		expect(segments[2]).toStrictEqual(original[2]);
+		expect(segments[3]).toStrictEqual(original[4]);
+		expect(segments[4].paragraphProperties).toStrictEqual(original[6].paragraphProperties);
+		expect(buildParagraphs(result).map((paragraph) => paragraph.bulletMarker)).toStrictEqual([
+			'III.',
+			'IV.',
+			'III.',
+			'IV.',
+			'V.',
+		]);
+	});
+
 	it('skips an unchanged rich-text commit', () => {
 		const element = textElement({
 			text: 'Alpha Beta\nBulleted item',

--- a/packages/shared/src/render/remap-paragraph-sources.ts
+++ b/packages/shared/src/render/remap-paragraph-sources.ts
@@ -1,0 +1,92 @@
+import type { TextSegment } from 'pptx-viewer-core';
+
+import { isBulletMarkerSegment } from './bullet-toggle';
+import { withoutRenderedBulletPrefix } from './remap-text-bullets';
+
+export interface RemapSourceParagraph {
+	segments: TextSegment[];
+	terminator?: TextSegment;
+}
+
+function matches(text: string, paragraph: RemapSourceParagraph): boolean {
+	const first = paragraph.segments[0];
+	const marker =
+		first &&
+		isBulletMarkerSegment(first) &&
+		(!first.bulletInfo?.autoNumType || first.bulletInfo.paragraphIndex !== undefined)
+			? first
+			: undefined;
+	const body = paragraph.segments
+		.slice(marker ? 1 : 0)
+		.map((segment) => segment.text)
+		.join('');
+	return text === body || withoutRenderedBulletPrefix(text, paragraph.segments, marker) === body;
+}
+
+/**
+ * Preserve exact ordered paragraphs, matching duplicates from the ends first.
+ * Interior anchors also survive when AutoCorrect changes a separate paragraph.
+ * Gaps keep positional donors; extra paragraphs have no original metadata source.
+ * This infers no moves or case equivalence from plain editor text.
+ */
+export function alignParagraphSources(
+	texts: readonly string[],
+	original: readonly RemapSourceParagraph[],
+): Array<number | undefined> {
+	const sources: Array<number | undefined> = Array.from({ length: texts.length });
+	let prefix = 0;
+	while (
+		prefix < texts.length &&
+		prefix < original.length &&
+		matches(texts[prefix], original[prefix])
+	) {
+		sources[prefix] = prefix;
+		prefix += 1;
+	}
+	let oldEnd = original.length;
+	let newEnd = texts.length;
+	while (oldEnd > prefix && newEnd > prefix && matches(texts[newEnd - 1], original[oldEnd - 1])) {
+		sources[--newEnd] = --oldEnd;
+	}
+	const anchors: Array<[number, number]> = [];
+	const oldCount = oldEnd - prefix;
+	const newCount = newEnd - prefix;
+	// Bound quadratic work for unusually large text bodies. Their ambiguous
+	// middle retains positional behavior while exact prefix/suffix still work.
+	if (oldCount * newCount <= 10_000) {
+		const lengths = Array.from({ length: oldCount + 1 }, () => new Uint16Array(newCount + 1));
+		for (let old = oldCount - 1; old >= 0; old--) {
+			for (let next = newCount - 1; next >= 0; next--) {
+				lengths[old][next] = matches(texts[prefix + next], original[prefix + old])
+					? lengths[old + 1][next + 1] + 1
+					: Math.max(lengths[old + 1][next], lengths[old][next + 1]);
+			}
+		}
+		let old = 0;
+		let next = 0;
+		while (old < oldCount && next < newCount) {
+			if (matches(texts[prefix + next], original[prefix + old])) {
+				anchors.push([prefix + next++, prefix + old++]);
+			} else if (lengths[old + 1][next] >= lengths[old][next + 1]) {
+				// Ties discard the old candidate first, consistently with token diff.
+				old++;
+			} else {
+				next++;
+			}
+		}
+	}
+	anchors.push([newEnd, oldEnd]);
+	let oldCursor = prefix;
+	let newCursor = prefix;
+	for (const [newAnchor, oldAnchor] of anchors) {
+		while (oldCursor < oldAnchor && newCursor < newAnchor) {
+			sources[newCursor++] = oldCursor++;
+		}
+		if (newAnchor < newEnd) {
+			sources[newAnchor] = oldAnchor;
+		}
+		oldCursor = oldAnchor + 1;
+		newCursor = newAnchor + 1;
+	}
+	return sources;
+}

--- a/packages/shared/src/render/remap-text-bullets.ts
+++ b/packages/shared/src/render/remap-text-bullets.ts
@@ -1,7 +1,43 @@
 import type { TextSegment } from 'pptx-viewer-core';
+import { breakAutoNumberRun, createAutoNumberSequence, nextAutoNumber } from 'pptx-viewer-core';
 
 import { resolveParagraphBullet } from './bullet-list';
 import { isBulletMarkerSegment } from './bullet-toggle';
+import { isParagraphSeparatorSegment } from './text-segment-paragraph-break';
+
+/** Refresh only derived ordinals after existing paragraphs have moved. */
+export function renumberRemappedParagraphs(segments: TextSegment[]): TextSegment[] {
+	const sequence = createAutoNumberSequence();
+	let first = true;
+	return segments.map((segment) => {
+		const paragraphStart = first;
+		first = isParagraphSeparatorSegment(segment);
+		if (!paragraphStart) {
+			return segment;
+		}
+		const info = segment.bulletInfo;
+		const level = segment.paragraphLevel ?? 0;
+		if (!info?.autoNumType || !resolveParagraphBullet(segment)?.isNumbered) {
+			breakAutoNumberRun(sequence, level);
+			return segment;
+		}
+		const ordinal =
+			nextAutoNumber(sequence, level, info.autoNumType, info.autoNumStartAt ?? 1) -
+			(info.autoNumStartAt ?? 1);
+		// An unknown runtime index may accompany literal marker-like body text.
+		if (info.paragraphIndex === undefined || info.paragraphIndex === ordinal) {
+			return segment;
+		}
+		const updated = { ...segment, bulletInfo: { ...info, paragraphIndex: ordinal } };
+		if (isBulletMarkerSegment(segment)) {
+			const resolved = resolveParagraphBullet(updated);
+			if (resolved) {
+				updated.text = resolved.marker + (segment.text.match(/\s+$/u)?.[0] ?? '');
+			}
+		}
+		return updated;
+	});
+}
 
 /** Remove a display-only marker from editor text before remapping its content. */
 export function withoutRenderedBulletPrefix(

--- a/packages/shared/src/render/remap-text.test.ts
+++ b/packages/shared/src/render/remap-text.test.ts
@@ -1,7 +1,102 @@
+import JSZip from 'jszip';
+import { hasTextProperties, PptxHandler, PresentationBuilder } from 'pptx-viewer-core';
 import type { TextSegment, TextStyle } from 'pptx-viewer-core';
 import { describe, it, expect } from 'vitest';
 
 import { remapTextToSegments } from './remap-text';
+import { buildParagraphs } from './text-paragraphs';
+
+const asBuffer = (bytes: Uint8Array): ArrayBuffer =>
+	bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+
+async function paragraphXml(bytes: Uint8Array, body: string): Promise<string> {
+	const zip = await JSZip.loadAsync(bytes);
+	const xml = await zip.file('ppt/slides/slide1.xml')!.async('string');
+	const paragraph = [...xml.matchAll(/<a:p>[\s\S]*?<\/a:p>/gu)].find((match) =>
+		match[0].includes(`>${body}<`),
+	);
+	expect(paragraph, `missing native paragraph ${body}`).toBeDefined();
+	return paragraph![0].match(/<a:pPr\b[\s\S]*?<\/a:pPr>/u)?.[0] ?? '';
+}
+
+describe('remapped paragraph provenance save/reload', () => {
+	it.each([
+		['First\nInserted\nLast', false],
+		['Last', false],
+		['First\nInserted\nLast', true],
+		['Last', true],
+	] as const)(
+		'preserves surviving paragraph XML after %s (numbered=%s)',
+		async (text, numbered) => {
+			const { handler: seedHandler, data: seed, createSlide } = await PresentationBuilder.create();
+			const slide = createSlide('Blank')
+				.addText('First\nLast', { x: 40, y: 40, width: 300, height: 160 })
+				.build();
+			const element = slide.elements[0];
+			if (!hasTextProperties(element)) {
+				throw new Error('expected text');
+			}
+			const paragraph = (body: string, after: number): TextSegment => ({
+				text: body,
+				style: { fontSize: 20, fontFamily: 'Arial', color: '#CC6600' },
+				bulletInfo: {
+					...(numbered ? { autoNumType: 'romanUcPeriod', autoNumStartAt: 4 } : { char: '◆' }),
+					fontFamily: 'Arial',
+					color: '#CC6600',
+				},
+				paragraphLevel: 1,
+				paragraphProperties: {
+					paragraphSpacingBefore: 10,
+					paragraphSpacingAfter: after,
+					lineSpacing: 1.25,
+				},
+				endParaRunProperties: { '@_sz': '2000' },
+			});
+			element.textSegments = [
+				paragraph('First', 14),
+				{ text: '\n', style: {}, isParagraphBreak: true },
+				paragraph('Last', 5),
+			];
+			seed.slides.push(slide);
+			const initial = await seedHandler.save(seed.slides);
+			const handler = new PptxHandler();
+			const loaded = await handler.load(asBuffer(initial));
+			const source = loaded.slides[0].elements[0];
+			if (!hasTextProperties(source)) {
+				throw new Error('expected loaded text');
+			}
+			const sourceLast = source.textSegments?.find((segment) => segment.text === 'Last');
+			const edited = {
+				...source,
+				text,
+				textSegments: remapTextToSegments(text, source.textSegments, source.textStyle),
+			};
+			const saved = await handler.save([
+				{ ...loaded.slides[0], isDirty: true, elements: [edited] },
+			]);
+			const originalProperties = await paragraphXml(initial, 'Last');
+			expect(originalProperties).toContain('a:spcAft');
+			expect(originalProperties).toContain(numbered ? 'a:buAutoNum' : 'a:buChar');
+			await expect(paragraphXml(saved, 'Last')).resolves.toBe(originalProperties);
+			const reloaded = await new PptxHandler().load(asBuffer(saved));
+			const result = reloaded.slides[0].elements[0];
+			if (!hasTextProperties(result)) {
+				throw new Error('expected reloaded text');
+			}
+			expect(result.textSegments?.find((segment) => segment.text === 'Last')?.style).toStrictEqual(
+				sourceLast?.style,
+			);
+			const bodies = result.textSegments
+				?.filter((segment) => !segment.bulletInfo && segment.text !== '\n')
+				.map((segment) => segment.text);
+			expect(bodies).toStrictEqual(text.split('\n'));
+			expect(buildParagraphs(result).map((item) => item.bulletMarker)).toStrictEqual(
+				buildParagraphs(edited).map((item) => item.bulletMarker),
+			);
+		},
+		30_000,
+	);
+});
 
 function seg(text: string, style: TextStyle = {}): TextSegment {
 	return { text, style };
@@ -12,6 +107,237 @@ function breakSeg(style: TextStyle = {}): TextSegment {
 }
 
 describe('remapTextToSegments', () => {
+	describe('unchanged paragraph provenance', () => {
+		it('bounds interior alignment work and retains positional fallback for oversized ambiguous ranges', () => {
+			const source: TextSegment[] = Array.from({ length: 102 }, (_, index) => ({
+				text: `Body ${index}`,
+				style: {},
+				paragraphProperties: { paragraphSpacingAfter: index },
+			}));
+			const original = source.flatMap((item, index) => (index ? [breakSeg(), item] : [item]));
+			const edited = [
+				'Body 0',
+				'Inserted',
+				...source.slice(1, -1).map((item) => item.text),
+				'Changed end',
+			];
+			const result = remapTextToSegments(edited.join('\n'), original, {}).filter(
+				(item) => !item.isParagraphBreak,
+			);
+			expect(result.map((item) => item.text)).toStrictEqual(edited);
+			expect(result[0]).toStrictEqual(source[0]);
+			expect(result[1].paragraphProperties).toStrictEqual(source[1].paragraphProperties);
+			expect(result.at(-1)?.paragraphProperties).toBeUndefined();
+		});
+
+		const paragraph = (text: string, index: number): TextSegment =>
+			Object.freeze({
+				text,
+				style: Object.freeze({
+					fontSize: 18 + index,
+					color: index ? '#009900' : '#cc3300',
+					bold: Boolean(index),
+				}),
+				bulletInfo: Object.freeze({ char: index ? '◆' : '»', fontFamily: 'Arial' }),
+				paragraphLevel: index,
+				paragraphProperties: Object.freeze({
+					paragraphSpacingBefore: 6 + index,
+					paragraphSpacingAfter: 14 - index,
+					lineSpacing: 1.25,
+				}),
+				endParaRunProperties: Object.freeze({ '@_sz': String(1800 + index * 100) }),
+			});
+		const group = (segments: TextSegment[]) => {
+			const paragraphs: TextSegment[][] = [[]];
+			for (const segment of segments) {
+				if (segment.isParagraphBreak || segment.text === '\n') {
+					paragraphs.push([]);
+				} else {
+					paragraphs.at(-1)!.push(segment);
+				}
+			}
+			return paragraphs;
+		};
+
+		it('keeps an unchanged suffix after a middle insertion without donating its paragraph metadata', () => {
+			const first = paragraph('First', 0),
+				last = paragraph('Last', 1);
+			const result = group(
+				remapTextToSegments('First\nInserted\nLast', [first, breakSeg(), last], {}),
+			);
+			expect(result[0][0]).toStrictEqual(first);
+			expect(result[2][0]).toStrictEqual(last);
+			expect(result[1][0].paragraphProperties).toBeUndefined();
+			expect(result[1][0].endParaRunProperties).toBeUndefined();
+			expect(result[1][0].paragraphLevel).toBeUndefined();
+		});
+
+		it('keeps surviving rich paragraphs after deleting the first paragraph', () => {
+			const first = paragraph('First', 0),
+				last = paragraph('Last', 1);
+			expect(remapTextToSegments('Last', [first, breakSeg(), last], {})).toStrictEqual([last]);
+		});
+
+		it.each(['Fir\nst\nLast', 'Joined\nLast'])(
+			'keeps the suffix for split/join text %s',
+			(text) => {
+				const last = paragraph('Last', 2);
+				const source = text.startsWith('Joined')
+					? [paragraph('First', 0), breakSeg(), paragraph('Second', 1), breakSeg(), last]
+					: [paragraph('First', 0), breakSeg(), last];
+				expect(group(remapTextToSegments(text, source, {})).at(-1)![0]).toStrictEqual(last);
+			},
+		);
+
+		it('matches duplicate body text from the corresponding ends, not the first global match', () => {
+			const first = paragraph('Same', 0),
+				last = paragraph('Same', 1);
+			const result = group(
+				remapTextToSegments('Same\nInserted\nSame', [first, breakSeg(), last], {}),
+			);
+			expect(result[0][0]).toStrictEqual(first);
+			expect(result[2][0]).toStrictEqual(last);
+			// Deleting an indistinguishable duplicate retains the first prefix deterministically.
+			expect(remapTextToSegments('Same', [first, breakSeg(), last], {})).toStrictEqual([first]);
+		});
+
+		it('preserves a shifted empty paragraph whose metadata rides its terminator', () => {
+			const empty = { ...paragraph('\n', 2), isParagraphBreak: true };
+			const last = paragraph('Last', 1);
+			const source = [paragraph('First', 0), breakSeg(), empty, last];
+			const result = group(remapTextToSegments('First\nInserted\n\nLast', source, {}));
+			expect(result[2][0].paragraphProperties).toBe(empty.paragraphProperties);
+			expect(result[2][0].paragraphLevel).toBe(2);
+			expect(result[3][0]).toStrictEqual(last);
+		});
+
+		it('matches body text while retaining a proven dedicated display marker', () => {
+			const first = paragraph('First', 0),
+				last = paragraph('Last', 1);
+			const marker = { ...last, text: '◆ ' };
+			const body = { text: 'Last', style: { italic: true } };
+			const result = group(
+				remapTextToSegments('First\nInserted\nLast', [first, breakSeg(), marker, body], {}),
+			);
+			expect(result[2]).toStrictEqual([marker, body]);
+		});
+
+		it('keeps no-op and append-only noninheritance controls', () => {
+			const first = paragraph('First', 0),
+				last = paragraph('Last', 1);
+			const source = [first, breakSeg(first.style), last];
+			expect(remapTextToSegments('First\nLast', source, {})).toStrictEqual(source);
+			const appended = group(remapTextToSegments('First\nLast\nAppended', source, {}));
+			expect(appended[1][0]).toStrictEqual(last);
+			expect(appended[2][0].paragraphProperties).toBeUndefined();
+			expect(appended[2][0].endParaRunProperties).toBeUndefined();
+		});
+
+		it('keeps leading and trailing blank paragraph provenance', () => {
+			const leading = { ...paragraph('\n', 0), isParagraphBreak: true };
+			const trailing = paragraph('', 2);
+			const result = group(
+				remapTextToSegments('First\n', [leading, paragraph('First', 1), breakSeg(), trailing], {}),
+			);
+			expect(result[0][0]).toStrictEqual(paragraph('First', 1));
+			expect(result[1][0]).toStrictEqual(trailing);
+			const inserted = group(
+				remapTextToSegments('First\nInserted\n', [paragraph('First', 1), breakSeg(), trailing], {}),
+			);
+			expect(inserted[2][0]).toStrictEqual(trailing);
+		});
+
+		it('retains literal marker-like body text without a proven display-marker index', () => {
+			const literal = { ...paragraph('1.', 1), bulletInfo: { autoNumType: 'arabicPeriod' } };
+			const result = group(
+				remapTextToSegments(
+					'First\nInserted\n1.',
+					[paragraph('First', 0), breakSeg(), literal],
+					{},
+				),
+			);
+			expect(result[2][0]).toStrictEqual(literal);
+		});
+
+		it('does not treat a long middle insertion as an appended numbered continuation', () => {
+			const marker: TextSegment = {
+				text: 'IV.',
+				style: {},
+				paragraphLevel: 2,
+				bulletInfo: { autoNumType: 'romanUcPeriod', autoNumStartAt: 4, paragraphIndex: 0 },
+				paragraphProperties: { paragraphSpacingAfter: 12 },
+			};
+			const source = [paragraph('First', 0), breakSeg(), marker, seg('Last')];
+			const result = group(remapTextToSegments('First\nA\nB\nC\nLast', source, {}));
+			expect(result[4][0]).toStrictEqual(marker);
+			for (const [index, inserted] of result.slice(1, 4).entries()) {
+				expect(inserted[0].paragraphLevel).toBeUndefined();
+				expect(inserted[0].paragraphProperties).toBeUndefined();
+				expect(inserted[0].bulletInfo?.paragraphIndex).toBe(index);
+			}
+		});
+
+		it('renumbers a shifted suffix without changing its authored numbering or run metadata', () => {
+			const first: TextSegment = {
+				text: 'IV.',
+				style: { fontSize: 24 },
+				bulletInfo: { autoNumType: 'romanUcPeriod', autoNumStartAt: 4, paragraphIndex: 0 },
+			};
+			const last: TextSegment = {
+				...paragraph('V.', 0),
+				bulletInfo: { autoNumType: 'romanUcPeriod', autoNumStartAt: 4, paragraphIndex: 1 },
+			};
+			const source = [first, seg('First'), breakSeg(), last, seg('Last')];
+			const deleted = remapTextToSegments('Last', source, {});
+			expect(deleted[0]).toStrictEqual({
+				...last,
+				text: 'IV.',
+				bulletInfo: { ...last.bulletInfo, paragraphIndex: 0 },
+			});
+			const inserted = group(remapTextToSegments('First\nInserted\nLast', source, {}));
+			expect(inserted[2][0]).toStrictEqual({
+				...last,
+				text: 'VI.',
+				bulletInfo: { ...last.bulletInfo, paragraphIndex: 2 },
+			});
+			expect(source[3]).toBe(last);
+		});
+
+		it('does not count suppressed paragraphs in a surviving numbered sequence', () => {
+			const hidden: TextSegment = {
+				text: 'Suppressed',
+				style: { listType: 'none' },
+				bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 0 },
+			};
+			const marker: TextSegment = {
+				text: '2.',
+				style: {},
+				bulletInfo: { autoNumType: 'arabicPeriod', paragraphIndex: 1 },
+			};
+			const result = remapTextToSegments(
+				'Suppressed\nLast',
+				[seg('Heading'), breakSeg(), hidden, breakSeg(), marker, seg('Last')],
+				{},
+			);
+			expect(group(result)[1][0]).toStrictEqual({
+				...marker,
+				text: '1.',
+				bulletInfo: { ...marker.bulletInfo, paragraphIndex: 0 },
+			});
+			expect(result[0]).toStrictEqual(hidden);
+		});
+
+		it('keeps positional fallback in a wholly replaced ambiguous region', () => {
+			const first = paragraph('First', 0),
+				last = paragraph('Last', 1);
+			const result = group(
+				remapTextToSegments('New first\nNew last', [first, breakSeg(), last], {}),
+			);
+			expect(result[0][0]).toStrictEqual({ ...first, text: 'New first' });
+			expect(result[1][0]).toStrictEqual({ ...last, text: 'New last' });
+		});
+	});
+
 	describe('fallback behaviour', () => {
 		it('returns single segment with fallback style when no original segments', () => {
 			const result = remapTextToSegments('Hello', undefined, { bold: true });

--- a/packages/shared/src/render/remap-text.ts
+++ b/packages/shared/src/render/remap-text.ts
@@ -6,7 +6,12 @@
 import type { TextSegment, TextStyle } from 'pptx-viewer-core';
 
 import { isBulletMarkerSegment } from './bullet-toggle';
-import { continueAutoNumberedParagraph, withoutRenderedBulletPrefix } from './remap-text-bullets';
+import { alignParagraphSources } from './remap-paragraph-sources';
+import {
+	continueAutoNumberedParagraph,
+	renumberRemappedParagraphs,
+	withoutRenderedBulletPrefix,
+} from './remap-text-bullets';
 
 /**
  * Whether an original segment is ATOMIC: its rendered text is not what is
@@ -125,6 +130,7 @@ export function remapTextToSegments(
 	}
 
 	const newParagraphTexts = newText.split('\n');
+	const paragraphSources = alignParagraphSources(newParagraphTexts, originalParagraphs);
 
 	const firstContentSeg = originalParagraphs
 		.flatMap((paragraph) => paragraph.segments)
@@ -252,23 +258,32 @@ export function remapTextToSegments(
 
 	const output: TextSegment[] = [];
 	const lastOrigPara = originalParagraphs[originalParagraphs.length - 1]?.segments;
+	const lastSourceOffset = [...paragraphSources]
+		.reverse()
+		.findIndex((source) => source !== undefined);
+	const appendStart = Math.max(
+		originalParagraphs.length,
+		lastSourceOffset < 0 ? 0 : paragraphSources.length - lastSourceOffset,
+	);
 
 	for (let pi = 0; pi < newParagraphTexts.length; pi++) {
 		if (pi > 0) {
-			const precedingOrigPara = originalParagraphs[pi - 1]?.segments ?? [];
+			const precedingOrigPara = originalParagraphs[paragraphSources[pi - 1] ?? -1]?.segments ?? [];
 			const breakStyle = precedingOrigPara[0]?.style
 				? { ...precedingOrigPara[0].style }
 				: { ...baseFallbackStyle };
 			output.push({ text: '\n', style: breakStyle, isParagraphBreak: true });
 		}
 
-		const originalParagraph = originalParagraphs[pi];
+		const originalParagraph = originalParagraphs[paragraphSources[pi] ?? -1];
 		const origPara = originalParagraph?.segments ?? lastOrigPara ?? [];
 		let paraSegments = restoreParagraphMetadata(
 			originalParagraph?.segments[0] ?? originalParagraph?.terminator,
 			remapParagraph(newParagraphTexts[pi], origPara),
 		);
-		if (!originalParagraph) {
+		// Only true tail appends use the historical numbering continuation rule.
+		// An unmatched middle paragraph has no donor paragraph metadata.
+		if (!originalParagraph && pi >= appendStart) {
 			paraSegments = continueAutoNumberedParagraph(
 				paraSegments,
 				lastOrigPara ?? [],
@@ -278,5 +293,8 @@ export function remapTextToSegments(
 		output.push(...paraSegments);
 	}
 
+	if (paragraphSources.some((source, index) => source !== undefined && source !== index)) {
+		return renumberRemappedParagraphs(output);
+	}
 	return output.length > 0 ? output : [{ text: '', style: { ...baseFallbackStyle } }];
 }

--- a/packages/svelte/src/viewer/editor/editor-inline-autofit.svelte.test.ts
+++ b/packages/svelte/src/viewer/editor/editor-inline-autofit.svelte.test.ts
@@ -80,6 +80,39 @@ afterEach(() => {
 });
 
 describe('commitInlineText - spAutoFit editor resize', () => {
+	it.each(['First\nInserted\nLast', 'Last'])(
+		'preserves suffix spacing and history for %s',
+		(text) => {
+			const last = {
+				text: 'Last',
+				style: { color: '#006600' },
+				paragraphProperties: { paragraphSpacingAfter: 10 },
+			};
+			const editor = make();
+			editor.setSlides([
+				slide('a', [
+					shape('e1', {
+						text: 'First\nLast',
+						textStyle: {},
+						textSegments: [
+							{ text: 'First', style: {}, paragraphProperties: { paragraphSpacingAfter: 20 } },
+							{ text: '\n', style: {}, isParagraphBreak: true },
+							last,
+						],
+					}),
+				]),
+			]);
+			editor.commitInlineText('e1', text);
+			expect(editor.slides[0].elements[0]).toMatchObject({ text });
+			expect(editor.slides[0].elements[0].textSegments?.at(-1)).toStrictEqual(last);
+			editor.undo();
+			expect(editor.slides[0].elements[0]).toMatchObject({ text: 'First\nLast' });
+			editor.redo();
+			expect(editor.slides[0].elements[0]).toMatchObject({ text });
+			expect(editor.slides[0].elements[0].textSegments?.at(-1)).toStrictEqual(last);
+		},
+	);
+
 	it('grows the shape to the measured content height on commit', () => {
 		mountEditorNode();
 		stubScrollHeight(250);

--- a/packages/vanilla/src/viewer/editor/editor-operations-inline-autofit.test.ts
+++ b/packages/vanilla/src/viewer/editor/editor-operations-inline-autofit.test.ts
@@ -80,6 +80,40 @@ afterEach(() => {
 });
 
 describe('createEditorOps commitInlineText - spAutoFit editor resize', () => {
+	it.each(['First\nInserted\nLast', 'Last'])(
+		'preserves suffix spacing and history for %s',
+		(text) => {
+			const last = {
+				text: 'Last',
+				style: { color: '#006600' },
+				paragraphProperties: { paragraphSpacingAfter: 10 },
+			};
+			const { store, ops } = makeOps([
+				shape('e1', {
+					text: 'First\nLast',
+					textStyle: {},
+					textSegments: [
+						{ text: 'First', style: {}, paragraphProperties: { paragraphSpacingAfter: 20 } },
+						{ text: '\n', style: {}, isParagraphBreak: true },
+						last,
+					],
+				} as Partial<PptxElement>),
+			]);
+			ops.commitInlineText('e1', text);
+			expect(store.get().slides[0].elements[0]).toMatchObject({ text });
+			expect(store.get().slides[0].elements[0]).toMatchObject({
+				textSegments: expect.arrayContaining([last]),
+			});
+			ops.undo();
+			expect(store.get().slides[0].elements[0]).toMatchObject({ text: 'First\nLast' });
+			ops.redo();
+			expect(store.get().slides[0].elements[0]).toMatchObject({ text });
+			expect(store.get().slides[0].elements[0]).toMatchObject({
+				textSegments: expect.arrayContaining([last]),
+			});
+		},
+	);
+
 	it('grows the shape to the measured content height on commit', () => {
 		mountEditorNode();
 		stubScrollHeight(250);

--- a/packages/vue/src/viewer/composables/useInlineEditing.noop-commit.test.ts
+++ b/packages/vue/src/viewer/composables/useInlineEditing.noop-commit.test.ts
@@ -50,6 +50,32 @@ function useHarness(element: PptxElement): Harness {
 }
 
 describe('commitInlineEdit', () => {
+	it.each(['First\nInserted\nLast', 'Last'])(
+		'records one changed commit preserving suffix spacing for %s',
+		(text) => {
+			const last = {
+				text: 'Last',
+				style: { color: '#006600' },
+				paragraphProperties: { paragraphSpacingAfter: 10 },
+			};
+			const element = makeElement({
+				text: 'First\nLast',
+				textSegments: [
+					{ text: 'First', style: {}, paragraphProperties: { paragraphSpacingAfter: 20 } },
+					{ text: '\n', style: {}, isParagraphBreak: true },
+					last,
+				],
+			} as Partial<PptxElement>);
+			const { editing, updateElement } = useHarness(element);
+			editing.enterInlineEdit(element.id);
+			editing.updateInlineText(text);
+			editing.commitInlineEdit();
+			expect(updateElement).toHaveBeenCalledOnce();
+			expect(updateElement.mock.calls[0][1]).toMatchObject({ text });
+			expect(updateElement.mock.calls[0][1].textSegments.at(-1)).toStrictEqual(last);
+		},
+	);
+
 	it('records nothing when the text was not changed', () => {
 		const element = makeElement();
 		const { editing, updateElement } = useHarness(element);


### PR DESCRIPTION
## Problem

Inserting or deleting a paragraph before existing text can give the unchanged paragraphs their former neighbors' formatting. The shared remapper currently identifies paragraphs by array position, so an ordinary middle insertion can change following paragraph spacing and nested list levels.

## Change

- Match unchanged paragraphs in their existing order, retaining their own runs, paragraph properties and terminators.
- Keep exact prefix/suffix matches, with bounded interior exact matches for cases where AutoCorrect independently changes another paragraph. Ambiguous gaps retain positional donors; this does not infer arbitrary paragraph moves or case equivalence.
- Refresh derived numbering after a shift through the existing core sequence. Keep authored numbering schemes, starts, levels, suppression/picture precedence and literal numeric body text.
- Keep the existing policy from the earlier paragraph work: newly created paragraphs do not copy paragraph spacing or end properties. True tail appends retain the existing continuation path.

All five bindings use this shared remapper. The only core change is a seven-line export of the existing numbering sequence, identical to the prerequisite already included in #251.

## Validation

- 170 focused tests across shared and all five bindings, including changed inline commits, pending React toolbar edits, history, duplicate/empty paragraphs, custom markers, nested Roman numbering, suppression and bounded fallback.
- Four dirty-save/reload cases check paragraph properties and numbering in native XML.
- Actual browser insertion checks in React, Vue, Angular, Svelte and Vanilla. Fresh default-AutoCorrect nested-list checks in React, Vue and Angular produced III / IV / III / IV / V; Vue Undo/Redo restored both states.
- Angular uses its existing Shift+Enter insertion gesture; plain Enter still commits.
- Independent code review and separate screenshot/XML evidence review.
- Typechecks, Angular build, changed-file lint and formatting passed. Svelte retains five pre-existing warnings.
- Added two binding-neutral cases to the existing desktop manipulation spec, covering insertion/deletion and Undo/Redo. All ten new project cases are discovered. The full automated browser suite has not been run locally.

## Scope

This fixes committed paragraph provenance, not live marker painting or arbitrary rich-text paragraph reordering. Separate testing exposed an existing save-time font-size override on main; the same behavior occurs before and after this change and is being addressed separately. Native PowerPoint visual parity is not claimed by these tests.
