### PR TITLE
fix(core): preserve run styles after text-only edits

### DIFF
--- a/packages/core/src/__tests__/integration/inheritance-not-flattened-on-save.test.ts
+++ b/packages/core/src/__tests__/integration/inheritance-not-flattened-on-save.test.ts
@@ -22,9 +22,93 @@ import JSZip from 'jszip';
 import { describe, it, expect, beforeAll } from 'vitest';
 
 import { PptxHandler } from '../../core/PptxHandler';
+import { hasTextProperties } from '../../core/types';
 import { readCorpusFixture } from './real-world-corpus-helpers';
 
 const FIXTURE = 'animations-transitions-multislide.pptx';
+
+describe('text-only commits do not become element-level style edits', () => {
+	it.each([{}, { fontSize: 32 }, { color: '#FF0000' }, { bold: true }])(
+		'preserves native run formatting while honoring explicit edit %j',
+		async (styleEdit) => {
+			const {
+				handler: seedHandler,
+				data: seed,
+				createSlide,
+			} = await PptxHandler.createBlank({ initialSlideCount: 0 });
+			seed.slides.push(
+				createSlide('Blank')
+					.addText('Placeholder', { x: 40, y: 40, width: 300, height: 120 })
+					.build(),
+			);
+			const zip = await JSZip.loadAsync(await seedHandler.save(seed.slides));
+			const part = 'ppt/slides/slide1.xml';
+			const xml = await zip.file(part)!.async('string');
+			const paragraphs = ['First', 'Second']
+				.map(
+					(body) =>
+						'<a:p><a:pPr><a:buAutoNum type="romanUcPeriod" startAt="3"/></a:pPr>' +
+						'<a:r><a:rPr sz="1650"><a:solidFill><a:srgbClr val="123456"/></a:solidFill>' +
+						`<a:latin typeface="Arial"/></a:rPr><a:t>${body}</a:t></a:r><a:endParaRPr lang="en-US"/></a:p>`,
+				)
+				.join('');
+			zip.file(
+				part,
+				xml.replace(
+					/<p:txBody>[\s\S]*?<\/p:txBody>/u,
+					'<p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr>' +
+						'<a:solidFill><a:srgbClr val="123456"/></a:solidFill>' +
+						`</a:defRPr></a:lvl1pPr></a:lstStyle>${paragraphs}</p:txBody>`,
+				),
+			);
+			const source = await zip.generateAsync({ type: 'arraybuffer' });
+			const handler = new PptxHandler();
+			const data = await handler.load(source);
+			const element = data.slides[0].elements[0];
+			if (!hasTextProperties(element)) {
+				throw new Error('expected text element');
+			}
+			expect(element.textStyle?.fontSize).toBe(24);
+			// A plain-text commit preserves body run sizes and copies the previous
+			// paragraph's run size onto separators. This can make all segments
+			// uniform without editing the inherited element-level default at all.
+			const textSegments = element.textSegments!.map((segment) => ({
+				...segment,
+				text: segment.text === 'First' ? 'First edited' : segment.text,
+				style: { ...segment.style, fontSize: 22 },
+			}));
+			const edited = {
+				...element,
+				text: 'First edited\nSecond',
+				textSegments,
+				textStyle: { ...element.textStyle, ...styleEdit },
+			};
+			const saved = await handler.save([{ ...data.slides[0], isDirty: true, elements: [edited] }]);
+			const reloaded = await new PptxHandler().load(
+				saved.buffer.slice(saved.byteOffset, saved.byteOffset + saved.byteLength) as ArrayBuffer,
+			);
+			const result = reloaded.slides[0].elements[0];
+			if (!hasTextProperties(result)) {
+				throw new Error('expected reloaded text');
+			}
+			const bodies = result.textSegments!.filter(
+				(segment) => segment.text === 'First edited' || segment.text === 'Second',
+			);
+			expect(bodies.map((segment) => segment.text)).toStrictEqual(['First edited', 'Second']);
+			for (const body of bodies) {
+				expect(body.style).toMatchObject({
+					fontSize: 22,
+					fontFamily: 'Arial',
+					color: '#123456',
+					...styleEdit,
+				});
+			}
+			const savedXml = await partOf(saved, part);
+			expect(savedXml).toContain('First edited');
+			expect(savedXml).toContain(`sz="${'fontSize' in styleEdit ? '2400' : '1650'}"`);
+		},
+	);
+});
 
 /** Count non-overlapping occurrences of a literal token. */
 function count(haystack: string, needle: string): number {

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphHelpers.test.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveParagraphHelpers.test.ts
@@ -675,6 +675,61 @@ describe('assembleParagraphXml', () => {
 // computeUniformSegmentOverrides
 // ---------------------------------------------------------------------------
 describe('computeUniformSegmentOverrides', () => {
+	it.each([
+		['fontFamily', 'Calibri', 'Arial', 'Courier New'],
+		['fontSize', 24, 22, 32],
+		['bold', false, true, true],
+		['italic', false, true, true],
+		['underline', false, true, true],
+		['strikethrough', false, true, true],
+		['rtl', false, true, true],
+		[
+			'hyperlink',
+			'https://example.com/original',
+			'https://example.com/run',
+			'https://example.com/edited',
+		],
+		['color', '#000000', '#123456', '#FF0000'],
+		['align', 'left', 'center', 'right'],
+	] as const)(
+		'distinguishes inherited %s from a real element-level edit',
+		(key, inherited, run, edited) => {
+			const baseline = { [key]: inherited } as TextStyle;
+			const style = { ...baseline, inheritedRunStyle: baseline, authoredRunStyle: {} } as TextStyle;
+			const segments: TextSegment[] = [{ text: 'Edited body', style: { [key]: run } as TextStyle }];
+			expect(computeUniformSegmentOverrides(style, segments)[key]).toBeUndefined();
+			expect(computeUniformSegmentOverrides({ ...style, [key]: edited }, segments)[key]).toBe(
+				edited,
+			);
+		},
+	);
+
+	it('also recognizes an unchanged authored element value over its inherited baseline', () => {
+		const style: TextStyle = {
+			fontSize: 20,
+			inheritedRunStyle: { fontSize: 24 },
+			authoredRunStyle: { fontSize: 20 },
+		};
+		const segments: TextSegment[] = [{ text: 'Body', style: { fontSize: 18 } }];
+		expect(computeUniformSegmentOverrides(style, segments)).toStrictEqual({});
+		expect(computeUniformSegmentOverrides({ ...style, fontSize: 32 }, segments)).toStrictEqual({
+			fontSize: 32,
+		});
+	});
+
+	it('still preserves mixed runs after an actual parsed element-level edit', () => {
+		const style: TextStyle = {
+			fontSize: 32,
+			inheritedRunStyle: { fontSize: 24 },
+			authoredRunStyle: {},
+		};
+		const segments: TextSegment[] = [
+			{ text: 'A', style: { fontSize: 18 } },
+			{ text: 'B', style: { fontSize: 20 } },
+		];
+		expect(computeUniformSegmentOverrides(style, segments)).toStrictEqual({});
+	});
+
 	it('should return empty object when textStyle is undefined', () => {
 		const segments: TextSegment[] = [
 			{ text: 'a', style: { bold: true } },

--- a/packages/core/src/core/core/runtime/uniform-segment-overrides.ts
+++ b/packages/core/src/core/core/runtime/uniform-segment-overrides.ts
@@ -35,6 +35,14 @@ export function computeUniformSegmentOverrides(
 		if (nextValue === undefined) {
 			return;
 		}
+		// A parsed element's resolved default is not an editing command. Text
+		// commits can make run styles uniform while that default stays unchanged.
+		// Use the existing authored/inherited split to recognize actual edits;
+		// SDK-built styles without a baseline retain the legacy override behavior.
+		const baseline = textStyle?.inheritedRunStyle;
+		if (baseline && nextValue === (textStyle?.authoredRunStyle?.[styleKey] ?? baseline[styleKey])) {
+			return;
+		}
 		const firstValue = textSegments[0]?.style?.[styleKey];
 		const isUniform = textSegments.every((segment) => segment.style?.[styleKey] === firstValue);
 		if (isUniform) {


### PR DESCRIPTION
## Problem

A text-only edit can unexpectedly change a run's saved formatting. For example, a paragraph with authored 16.5pt text can become 18pt after typing, even though the editor's run model still holds the original size.

The uniform-run override channel compares current run styles to the element's resolved defaults. Once a text commit makes separator and body styles uniform, it mistakes an unchanged element default for a new formatting command.

## Minimal fix

Use the existing authored/inherited snapshot to skip values that have not changed since loading. This adds eight lines to the existing helper and applies to its ten existing style keys, not font size alone.

Actual element-level formatting edits still override uniform runs. Mixed formatting remains protected, and SDK-created styles without a parsed snapshot retain the existing behavior. This extends the provenance policy introduced in 6fb27675 rather than changing formatting precedence.

## Validation

- Eleven new helper expectations fail before the guard, covering all ten keys and authored-baseline precedence.
- Public load/edit/dirty-save/reload regression and explicit size/color/bold controls.
- 101 focused core tests pass, including existing paragraph serialization and inheritance tests; typecheck, lint and formatting pass.
- Actual React browser comparison against unmodified main: the same text edit saves all four authored runs as 1800 before, and retains 1650 after. Choosing 32pt explicitly still saves 3200.
- Independent code review and independent inspection of those browser-produced native files confirm paragraph levels, numbering, spacing and unrelated run properties are retained.

This is a core serialization fix inherited by all five bindings; no binding-specific behavior or UI is changed. Browser execution was performed in React, not separately in all five. Tests extend existing files; no temporary QA controls or fixtures are included.
