### PR TITLE
fix(core): save edited inherited placeholder transforms

### DIFF
--- a/packages/core/src/__tests__/integration/inheritance-not-flattened-on-save.test.ts
+++ b/packages/core/src/__tests__/integration/inheritance-not-flattened-on-save.test.ts
@@ -1,3 +1,4 @@
+import { XMLParser } from 'fast-xml-parser';
 /**
  * A save must write what the source AUTHORED, not what the loader RESOLVED.
  *
@@ -22,9 +23,264 @@ import JSZip from 'jszip';
 import { describe, it, expect, beforeAll } from 'vitest';
 
 import { PptxHandler } from '../../core/PptxHandler';
+import type { PptxElement } from '../../core/types';
 import { readCorpusFixture } from './real-world-corpus-helpers';
 
 const FIXTURE = 'animations-transitions-multislide.pptx';
+
+describe('edited inherited placeholder transforms', () => {
+	const fixture = 'master-layout-inheritance-fills.pptx';
+	const cases: Array<[string, (element: PptxElement) => Partial<PptxElement>]> = [
+		['move', (element) => ({ x: element.x + 40, y: element.y + 20 })],
+		['resize', (element) => ({ width: element.width + 80, height: element.height + 30 })],
+		['rotation', () => ({ rotation: 30 })],
+		['horizontal flip', () => ({ flipHorizontal: true })],
+		['vertical flip', () => ({ flipVertical: true })],
+		['zero width', () => ({ width: 0 })],
+		[
+			'move, resize, rotate and flip together',
+			() => ({ x: 200, y: 138, width: 1000, height: 251, rotation: 30, flipHorizontal: true }),
+		],
+	];
+
+	it('persists a picture placeholder edit without changing its inherited layout', async () => {
+		const zip = await JSZip.loadAsync(readCorpusFixture(fixture));
+		const images = await JSZip.loadAsync(readCorpusFixture('ole-embedded-media.pptx'));
+		const image = Object.keys(images.files).find((name) => /^ppt\/media\/.*\.png$/u.test(name))!;
+		expect(image).toBeDefined();
+		zip.file('ppt/media/inherited-picture.png', await images.file(image)!.async('uint8array'));
+		const slidePath = 'ppt/slides/slide1.xml';
+		const xml = await zip.file(slidePath)!.async('string');
+		const title = [...xml.matchAll(/<p:sp>[\s\S]*?<\/p:sp>/gu)].find((match) =>
+			match[0].includes('name="Title 1"'),
+		)?.[0];
+		expect(title).toBeDefined();
+		zip.file(
+			slidePath,
+			xml.replace(
+				title!,
+				'<p:pic><p:nvPicPr><p:cNvPr id="999" name="Inherited picture"/><p:cNvPicPr/><p:nvPr><p:ph type="ctrTitle"/></p:nvPr></p:nvPicPr><p:blipFill><a:blip r:embed="rIdInheritedPicture"/><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr/></p:pic>',
+			),
+		);
+		const relsPath = 'ppt/slides/_rels/slide1.xml.rels';
+		zip.file(
+			relsPath,
+			(await zip.file(relsPath)!.async('string')).replace(
+				'</Relationships>',
+				'<Relationship Id="rIdInheritedPicture" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/inherited-picture.png"/></Relationships>',
+			),
+		);
+		const contentTypes = await zip.file('[Content_Types].xml')!.async('string');
+		if (!contentTypes.includes('Extension="png"')) {
+			zip.file(
+				'[Content_Types].xml',
+				contentTypes.replace(
+					'</Types>',
+					'<Default Extension="png" ContentType="image/png"/></Types>',
+				),
+			);
+		}
+		const handler = new PptxHandler();
+		const data = await handler.load(await zip.generateAsync({ type: 'uint8array' }));
+		const target = data.slides[0].elements.find((element) => element.name === 'Inherited picture')!;
+		expect(target).toMatchObject({ type: 'picture', width: 960, x: 160 });
+		expect(target.rawXml?.['p:spPr']).toBe('');
+		target.x += 40;
+		target.width += 80;
+		target.rotation = 30;
+		data.slides[0].isDirty = true;
+		const saved = await handler.save(data.slides);
+		const reader = new PptxHandler();
+		const reloaded = await reader.load(saved);
+		expect(
+			reloaded.slides[0].elements.find((element) => element.name === 'Inherited picture'),
+		).toMatchObject({ x: 200, width: 1040, rotation: 30 });
+		const picture = reloaded.slides[0].elements.find(
+			(element) => element.name === 'Inherited picture',
+		)!;
+		picture.rotation = 45;
+		reloaded.slides[0].isDirty = true;
+		const rotated = await new PptxHandler().load(await reader.save(reloaded.slides));
+		expect(
+			rotated.slides[0].elements.find((element) => element.name === 'Inherited picture'),
+		).toMatchObject({ x: 200, width: 1040, rotation: 45 });
+	});
+
+	it.each(cases)('persists a %s without rewriting the layout', async (_name, patchFor) => {
+		const source = readCorpusFixture(fixture);
+		const handler = new PptxHandler();
+		const data = await handler.load(source);
+		const slide = data.slides[0];
+		const target = slide.elements.find((element) => element.name === 'Title 1')!;
+		expect(target, 'the committed fixture must contain its inherited title').toBeDefined();
+		expect(target.rawXml?.['p:spPr']).toBe('');
+		expect(target.width).toBeGreaterThan(0);
+		const patch = patchFor(target);
+		Object.assign(target, patch);
+		slide.isDirty = true;
+		const saved = await handler.save(data.slides);
+		const reloaded = await new PptxHandler().load(saved);
+		const actual = reloaded.slides[0].elements.find((element) => element.name === 'Title 1');
+		const parser = new XMLParser({ ignoreAttributes: false });
+		expect(parser.parse(await partOf(saved, 'ppt/slideLayouts/slideLayout1.xml'))).toStrictEqual(
+			parser.parse(await partOf(source, 'ppt/slideLayouts/slideLayout1.xml')),
+		);
+		expect(actual).toMatchObject(patch);
+	});
+
+	it.each([false, true])(
+		'preserves combined edits across saves (save rotation first=%s)',
+		async (saveRotationFirst) => {
+			const handler = new PptxHandler();
+			const data = await handler.load(readCorpusFixture(fixture));
+			const target = data.slides[0].elements.find((element) => element.name === 'Title 1')!;
+			target.rotation = 30;
+			data.slides[0].isDirty = true;
+			if (saveRotationFirst) {
+				await handler.save(data.slides);
+			}
+			const patch = {
+				x: 200,
+				y: 138,
+				width: 1000,
+				height: 251,
+				rotation: 30,
+				flipHorizontal: true,
+			};
+			Object.assign(target, patch);
+			const saved = await handler.save(data.slides);
+			const secondSave = await handler.save(data.slides);
+			for (const bytes of [saved, secondSave]) {
+				const reloaded = await new PptxHandler().load(bytes);
+				expect(
+					reloaded.slides[0].elements.find((element) => element.name === 'Title 1'),
+				).toMatchObject(patch);
+			}
+		},
+	);
+
+	it('resets inherited rotation and flips through repeated saves', async () => {
+		const zip = await JSZip.loadAsync(readCorpusFixture(fixture));
+		const layoutPath = 'ppt/slideLayouts/slideLayout1.xml';
+		const xml = await zip.file(layoutPath)!.async('string');
+		const title = [...xml.matchAll(/<p:sp>[\s\S]*?<\/p:sp>/gu)].find((match) =>
+			match[0].includes('type="ctrTitle"'),
+		)?.[0];
+		expect(title).toContain('<a:xfrm>');
+		zip.file(
+			layoutPath,
+			xml.replace(title!, title!.replace('<a:xfrm>', '<a:xfrm rot="2700000" flipH="1" flipV="1">')),
+		);
+		const handler = new PptxHandler();
+		const data = await handler.load(await zip.generateAsync({ type: 'uint8array' }));
+		const target = data.slides[0].elements.find((element) => element.name === 'Title 1')!;
+		expect(target).toMatchObject({ rotation: 45, flipHorizontal: true, flipVertical: true });
+		expect(target.rawXml?.['p:spPr']).toBe('');
+		// Autosave may already have materialized the override while it was true.
+		Object.assign(target, {
+			rotation: 45,
+			flipHorizontal: true,
+			flipVertical: true,
+			x: target.x + 1,
+		});
+		data.slides[0].isDirty = true;
+		await handler.save(data.slides);
+		Object.assign(target, { rotation: 0, flipHorizontal: false, flipVertical: false });
+		data.slides[0].isDirty = true;
+		const reader = new PptxHandler();
+		const reloaded = await reader.load(await handler.save(data.slides));
+		expect(reloaded.slides[0].elements.find((element) => element.name === 'Title 1')).toMatchObject(
+			{
+				rotation: 0,
+				flipHorizontal: false,
+				flipVertical: false,
+			},
+		);
+		reloaded.slides[0].isDirty = true;
+		const reopened = reloaded.slides[0].elements.find((element) => element.name === 'Title 1')!;
+		Object.assign(reopened, { flipHorizontal: true, flipVertical: true });
+		await reader.save(reloaded.slides);
+		Object.assign(reopened, { flipHorizontal: false, flipVertical: false });
+		const second = await new PptxHandler().load(await reader.save(reloaded.slides));
+		expect(second.slides[0].elements.find((element) => element.name === 'Title 1')).toMatchObject({
+			rotation: 0,
+			flipHorizontal: false,
+			flipVertical: false,
+		});
+	});
+
+	it.each([false, true])(
+		'does not mistake scaled group coordinates for an edit (text-only=%s)',
+		async (editText) => {
+			const zip = await JSZip.loadAsync(readCorpusFixture(fixture));
+			const slidePath = 'ppt/slides/slide1.xml';
+			const xml = await zip.file(slidePath)!.async('string');
+			const title = [...xml.matchAll(/<p:sp>[\s\S]*?<\/p:sp>/gu)].find((match) =>
+				match[0].includes('name="Title 1"'),
+			)?.[0];
+			expect(title).toBeDefined();
+			zip.file(
+				slidePath,
+				xml.replace(
+					title!,
+					`<p:grpSp><p:nvGrpSpPr><p:cNvPr id="999" name="Scaled group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="952500" y="952500"/><a:ext cx="12192000" cy="6858000"/><a:chOff x="0" y="0"/><a:chExt cx="6096000" cy="3429000"/></a:xfrm></p:grpSpPr>${title!}</p:grpSp>`,
+				),
+			);
+			const handler = new PptxHandler();
+			const data = await handler.load(await zip.generateAsync({ type: 'uint8array' }));
+			const group = data.slides[0].elements.find((element) => element.type === 'group');
+			expect(group?.type).toBe('group');
+			if (group?.type !== 'group') {
+				throw new Error('Expected group');
+			}
+			const target = group.children.find((element) => element.name === 'Title 1')!;
+			expect(target.rawXml?.['p:spPr']).toBe('');
+			expect(target.width).toBe(1920);
+			if (target.type !== 'shape' && target.type !== 'text') {
+				throw new Error('Expected text');
+			}
+			if (editText) {
+				target.text = 'Changed grouped text';
+				target.textSegments = [{ text: target.text, style: target.textStyle ?? {} }];
+			}
+			data.slides[0].isDirty = true;
+			const saved = await partOf(await handler.save(data.slides), slidePath);
+			const savedTitle = [...saved.matchAll(/<p:sp>[\s\S]*?<\/p:sp>/gu)].find((match) =>
+				match[0].includes('name="Title 1"'),
+			)?.[0];
+			if (editText) {
+				expect(savedTitle).toContain('Changed grouped text');
+			}
+			expect(savedTitle).not.toContain('<a:xfrm');
+		},
+	);
+
+	it.each([false, true])(
+		'keeps a placeholder inherited on a text-only=%s save',
+		async (editText) => {
+			const handler = new PptxHandler();
+			const data = await handler.load(readCorpusFixture(fixture));
+			const slide = data.slides[0];
+			const target = slide.elements.find((element) => element.name === 'Title 1')!;
+			expect(target.rawXml?.['p:spPr']).toBe('');
+			if (editText && (target.type === 'text' || target.type === 'shape')) {
+				target.text = 'Changed title text';
+				target.textSegments = [{ text: target.text, style: target.textStyle ?? {} }];
+			}
+			slide.isDirty = true;
+			const saved = await handler.save(data.slides);
+			const xml = await partOf(saved, 'ppt/slides/slide1.xml');
+			const title = [...xml.matchAll(/<p:sp>[\s\S]*?<\/p:sp>/gu)].find((match) =>
+				match[0].includes('name="Title 1"'),
+			)?.[0];
+			expect(title).toBeDefined();
+			expect(title).not.toContain('<a:xfrm');
+			if (editText) {
+				expect(title).toContain('Changed title text');
+			}
+		},
+	);
+});
 
 /** Count non-overlapping occurrences of a literal token. */
 function count(haystack: string, needle: string): number {

--- a/packages/core/src/core/core/builders/PptxElementTransformUpdater.test.ts
+++ b/packages/core/src/core/core/builders/PptxElementTransformUpdater.test.ts
@@ -215,6 +215,139 @@ describe('pptxElementTransformUpdater', () => {
 		expect((shape['p:spPr'] as XmlObject)['a:xfrm']).toBeUndefined();
 	});
 
+	it('materializes a changed inherited shape while keeping property siblings and native EMUs', () => {
+		const geometry = { '@_prst': 'rect' };
+		const shape: XmlObject = { 'p:nvSpPr': {}, 'p:spPr': { 'a:prstGeom': geometry } };
+		const element = makeElement({ x: 10, y: 20, width: 100, height: 100, yEmu: 190501 });
+		element.inheritedTransform = { x: 0, y: 20, width: 100, height: 100 };
+		const baseline = structuredClone(element.inheritedTransform);
+		updater.applyTransform(shape, structuredClone(element), EMU_PER_PX);
+		const properties = shape['p:spPr'] as XmlObject;
+		const transform = properties['a:xfrm'] as XmlObject;
+		expect(Object.keys(properties)).toStrictEqual(['a:xfrm', 'a:prstGeom']);
+		expect(properties['a:prstGeom']).toBe(geometry);
+		expect(transform['a:off']).toStrictEqual({ '@_x': '95250', '@_y': '190501' });
+		expect(element.inheritedTransform).toStrictEqual(baseline);
+	});
+
+	it('does not pin an inherited transform after an edit is undone', () => {
+		const shape: XmlObject = { 'p:nvSpPr': {}, 'p:spPr': '' };
+		const element = makeElement({ x: 10, rotation: 45, flipHorizontal: true });
+		element.inheritedTransform = {
+			x: element.x,
+			y: element.y,
+			width: element.width,
+			height: element.height,
+			rotation: 45,
+			flipHorizontal: true,
+		};
+		element.x += 20;
+		element.x -= 20;
+		element.rotation = 0;
+		element.rotation = 45;
+		element.flipHorizontal = false;
+		element.flipHorizontal = true;
+		updater.applyTransform(shape, element, EMU_PER_PX);
+		expect(shape['p:spPr']).toBe('');
+	});
+
+	it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
+		'does not materialize invalid width %s',
+		(width) => {
+			const shape: XmlObject = { 'p:nvSpPr': {}, 'p:spPr': '' };
+			const element = makeElement({ width });
+			element.inheritedTransform = { x: 0, y: 0, width: 100, height: 100 };
+			updater.applyTransform(shape, element, EMU_PER_PX);
+			expect(shape['p:spPr']).toBe('');
+		},
+	);
+
+	it('allows zero inherited extent without pinning it until another coordinate changes', () => {
+		const shape: XmlObject = { 'p:nvSpPr': {}, 'p:spPr': '' };
+		const element = makeElement({ width: 0 });
+		element.inheritedTransform = { x: 0, y: 0, width: 0, height: 100 };
+		updater.applyTransform(shape, element, EMU_PER_PX);
+		expect(shape['p:spPr']).toBe('');
+		element.x = 10;
+		updater.applyTransform(shape, element, EMU_PER_PX);
+		const transform = (shape['p:spPr'] as XmlObject)['a:xfrm'] as XmlObject;
+		expect(transform['a:ext']).toStrictEqual({ '@_cx': '0', '@_cy': '952500' });
+	});
+
+	it.each(['p:nvPicPr', 'p:nvGraphicFramePr', 'p:nvGrpSpPr'])(
+		'does not synthesize a shape transform for %s',
+		(envelope) => {
+			const shape: XmlObject = { [envelope]: {}, 'p:spPr': '' };
+			const element = makeElement({ x: 10 });
+			element.inheritedTransform = { x: 0, y: 0, width: 100, height: 100 };
+			updater.applyTransform(shape, element, EMU_PER_PX);
+			expect(shape['p:spPr']).toBe('');
+		},
+	);
+
+	it.each(['0', 'false'])(
+		'preserves an authored false flip override %s on repeated saves',
+		(flag) => {
+			const shape = makeShapeXml();
+			const transform = (shape['p:spPr'] as XmlObject)['a:xfrm'] as XmlObject;
+			transform['@_flipH'] = flag;
+			transform['@_flipV'] = flag;
+			updater.applyTransform(
+				shape,
+				makeElement({ flipHorizontal: false, flipVertical: false }),
+				EMU_PER_PX,
+			);
+			expect(transform['@_flipH']).toBe(flag);
+			expect(transform['@_flipV']).toBe(flag);
+		},
+	);
+
+	it.each(['p:nvSpPr', 'p:nvPicPr'])(
+		'keeps an explicit false override when clearing a %s placeholder flip',
+		(envelope) => {
+			const shape = makeShapeXml();
+			shape[envelope] = { 'p:nvPr': { 'p:ph': '' } };
+			const transform = (shape['p:spPr'] as XmlObject)['a:xfrm'] as XmlObject;
+			transform['@_flipH'] = '1';
+			transform['@_flipV'] = '1';
+			updater.applyTransform(
+				shape,
+				makeElement({ flipHorizontal: false, flipVertical: false }),
+				EMU_PER_PX,
+			);
+			expect(transform['@_flipH']).toBe('0');
+			expect(transform['@_flipV']).toBe('0');
+		},
+	);
+
+	it('retains the existing resize anchor when inherited rotation has not changed', () => {
+		const shape: XmlObject = { 'p:nvSpPr': {}, 'p:spPr': '' };
+		const element = makeElement({
+			x: 400,
+			y: 133,
+			width: 400,
+			height: 107,
+			rotation: 25,
+			xEmu: 3810000,
+			yEmu: 1270000,
+			widthEmu: 2540000,
+			heightEmu: 1016000,
+		});
+		element.inheritedTransform = { x: 400, y: 133, width: 267, height: 107, rotation: 25 };
+		updater.applyTransform(shape, element, EMU_PER_PX);
+		const transform = (shape['p:spPr'] as XmlObject)['a:xfrm'] as XmlObject;
+		expect(transform['a:off']).toStrictEqual({ '@_x': '3750505', '@_y': '1538363' });
+	});
+
+	it('does not add false flip attributes to an unchanged placeholder', () => {
+		const shape = makeShapeXml();
+		shape['p:nvSpPr'] = { 'p:nvPr': { 'p:ph': '' } };
+		const transform = (shape['p:spPr'] as XmlObject)['a:xfrm'] as XmlObject;
+		updater.applyTransform(shape, makeElement({}), EMU_PER_PX);
+		expect(transform['@_flipH']).toBeUndefined();
+		expect(transform['@_flipV']).toBeUndefined();
+	});
+
 	// ── Creates a:off / a:ext if missing ─────────────────────────────────
 
 	it('creates a:off and a:ext nodes if they are missing from xfrm', () => {

--- a/packages/core/src/core/core/builders/PptxElementTransformUpdater.ts
+++ b/packages/core/src/core/core/builders/PptxElementTransformUpdater.ts
@@ -1,8 +1,10 @@
 import type { PptxElement, XmlObject } from '../../types';
 import { resolveRotatedResizeOffset } from '../../utils/rotated-resize-anchor';
 import { resolveXfrmEmu } from '../../utils/xfrm-emu-resolution';
+import { xmlChild, xmlHasChild } from '../../utils/xml-access';
 import { resolveGroupChildBoxEmu } from '../runtime/group-tight-rewrap';
 import type { GroupChildSpaceOwner } from '../runtime/group-xfrm-preservation';
+import { materializeInheritedShapeTransform } from './inherited-shape-transform';
 
 export interface IPptxElementTransformUpdater {
 	applyTransform(
@@ -21,7 +23,11 @@ export class PptxElementTransformUpdater implements IPptxElementTransformUpdater
 		enclosingGroupChildSpace?: GroupChildSpaceOwner,
 	): void {
 		const transform = ((shape['p:spPr'] as XmlObject | undefined)?.['a:xfrm'] ||
-			shape['p:xfrm']) as XmlObject | undefined;
+			shape['p:xfrm'] ||
+			// A group's child geometry uses a different frame from the load-time baseline.
+			(!enclosingGroupChildSpace && materializeInheritedShapeTransform(shape, element))) as
+			| XmlObject
+			| undefined;
 		if (!transform) {
 			return;
 		}
@@ -76,8 +82,13 @@ export class PptxElementTransformUpdater implements IPptxElementTransformUpdater
 			// changed, this is a no-op and the naive result stands untouched.
 			const naiveOffX = resolveXfrmEmu(element.x, element.xEmu, emuPerPx);
 			const naiveOffY = resolveXfrmEmu(element.y, element.yEmu, emuPerPx);
+			// The old box cannot anchor a resize at a newly edited rotation. Keep
+			// this load-time comparison across saves, just like the original EMUs.
+			const rotationChanged =
+				element.inheritedTransform !== undefined &&
+				(element.inheritedTransform.rotation ?? 0) !== (element.rotation ?? 0);
 			const rotatedResize = resolveRotatedResizeOffset({
-				rotationDeg: element.rotation,
+				rotationDeg: rotationChanged ? undefined : element.rotation,
 				oldOffXEmu: element.xEmu,
 				oldOffYEmu: element.yEmu,
 				oldExtWidthEmu: element.widthEmu,
@@ -105,14 +116,26 @@ export class PptxElementTransformUpdater implements IPptxElementTransformUpdater
 		if (element.skewY !== undefined) {
 			transform['@_skewY'] = String(Math.round(element.skewY * 60000));
 		}
+		const nonVisual = xmlChild(shape, 'p:nvSpPr') ?? xmlChild(shape, 'p:nvPicPr');
+		const isPlaceholder = xmlHasChild(xmlChild(nonVisual, 'p:nvPr'), 'p:ph');
 		if (element.flipHorizontal) {
 			transform['@_flipH'] = '1';
-		} else {
+		} else if (
+			element.inheritedTransform?.flipHorizontal ||
+			(isPlaceholder && transform['@_flipH'] !== undefined && transform['@_flipH'] !== 'false')
+		) {
+			transform['@_flipH'] = '0';
+		} else if (transform['@_flipH'] !== '0' && transform['@_flipH'] !== 'false') {
 			delete transform['@_flipH'];
 		}
 		if (element.flipVertical) {
 			transform['@_flipV'] = '1';
-		} else {
+		} else if (
+			element.inheritedTransform?.flipVertical ||
+			(isPlaceholder && transform['@_flipV'] !== undefined && transform['@_flipV'] !== 'false')
+		) {
+			transform['@_flipV'] = '0';
+		} else if (transform['@_flipV'] !== '0' && transform['@_flipV'] !== 'false') {
 			delete transform['@_flipV'];
 		}
 	}

--- a/packages/core/src/core/core/builders/inherited-shape-transform.ts
+++ b/packages/core/src/core/core/builders/inherited-shape-transform.ts
@@ -1,0 +1,47 @@
+import type { PptxElement, XmlObject } from '../../types';
+import { xmlChild } from '../../utils/xml-access';
+
+const NUMERIC_KEYS = ['x', 'y', 'width', 'height', 'rotation', 'skewX', 'skewY'] as const;
+
+/** Materialize only an edited inherited p:sp/p:pic transform, not an unchanged placeholder. */
+export function materializeInheritedShapeTransform(
+	shape: XmlObject,
+	element: PptxElement,
+): XmlObject | undefined {
+	const baseline = element.inheritedTransform;
+	const envelope =
+		element.type === 'text' || element.type === 'shape'
+			? 'p:nvSpPr'
+			: element.type === 'picture' || element.type === 'media'
+				? 'p:nvPicPr'
+				: undefined;
+	if (!baseline || !envelope || !xmlChild(shape, envelope)) {
+		return undefined;
+	}
+	if (
+		(['x', 'y', 'width', 'height'] as const).some(
+			(key) => !Number.isFinite(element[key]) || !Number.isFinite(baseline[key]),
+		) ||
+		NUMERIC_KEYS.some(
+			(key) => !Number.isFinite(element[key] ?? 0) || !Number.isFinite(baseline[key] ?? 0),
+		) ||
+		element.width < 0 ||
+		element.height < 0 ||
+		baseline.width < 0 ||
+		baseline.height < 0
+	) {
+		return undefined;
+	}
+	const changed =
+		NUMERIC_KEYS.some((key) => (element[key] ?? 0) !== (baseline[key] ?? 0)) ||
+		Boolean(element.flipHorizontal) !== Boolean(baseline.flipHorizontal) ||
+		Boolean(element.flipVertical) !== Boolean(baseline.flipVertical);
+	if (!changed) {
+		return undefined;
+	}
+	const transform: XmlObject = {};
+	const properties = { ...xmlChild(shape, 'p:spPr') };
+	delete properties['a:xfrm'];
+	shape['p:spPr'] = { 'a:xfrm': transform, ...properties };
+	return transform;
+}

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimePictureParsing.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimePictureParsing.ts
@@ -80,6 +80,10 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			const skewX = xfrm['@_skewX'] ? parseEmuInt(xfrm['@_skewX']) / 60000 : undefined;
 			const skewY = xfrm['@_skewY'] ? parseEmuInt(xfrm['@_skewY']) / 60000 : undefined;
 			const { flipHorizontal, flipVertical } = this.readFlipState(xfrm);
+			const inheritedTransform =
+				!spPr?.['a:xfrm'] && off && ext
+					? { x, y, width, height, rotation, skewX, skewY, flipHorizontal, flipVertical }
+					: undefined;
 
 			// ── Check if this picture is actually a video/audio placeholder ──
 			const nvPr = (pic?.['p:nvPicPr'] as XmlObject | undefined)?.['p:nvPr'] as
@@ -168,6 +172,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 				return {
 					id,
 					type: 'media',
+					inheritedTransform,
 					x,
 					y,
 					width,
@@ -427,6 +432,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 				id,
 				name: picElementName || undefined,
 				type: 'picture',
+				inheritedTransform,
 				x,
 				y,
 				width,

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParsing.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeShapeParsing.ts
@@ -57,11 +57,9 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			// Exact EMU alongside the rounded pixel value, for `resolveXfrmEmu`
 			// (xfrm-emu-resolution.ts) to re-emit byte-identical `a:off`/`a:ext`
 			// on save when this shape has not moved/resized. `off`/`ext` here
-			// are the EFFECTIVE (placeholder-merged) transform, but the save
-			// writer only ever patches THIS shape's own `a:xfrm` (a no-op when
-			// it has none), so a value inherited from a layout/master is
-			// harmless to record: it is never written unless the slide shape
-			// already carries its own `a:xfrm` to patch.
+			// are the EFFECTIVE (placeholder-merged) transform. A shape with no
+			// own a:xfrm keeps a scalar baseline below: only an actual transform
+			// edit may turn its inherited geometry into a slide-level override.
 			const xEmu = parseInt(xmlAttr(off, 'x') || '0');
 			const yEmu = parseInt(xmlAttr(off, 'y') || '0');
 			const widthEmu = parseInt(xmlAttr(ext, 'cx') || '0');
@@ -403,6 +401,10 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 				skewY,
 				flipHorizontal,
 				flipVertical,
+				inheritedTransform:
+					!spPr?.['a:xfrm'] && xfrm && off && ext
+						? { x, y, width, height, rotation, skewX, skewY, flipHorizontal, flipVertical }
+						: undefined,
 				actionClick,
 				actionHover,
 				locks,

--- a/packages/core/src/core/types/collaboration-field-schema.ts
+++ b/packages/core/src/core/types/collaboration-field-schema.ts
@@ -62,6 +62,7 @@ export const ELEMENT_FIELD_KIND: Record<AnyElementKey, CollabFieldKind> = {
 	hidden: 'scalar',
 	opacity: 'scalar',
 	rawXml: 'complex',
+	inheritedTransform: 'complex',
 	actionClick: 'complex',
 	actionHover: 'complex',
 	locks: 'complex',

--- a/packages/core/src/core/types/element-base.ts
+++ b/packages/core/src/core/types/element-base.ts
@@ -107,6 +107,19 @@ export interface PptxElementBase {
 	widthEmu?: number;
 	/** The exact EMU integer `height` was parsed from (`a:ext/@_cy`). See {@link xEmu}. */
 	heightEmu?: number;
+	/** Resolved load-time transform for a shape with no own a:xfrm. Used only to detect edits. */
+	inheritedTransform?: Pick<
+		PptxElementBase,
+		| 'x'
+		| 'y'
+		| 'width'
+		| 'height'
+		| 'rotation'
+		| 'skewX'
+		| 'skewY'
+		| 'flipHorizontal'
+		| 'flipVertical'
+	>;
 	rotation?: number;
 	/** Skew along the X axis in degrees (parsed from `@_skewX` in 1/60000ths of a degree). */
 	skewX?: number;

--- a/packages/shared/src/render/collaboration-sync.test.ts
+++ b/packages/shared/src/render/collaboration-sync.test.ts
@@ -57,6 +57,26 @@ function roundTripSlide(slide: PptxSlide): PptxSlide {
 }
 
 describe('collaboration-sync: element field coverage', () => {
+	it('keeps the inherited transform baseline when a peer receives an edited placeholder', () => {
+		const element: PptxElement = {
+			type: 'shape',
+			id: 'placeholder',
+			x: 40,
+			y: 20,
+			width: 100,
+			height: 100,
+			inheritedTransform: {
+				x: 0,
+				y: 20,
+				width: 100,
+				height: 100,
+				rotation: 45,
+				flipHorizontal: true,
+			},
+		};
+		expect(roundTripElement(element)).toStrictEqual(element);
+	});
+
 	it('round-trips OLE fields, including binary payloads via the asset map', () => {
 		const ole: PptxElement = {
 			type: 'ole',

--- a/packages/shared/src/render/collaboration-sync.ts
+++ b/packages/shared/src/render/collaboration-sync.ts
@@ -225,6 +225,7 @@ export const COMPLEX_ELEMENT_FIELDS: Readonly<Record<string, string>> = {
 	children: '_ch',
 	paragraphIndents: '_pi',
 	rawXml: '_rx',
+	inheritedTransform: '_it',
 	extLstXml: '_elx',
 	actionClick: '_ac',
 	actionHover: '_av',


### PR DESCRIPTION
## What does this change?

Save geometry edits to top-level shape and picture placeholders that inherit
their transform from a layout or master and have no own `a:xfrm`. Moving or
resizing these elements currently changes the editor but is lost on save/reload.

- Capture the resolved load-time transform only for elements without their own
  transform, then create an override only when that geometry actually changes.
- Leave unchanged and text-only edits inherited, preserving the distinction
  between authored and resolved values used by the existing save pipeline.
- Preserve placeholder flip overrides through save/reopen/flip cycles, without
  changing ordinary shapes' existing cleared-flip behavior.
- Do not apply the old rotated-box resize correction at a different rotation
  from the captured inherited baseline. This covers the combined move, resize,
  rotate and flip case and repeated saves without changing the existing
  COM-verified resize helper.
- Carry the baseline through the existing collaboration field codec.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

This is a core parse/save fix, not a new UI control. All five bindings use this
core serialization path; no binding-specific implementation is added. Actual
browser validation was performed in React. The other four browser demos were
not run for this PR.

## Testing

- [x] Regression tests fail before the corresponding fixes.
- [x] 127 core tests pass across nine focused suites, including existing
  rotated-resize COM goldens, exact EMU precision, nested groups, template
  edits, themed placeholders, and picture-shaped media controls.
- [x] 19 shared collaboration codec tests pass.
- [x] Core TypeScript check and changed-file lint/format checks pass.
- [x] Actual browser edit -> public `getContent()` -> native PPTX -> reopen
  validation passes for the inherited title and picture fixtures.

The title regression uses the existing PowerPoint-authored
`master-layout-inheritance-fills.pptx` corpus fixture. The picture case is a
synthetic native package assembled from existing committed fixture parts.
Coverage includes isolated and combined geometry edits, repeated saves,
rotation-only save followed by resize, inherited true flips reset to false,
zero width, invalid geometry, untouched layout XML, and no-op/text-only saves.

The full monorepo test suite and Playwright runner were not run. The generated
files were reloaded through the library and browser, not opened in native
PowerPoint. Temporary browser QA controls are not included in this PR.

## Scope boundaries

- Missing transforms on grouped children remain untouched. Their coordinates
  are remapped after parsing, so using the top-level baseline would incorrectly
  flatten an unchanged placeholder. No-op and text-only group regressions
  protect that boundary; this PR does not add grouped-placeholder editing.
- This does not redefine the existing rotated-resize contract for elements
  that already have their own transform. A separate control reproduced drift
  for an arbitrary combined move/resize/rotation on that existing path. Final
  geometry alone does not identify the edit sequence, so that broader behavior
  is not changed by guessing an anchor or disabling the helper globally.

Feedback on those boundaries is welcome, especially if a different contract is
preferred for combining explicit position changes with resize operations.
