### PR TITLE
fix(react): record click-away text edits in history

### DIFF
--- a/packages/react/src/viewer/hooks/pointer-up-handlers.ts
+++ b/packages/react/src/viewer/hooks/pointer-up-handlers.ts
@@ -136,6 +136,11 @@ export function processPointerUp(input: UsePointerHandlersInput): void {
 
 	if (wasMoved) {
 		markDirty();
+	}
+	// Pointer-down can commit text before arming a selection drag or marquee.
+	// Wake history after clearing that interaction even when the pointer stayed
+	// still; its document comparison rejects clicks that changed nothing.
+	if (drag || rs || adj || marquee) {
 		setPointerCommitNonce((n) => n + 1);
 	}
 }

--- a/packages/react/src/viewer/hooks/useViewerBuildingBlocks.test.ts
+++ b/packages/react/src/viewer/hooks/useViewerBuildingBlocks.test.ts
@@ -26,6 +26,7 @@ import type { ViewerBuildingBlocksResult } from './useViewerBuildingBlocks';
 let fixtureBytes: Uint8Array;
 let twoSlideFixtureBytes: Uint8Array;
 let embeddedFixtureBytes: Uint8Array;
+let textEditingFixtureBytes: Uint8Array;
 
 const { autosaveInputs } = vi.hoisted(() => ({ autosaveInputs: [] as UseAutosaveInput[] }));
 
@@ -52,6 +53,18 @@ beforeAll(async () => {
 	embeddedFixtureBytes = await oneSlide.handler.save(oneSlide.data.slides, {
 		embeddedFonts: [{ name: 'Sample Font', dataUrl: '', rawFontData, format: 'truetype' }],
 	});
+	oneSlide.data.slides[0].elements = ['First body', 'Second body'].map((text, index) => ({
+		id: `text-${index}`,
+		type: 'text',
+		text,
+		x: 20,
+		y: 20 + index * 100,
+		width: 250,
+		height: 80,
+		textStyle: { fontSize: 24 },
+	}));
+	oneSlide.data.slides[0].isDirty = true;
+	textEditingFixtureBytes = await oneSlide.handler.save(oneSlide.data.slides);
 	oneSlide.handler.dispose();
 
 	const twoSlides = await PptxHandler.create({
@@ -173,6 +186,131 @@ describe('useViewerBuildingBlocks', () => {
 			}
 		}
 	}, 30_000);
+
+	it.each(['click-away', 'explicit-commit', 'click-away-after-undo'] as const)(
+		'records an inline text change after %s without needing another document edit',
+		async (commit) => {
+			const handle = createRef<PowerPointViewerHandle>();
+			await act(async () =>
+				root.render(React.createElement(Harness, { content: textEditingFixtureBytes, handle })),
+			);
+			await flushUntil(() => latest?.loading === false);
+			expect(latest?.loading).toBeFalsy();
+			const [first, second] = handle.current!.getElements();
+			expect(handle.current!.canUndo()).toBeFalsy();
+			if (commit === 'click-away-after-undo') {
+				await act(async () => {
+					handle.current!.updateElement(first.id, { x: first.x + 10 });
+				});
+				expect(handle.current!.canUndo()).toBeTruthy();
+				await act(async () => {
+					handle.current!.undo();
+				});
+				await flush();
+				expect(handle.current!.canRedo()).toBeTruthy();
+			}
+			await act(async () =>
+				latest!.canvasProps.onDoubleClick(
+					first.id,
+					new MouseEvent('dblclick') as unknown as React.MouseEvent,
+				),
+			);
+			await act(async () => latest!.canvasProps.onInlineEditChange('First body edited'));
+			if (commit !== 'explicit-commit') {
+				await act(async () =>
+					latest!.canvasProps.onMouseDown(
+						second.id,
+						new MouseEvent('mousedown', {
+							button: 0,
+							clientX: 30,
+							clientY: 130,
+						}) as unknown as React.MouseEvent,
+					),
+				);
+				// Pointerup is a separate native event: allow the history effect to
+				// observe the pending selection drag first. No pointermove occurs.
+				await act(async () => {
+					document.dispatchEvent(new Event('pointerup'));
+				});
+			} else {
+				await act(async () => latest!.canvasProps.onInlineEditCommit());
+			}
+			await flush();
+			const edited = handle.current!.getElementById(first.id);
+			expect(edited?.type === 'text' && edited.text).toBe('First body edited');
+			expect(latest!.canvasProps.inlineEditingElementId).toBeNull();
+			expect(handle.current!.canRedo()).toBeFalsy();
+			expect(handle.current!.canUndo()).toBeTruthy();
+			await act(async () => handle.current!.undo());
+			const restored = handle.current!.getElementById(first.id);
+			expect(restored?.type === 'text' && restored.text).toBe('First body');
+		},
+	);
+
+	it('does not dirty the document or create history for selection or unrelated pointerup', async () => {
+		const handle = createRef<PowerPointViewerHandle>();
+		await act(async () => {
+			root.render(React.createElement(Harness, { content: textEditingFixtureBytes, handle }));
+		});
+		await flushUntil(() => latest?.loading === false);
+		expect(latest?.loading).toBeFalsy();
+		const [first] = handle.current!.getElements();
+		await act(async () => {
+			latest!.canvasProps.onMouseDown(
+				first.id,
+				new MouseEvent('mousedown', { button: 0 }) as unknown as React.MouseEvent,
+			);
+		});
+		await act(async () => {
+			document.dispatchEvent(new Event('pointerup'));
+		});
+		await act(async () => {
+			document.dispatchEvent(new Event('pointerup'));
+		});
+		expect(handle.current!.getElementById(first.id)).toStrictEqual(first);
+		expect(handle.current!.isDirty()).toBeFalsy();
+		expect(handle.current!.canUndo()).toBeFalsy();
+		expect(handle.current!.canRedo()).toBeFalsy();
+	});
+
+	it('coalesces multiple real drag frames into one undo step on pointerup', async () => {
+		const handle = createRef<PowerPointViewerHandle>();
+		await act(async () => {
+			root.render(React.createElement(Harness, { content: textEditingFixtureBytes, handle }));
+		});
+		await flushUntil(() => latest?.loading === false);
+		expect(latest?.loading).toBeFalsy();
+		const [first] = handle.current!.getElements();
+		await act(async () => {
+			latest!.canvasProps.onMouseDown(
+				first.id,
+				new MouseEvent('mousedown', {
+					button: 0,
+					clientX: 20,
+					clientY: 20,
+				}) as unknown as React.MouseEvent,
+			);
+		});
+		for (const x of [50, 90]) {
+			await act(async () => {
+				document.dispatchEvent(new MouseEvent('pointermove', { clientX: x, clientY: 50 }));
+				await new Promise<void>((resolve) => {
+					requestAnimationFrame(() => resolve());
+				});
+			});
+			expect(handle.current!.canUndo()).toBeFalsy();
+		}
+		await act(async () => {
+			document.dispatchEvent(new Event('pointerup'));
+		});
+		expect(handle.current!.getElementById(first.id)?.x).not.toBe(first.x);
+		expect(handle.current!.canUndo()).toBeTruthy();
+		await act(async () => {
+			handle.current!.undo();
+		});
+		expect(handle.current!.getElementById(first.id)).toStrictEqual(first);
+		expect(handle.current!.canUndo()).toBeFalsy();
+	});
 
 	it('loads a real PPTX buffer and produces working toolbar/canvas props', async () => {
 		await act(async () => {


### PR DESCRIPTION
## What does this change?

Make a text edit undoable when it is committed by clicking another shape or the blank canvas.

Pointer-down commits the pending text and starts a selection drag or marquee. React's history effect correctly waits while that interaction is active. Previously a pointer-up with no movement cleared the interaction but did not wake history, so the committed text could be missing from Undo until another document edit. After an earlier Undo, the new text edit could also leave stale Redo available.

The fix wakes history after an actual pointer interaction finishes, including a stationary click. It does not mark stationary clicks dirty: the existing document comparison rejects unchanged snapshots. Unrelated document pointer-up events do not wake history. Real drags still commit one history step.

## Why this approach?

This preserves the author's active-pointer snapshot deferral, cheap hash gate, and `justInteractedRef` protection against a drag's trailing click opening the text editor (`1c617883`). The production change is five added lines in the existing pointer-up handler; it does not replace history or alter click-to-edit behavior.

## Cross-binding parity

React's full viewer and headless building blocks share the affected pointer-up handler and effect-based history. Source inspection of all four other bindings found synchronous inline-commit history: Vue updates through its operation transaction, Angular through its editor state service, and Svelte/Vanilla explicitly push history before mutation. None uses this deferred pointer-ref/nonce mechanism, so this fix is React-specific. Actual browser comparison was React only.

## Testing

- Regression reproduced first on unchanged main `cefe90bd`: click-away updated text but left Undo disabled; the explicit-commit control passed.
- Existing building-block tests use real PPTX loading, public handles, canvas callbacks, and separate document pointer events.
- Controls cover click-away Undo, stale Redo invalidation, no-op selection and unrelated pointer-up, and multiple live drag frames producing one Undo step.
- 46 tests passed independently before rebase; 47 pass after rebasing onto main `3808156f`, retaining the newly merged embedded-font regression. These cover the existing building-block, history content-edit, pointer-up, and pointer-move suites. Changed-file formatting, deny-warnings lint and diff checks pass. The full monorepo suite was not run; the test environment emits unrelated Google Fonts/CORS warnings.
- Actual React browser comparison: baseline click-away failed, while Cmd+Enter worked. With the fix, both another-shape and blank-canvas click-away enable Undo; Undo restores original text and Redo restores the committed edit. The blank-canvas check was repeated with AutoSave off and confirmed actual background deselection.
- Independent code/test and screenshot/artifact review. Browser operation was performed by the primary reviewer, not independently by both reviewers.

This does not change PPTX serialization or claim native PowerPoint validation. Temporary preview configuration and dependencies are not included.
