### PR TITLE
fix(shared): preserve cloned group connector attachments

### DIFF
--- a/packages/core/src/__tests__/integration/authored-handout-package-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/authored-handout-package-roundtrip.test.ts
@@ -8,6 +8,58 @@ import type { PptxHandoutMaster } from '../../core/types';
 const HANDOUT_PATH = 'ppt/handoutMasters/handoutMaster1.xml';
 
 describe('authored handout master package round-trip', () => {
+	it.each(['notesMaster', 'handoutMaster'] as const)(
+		'preserves %s native identities through no-op and edited saves',
+		async (kind) => {
+			const created = await PresentationBuilder.create({ initialSlideCount: 1 });
+			created.data.slides[0].notes = 'Notes master fixture';
+			const seed = await created.handler.save(created.data.slides, {
+				handoutMaster: { path: HANDOUT_PATH },
+			});
+			const zip = await JSZip.loadAsync(seed);
+			const partPath = kind === 'notesMaster' ? 'ppt/notesMasters/notesMaster1.xml' : HANDOUT_PATH;
+			const part = await zip.file(partPath)!.async('string');
+			const transform =
+				'<a:xfrm><a:off x="95250" y="95250"/><a:ext cx="952500" cy="952500"/></a:xfrm>';
+			const shape = `<p:sp><p:nvSpPr><p:cNvPr id="41" name="Native target"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr>${
+				transform
+			}<a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:sp>`;
+			const connector = `<p:cxnSp><p:nvCxnSpPr><p:cNvPr id="42" name="Native connection"/><p:cNvCxnSpPr><a:stCxn id="41" idx="1"/></p:cNvCxnSpPr><p:nvPr/></p:nvCxnSpPr><p:spPr>${
+				transform
+			}<a:prstGeom prst="straightConnector1"><a:avLst/></a:prstGeom></p:spPr></p:cxnSp>`;
+			zip.file(partPath, part.replace('</p:spTree>', `${shape + connector}</p:spTree>`));
+			const bytes = await zip.generateAsync({ type: 'uint8array' });
+			const handler = new PptxHandler();
+			const data = await handler.load(
+				bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+			);
+			const master = data[kind]!;
+			const target = master.elements?.find((element) => element.name === 'Native target');
+			expect(target?.shapeId).toBe('41');
+			const options = { [kind]: master };
+			const untouched = await handler.save(data.slides, options);
+			const untouchedNative = await (
+				await JSZip.loadAsync(untouched)
+			)
+				.file(partPath)!
+				.async('string');
+			expect(untouchedNative).toContain('id="41" name="Native target"');
+			expect(untouchedNative).toContain('id="42" name="Native connection"');
+			expect(untouchedNative).toContain('<a:stCxn id="41" idx="1"');
+			if (!target) {
+				throw new Error('expected native target');
+			}
+			target.x += 10;
+			const edited = await handler.save(data.slides, options);
+			const native = await (await JSZip.loadAsync(edited)).file(partPath)!.async('string');
+			expect(native).toContain('id="41" name="Native target"');
+			expect(native).toContain('id="42" name="Native connection"');
+			expect(native).toContain('<a:stCxn id="41" idx="1"');
+			handler.dispose();
+			created.handler.dispose();
+		},
+	);
+
 	it('creates and preserves the complete handout master OPC graph', async () => {
 		const { handler, data, createSlide } = await PresentationBuilder.create();
 		data.slides.push(createSlide('Blank').build());

--- a/packages/core/src/__tests__/integration/template-group-editing-roundtrip.test.ts
+++ b/packages/core/src/__tests__/integration/template-group-editing-roundtrip.test.ts
@@ -135,6 +135,40 @@ function slideGroup(slide: { elements: PptxElement[] }): GroupPptxElement {
 }
 
 describe('template group editing round-trip', () => {
+	it('keeps loaded layout native IDs and numeric connector targets when editing a group', async () => {
+		const zip = await JSZip.loadAsync(await buildDeckWithLayoutGroup());
+		const xml = await zip.file(LAYOUT_PATH)!.async('string');
+		zip.file(
+			LAYOUT_PATH,
+			xml.replace(
+				'<p:cNvCxnSpPr/>',
+				'<p:cNvCxnSpPr><a:stCxn id="201" idx="3"/><a:endCxn id="203" idx="1"/></p:cNvCxnSpPr>',
+			),
+		);
+		const bytes = await zip.generateAsync({ type: 'uint8array' });
+		const handler = new PptxHandler();
+		const data = await handler.load(
+			bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer,
+		);
+		const layout = data.slideMasters![0].layouts!.find((entry) => entry.path === LAYOUT_PATH)!;
+		const group = layout.elements?.find((element) => element.type === 'group');
+		if (!group) {
+			throw new Error('expected native layout group');
+		}
+		expect(group.shapeId).toBe('200');
+		expect(group.children[0].shapeId).toBe('201');
+		group.name = 'Edited layout group';
+		const saved = await handler.save(data.slides, { slideMasters: data.slideMasters });
+		const tree = layoutSpTree(await savedPart(saved, LAYOUT_PATH));
+		const nativeGroup = groupNode(tree)!;
+		expect((nativeGroup['p:nvGrpSpPr'] as XmlObject)['p:cNvPr']['@_id']).toBe('200');
+		expect(
+			asArray(nativeGroup['p:cxnSp'])[0]['p:nvCxnSpPr']['p:cNvCxnSpPr']['a:stCxn']['@_id'],
+		).toBe('201');
+		expect(asArray(nativeGroup['p:sp'])[0]['p:nvSpPr']['p:cNvPr']['@_id']).toBe('201');
+		handler.dispose();
+	});
+
 	it('writes a moved + retyped layout group back into the layout part', async () => {
 		const handler = new PptxHandler();
 		const data = await handler.load(await buildDeckWithLayoutGroup());

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeAuxiliaryMasterElements.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeAuxiliaryMasterElements.ts
@@ -1,3 +1,4 @@
+import { reconcileAnimationTargets } from '../../services';
 /**
  * @fileoverview Shape-tree parsing for the four "template" parts whose
  * artwork the Slide Master view renders and edits: `p:notesMaster`,
@@ -119,6 +120,8 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 		} finally {
 			this.currentSlideClrMapOverride = previousClrMapOverride;
 		}
+		// Keep native identities just as the slide loader does, before editing can clone them.
+		reconcileAnimationTargets(part.elements, undefined, undefined);
 		rememberMasterPartElementSignature(this, partPath, part.elements);
 		this.rememberUnparsedMasterNodes(partPath, spTree, part.elements);
 	}

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveElementEmbedding.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveElementEmbedding.ts
@@ -27,6 +27,7 @@ import { PptxHandlerRuntime as PptxHandlerRuntimeBase } from './PptxHandlerRunti
 
 /** Context passed to per-element save processing. */
 export interface SaveSlideContext {
+	readonly connectorShapeIds?: ReadonlyMap<string, string>;
 	readonly slide: PptxSlide;
 	readonly slideRelationships: XmlObject[];
 	readonly slideRelationshipRegistry: IPptxSlideRelationshipRegistry;

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveElementWriter.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveElementWriter.ts
@@ -1,3 +1,4 @@
+import { applyConnectorShapeIds } from '../../services';
 import { hasShapeProperties, hasTextProperties } from '../../types';
 import type {
 	XmlObject,
@@ -711,6 +712,9 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 		this.applyDataSerialization(shape, el, ctx.slide.id);
 
 		// Actions and locks
+		if (ctx.connectorShapeIds) {
+			applyConnectorShapeIds(shape, el, ctx.connectorShapeIds);
+		}
 		this.serializeElementActions(shape, el, ctx.resolveHyperlinkRelationshipId);
 		this.serializeShapeLocks(shape, el);
 

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveMasterElements.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveMasterElements.ts
@@ -1,3 +1,4 @@
+import { resolveConnectorShapeIds } from '../../services';
 import type {
 	PptxElement,
 	PptxSlide,
@@ -128,6 +129,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 			elements,
 		};
 		const ctx: SaveSlideContext = {
+			connectorShapeIds: resolveConnectorShapeIds(elements, this.maxCnvPrId(spTree)),
 			slide,
 			slideRelationships: relationships,
 			slideRelationshipRegistry: relationshipRegistry,

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveShapeXml.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveShapeXml.ts
@@ -126,7 +126,10 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 	): XmlObject | null {
 		// If the group still has rawXml and children haven't changed, reuse it
 		if (group.rawXml && group.children.length === 0) {
-			return group.rawXml;
+			return {
+				...group.rawXml,
+				'p:nvGrpSpPr': buildGroupNonVisualXml(group.rawXml, group.name, group.id, group.shapeId),
+			};
 		}
 
 		const EMU = PptxHandlerRuntime.EMU_PER_PX;
@@ -145,7 +148,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 		const childSpace: GroupChildSpaceOwner = group;
 
 		const grpXml: XmlObject = {
-			'p:nvGrpSpPr': buildGroupNonVisualXml(rawGroupXml, group.name, group.id),
+			'p:nvGrpSpPr': buildGroupNonVisualXml(rawGroupXml, group.name, group.id, group.shapeId),
 			'p:grpSpPr': buildGroupPropertiesXml(rawGroupXml, xfrm),
 		};
 		const rawExtLst = rawGroupXml?.['p:extLst'];

--- a/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveSlideWriter.ts
+++ b/packages/core/src/core/core/runtime/PptxHandlerRuntimeSaveSlideWriter.ts
@@ -1,4 +1,4 @@
-import { remapEditorAnimationsToShapeIds } from '../../services';
+import { remapEditorAnimationsToShapeIds, resolveConnectorShapeIds } from '../../services';
 import { writeCommonSlideDataName } from '../../services/slide-name';
 import { XmlObject, PptxComment, PptxSlide } from '../../types';
 import type { MediaPptxElement, PptxElementAnimation } from '../../types';
@@ -406,6 +406,7 @@ export class PptxHandlerRuntime extends PptxHandlerRuntimeBase {
 		};
 
 		const ctx: SaveSlideContext = {
+			connectorShapeIds: resolveConnectorShapeIds(slide.elements, this.maxCnvPrId(spTree)),
 			slide,
 			slideRelationships,
 			slideRelationshipRegistry,

--- a/packages/core/src/core/core/runtime/save-group-shape-xml.ts
+++ b/packages/core/src/core/core/runtime/save-group-shape-xml.ts
@@ -151,17 +151,21 @@ export function buildGroupNonVisualXml(
 	rawGroupXml: XmlObject | undefined,
 	modelName: string | undefined,
 	fallbackName: string,
+	modelShapeId?: string,
 ): XmlObject {
 	const rawNv = rawGroupXml?.['p:nvGrpSpPr'] as XmlObject | undefined;
 	if (!rawNv) {
 		return {
-			'p:cNvPr': { '@_id': '0', '@_name': modelName ?? fallbackName },
+			'p:cNvPr': { '@_id': modelShapeId ?? '0', '@_name': modelName ?? fallbackName },
 			'p:cNvGrpSpPr': {},
 			'p:nvPr': {},
 		};
 	}
 	const nv = cloneXmlNode(rawNv);
 	const cNvPr = (nv['p:cNvPr'] as XmlObject | undefined) ?? {};
+	if (modelShapeId !== undefined) {
+		cNvPr['@_id'] = modelShapeId;
+	}
 	if (typeof cNvPr['@_id'] !== 'string' || cNvPr['@_id'].length === 0) {
 		cNvPr['@_id'] = '0';
 	}

--- a/packages/core/src/core/services/animation-shape-id-assign.test.ts
+++ b/packages/core/src/core/services/animation-shape-id-assign.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { PptxElement, PptxElementAnimation } from '../types';
 import { remapEditorAnimationsToShapeIds } from './animation-shape-id-assign';
+import { applyConnectorShapeIds, resolveConnectorShapeIds } from './connector-shape-id-assign';
 
 function el(id: string, shapeId?: string): PptxElement {
 	return {
@@ -75,5 +76,100 @@ describe('remapEditorAnimationsToShapeIds', () => {
 		const anims: PptxElementAnimation[] = [{ elementId: 'group-child', entrance: 'fadeIn' }];
 		const out = remapEditorAnimationsToShapeIds([group], anims);
 		expect(out[0].elementId).toBe('6');
+	});
+});
+
+describe('connector native shape IDs', () => {
+	it('shares the native ID space with animation targets and leaves unknown references intact', () => {
+		const target = el('target');
+		const animated = el('animated');
+		const connector: PptxElement = {
+			type: 'connector',
+			id: 'connector',
+			x: 0,
+			y: 0,
+			width: 10,
+			height: 0,
+			shapeStyle: {
+				connectorStartConnection: { shapeId: 'target', connectionSiteIndex: 2 },
+				connectorEndConnection: { shapeId: 'foreign', connectionSiteIndex: 3 },
+			},
+		};
+		const elements = [connector, target, animated];
+		const animation = remapEditorAnimationsToShapeIds(elements, [{ elementId: 'animated' }], 8);
+		const ids = resolveConnectorShapeIds(elements, 8);
+		expect(animation[0].elementId).toBe('9');
+		expect(ids.get('target')).toBe('11');
+		expect(ids.has('foreign')).toBeFalsy();
+		expect(connector.shapeStyle?.connectorStartConnection?.shapeId).toBe('target');
+		expect(resolveConnectorShapeIds(elements, 8)).toStrictEqual(ids);
+		expect(
+			resolveConnectorShapeIds([el('target'), { ...connector, shapeId: undefined }], 1).get(
+				'target',
+			),
+		).toBe('2');
+	});
+
+	it('preserves opaque XML and unrepresented endpoint data while updating represented bindings', () => {
+		const shape = {
+			'p:nvCxnSpPr': {
+				'p:cNvCxnSpPr': {
+					'a:cxnSpLocks': { '@_noMove': '1' },
+					'a:stCxn': { '@_id': '2', '@_idx': '0', '@_extension': 'keep' },
+					'a:endCxn': { '@_unrepresented': 'keep' },
+				},
+			},
+		};
+		const connector: PptxElement = { type: 'connector', id: 'c', x: 0, y: 0, width: 10, height: 0 };
+		const original = structuredClone(shape);
+		applyConnectorShapeIds(shape, connector, new Map());
+		expect(shape).toStrictEqual(original);
+		connector.shapeStyle = {
+			connectorStartConnection: { shapeId: 'target', connectionSiteIndex: 3 },
+		};
+		applyConnectorShapeIds(shape, connector, new Map([['target', '12']]));
+		expect(shape['p:nvCxnSpPr']['p:cNvCxnSpPr']).toStrictEqual({
+			...original['p:nvCxnSpPr']['p:cNvCxnSpPr'],
+			'a:stCxn': { '@_id': '12', '@_idx': '3', '@_extension': 'keep' },
+		});
+	});
+
+	it('does not write unresolved runtime IDs and inserts new endpoints before extensions', () => {
+		const shape = {
+			'p:nvCxnSpPr': {
+				'p:cNvCxnSpPr': {
+					'a:cxnSpLocks': { '@_noMove': '1' },
+					'a:endCxn': { '@_id': '7', '@_idx': '0' },
+					'a:extLst': { 'a:ext': { '@_uri': 'retained' } },
+				},
+			},
+		};
+		const connector: PptxElement = {
+			type: 'connector',
+			id: 'c',
+			x: 0,
+			y: 0,
+			width: 10,
+			height: 0,
+			rawXml: structuredClone(shape),
+			shapeStyle: {
+				connectorStartConnection: { shapeId: 'target', connectionSiteIndex: 3 },
+				connectorEndConnection: { shapeId: 'unresolved', connectionSiteIndex: 2 },
+			},
+		};
+		applyConnectorShapeIds(shape, connector, new Map([['target', '12']]));
+		expect(shape['p:nvCxnSpPr']['p:cNvCxnSpPr']['a:endCxn']).toStrictEqual({
+			'@_id': '7',
+			'@_idx': '0',
+		});
+		expect(Object.keys(shape['p:nvCxnSpPr']['p:cNvCxnSpPr'])).toStrictEqual([
+			'a:cxnSpLocks',
+			'a:stCxn',
+			'a:endCxn',
+			'a:extLst',
+		]);
+		delete connector.rawXml;
+		applyConnectorShapeIds(shape, connector, new Map([['target', '12']]));
+		expect(shape['p:nvCxnSpPr']['p:cNvCxnSpPr']).not.toHaveProperty('a:endCxn');
 	});
 });

--- a/packages/core/src/core/services/animation-shape-id-assign.ts
+++ b/packages/core/src/core/services/animation-shape-id-assign.ts
@@ -17,30 +17,7 @@
  * @module services/animation-shape-id-assign
  */
 import type { PptxElement, PptxElementAnimation } from '../types';
-
-/** Flatten an element tree (following group children) into a single list. */
-function flattenElements(elements: readonly PptxElement[], out: PptxElement[]): void {
-	for (const el of elements) {
-		out.push(el);
-		if (el.type === 'group' && Array.isArray(el.children)) {
-			flattenElements(el.children, out);
-		}
-	}
-}
-
-/** Largest numeric `shapeId` currently present across all elements. */
-function maxShapeId(elements: readonly PptxElement[]): number {
-	let max = 0;
-	for (const el of elements) {
-		if (el.shapeId !== undefined) {
-			const n = Number.parseInt(el.shapeId, 10);
-			if (Number.isFinite(n) && n > max) {
-				max = n;
-			}
-		}
-	}
-	return max;
-}
+import { createShapeIdResolver } from './shape-id-resolver';
 
 /**
  * Remap a slide's editor animations so their shape references use native cNvPr
@@ -61,28 +38,7 @@ export function remapEditorAnimationsToShapeIds(
 	animations: readonly PptxElementAnimation[],
 	reservedMaxId: number = 0,
 ): PptxElementAnimation[] {
-	const flat: PptxElement[] = [];
-	flattenElements(elements, flat);
-
-	const byId = new Map<string, PptxElement>();
-	for (const el of flat) {
-		byId.set(el.id, el);
-	}
-
-	let nextId = Math.max(maxShapeId(flat), reservedMaxId) + 1;
-
-	/** Resolve an `element.id` reference to a native cNvPr id, minting if needed. */
-	const resolve = (elementId: string): string | undefined => {
-		const el = byId.get(elementId);
-		if (!el) {
-			return undefined;
-		}
-		if (el.shapeId === undefined) {
-			el.shapeId = String(nextId);
-			nextId += 1;
-		}
-		return el.shapeId;
-	};
+	const resolve = createShapeIdResolver(elements, reservedMaxId);
 
 	return animations.map((anim) => {
 		const resolvedElement = resolve(anim.elementId);

--- a/packages/core/src/core/services/connector-shape-id-assign.ts
+++ b/packages/core/src/core/services/connector-shape-id-assign.ts
@@ -1,0 +1,76 @@
+import type { PptxElement, XmlObject } from '../types';
+import { xmlChild } from '../utils/xml-access';
+import { reorderObjectKeys } from '../utils/xml-reorder';
+import { createShapeIdResolver } from './shape-id-resolver';
+
+/**
+ * Assign missing native identities before any shape is serialized, then map
+ * runtime references without changing the canvas model's connector bindings.
+ * Allocating only targets lets an earlier unreferenced shape take their IDs.
+ */
+export function resolveConnectorShapeIds(
+	elements: readonly PptxElement[],
+	reservedMaxId: number,
+): Map<string, string> {
+	const resolve = createShapeIdResolver(elements, reservedMaxId);
+	const result = new Map<string, string>();
+	const visit = (element: PptxElement): void => {
+		const nativeId = resolve(element.id);
+		if (nativeId !== undefined) {
+			result.set(element.id, nativeId);
+		}
+		if (element.type === 'group') {
+			element.children.forEach(visit);
+		}
+	};
+	elements.forEach(visit);
+	return result;
+}
+
+/** Update only represented connector bindings, leaving unknown native endpoint data alone. */
+export function applyConnectorShapeIds(
+	shape: XmlObject,
+	element: PptxElement,
+	nativeIds: ReadonlyMap<string, string>,
+): void {
+	if (element.type !== 'connector' || !element.shapeStyle) {
+		return;
+	}
+	const nv = xmlChild(shape, 'p:nvCxnSpPr');
+	if (!nv) {
+		return;
+	}
+	const connections = xmlChild(nv, 'p:cNvCxnSpPr') ?? {};
+	for (const [tag, reference] of [
+		['a:stCxn', element.shapeStyle.connectorStartConnection],
+		['a:endCxn', element.shapeStyle.connectorEndConnection],
+	] as const) {
+		if (!reference?.shapeId) {
+			continue;
+		}
+		const nativeId =
+			nativeIds.get(reference.shapeId) ??
+			(/^\d+$/.test(reference.shapeId) ? reference.shapeId : undefined);
+		if (nativeId === undefined) {
+			// Do not replace an authored endpoint with an unresolved runtime ID.
+			// Newly fabricated connectors have no native endpoint to preserve.
+			if (!element.rawXml) {
+				delete connections[tag];
+			}
+			continue;
+		}
+		connections[tag] = {
+			...xmlChild(connections, tag),
+			'@_id': nativeId,
+			'@_idx': String(reference.connectionSiteIndex ?? 0),
+		};
+	}
+	if (Object.keys(connections).length > 0) {
+		nv['p:cNvCxnSpPr'] = reorderObjectKeys(connections, [
+			'a:cxnSpLocks',
+			'a:stCxn',
+			'a:endCxn',
+			'a:extLst',
+		]);
+	}
+}

--- a/packages/core/src/core/services/index.ts
+++ b/packages/core/src/core/services/index.ts
@@ -37,6 +37,7 @@ export {
 } from './PptxEditorAnimationService';
 export { reconcileAnimationTargets } from './animation-target-reconcile';
 export { remapEditorAnimationsToShapeIds } from './animation-shape-id-assign';
+export { resolveConnectorShapeIds, applyConnectorShapeIds } from './connector-shape-id-assign';
 export { mergeNativeSoundIntoEditorAnimations } from './animation-sound-merge';
 export {
 	PptxNativeAnimationService,

--- a/packages/core/src/core/services/shape-id-resolver.ts
+++ b/packages/core/src/core/services/shape-id-resolver.ts
@@ -1,0 +1,34 @@
+import type { PptxElement } from '../types';
+
+/** Resolve runtime element IDs to native shape IDs, allocating only referenced targets. */
+export function createShapeIdResolver(
+	elements: readonly PptxElement[],
+	reservedMaxId: number = 0,
+): (elementId: string) => string | undefined {
+	const byId = new Map<string, PptxElement>();
+	let maxId = reservedMaxId;
+	const visit = (element: PptxElement): void => {
+		byId.set(element.id, element);
+		if (element.shapeId !== undefined) {
+			const value = Number.parseInt(element.shapeId, 10);
+			if (Number.isFinite(value)) {
+				maxId = Math.max(maxId, value);
+			}
+		}
+		if (element.type === 'group') {
+			element.children.forEach(visit);
+		}
+	};
+	elements.forEach(visit);
+	return (elementId) => {
+		const element = byId.get(elementId);
+		if (!element) {
+			return undefined;
+		}
+		if (element.shapeId === undefined) {
+			maxId += 1;
+			element.shapeId = String(maxId);
+		}
+		return element.shapeId;
+	};
+}

--- a/packages/shared/src/render/element-clipboard.test.ts
+++ b/packages/shared/src/render/element-clipboard.test.ts
@@ -1,5 +1,7 @@
+import JSZip from 'jszip';
 import type { ChartPptxElement, PptxElement } from 'pptx-viewer-core';
 import {
+	PptxHandler,
 	makeStoreAwareId,
 	reassignDescendantIds as coreReassignDescendantIds,
 } from 'pptx-viewer-core';
@@ -65,6 +67,214 @@ function collectIds(element: PptxElement): string[] {
 	}
 	return ids;
 }
+
+function connectedGroup(): PptxElement {
+	return {
+		type: 'group',
+		id: 'group',
+		shapeId: '10',
+		name: 'Connected group',
+		x: 60,
+		y: 80,
+		width: 400,
+		height: 100,
+		children: [
+			{
+				type: 'shape',
+				id: 'left',
+				shapeId: '11',
+				name: 'Left',
+				shapeType: 'rect',
+				x: 0,
+				y: 0,
+				width: 100,
+				height: 100,
+			},
+			{
+				type: 'shape',
+				id: 'right',
+				shapeId: '12',
+				name: 'Right',
+				shapeType: 'rect',
+				x: 300,
+				y: 0,
+				width: 100,
+				height: 100,
+			},
+			{
+				type: 'connector',
+				id: 'line',
+				shapeId: '13',
+				name: 'Connection',
+				shapeType: 'straightConnector1',
+				x: 100,
+				y: 50,
+				width: 200,
+				height: 0,
+				shapeStyle: {
+					connectorStartConnection: { shapeId: 'left', connectionSiteIndex: 3 },
+					connectorEndConnection: { shapeId: 'right', connectionSiteIndex: 1 },
+				},
+			},
+		],
+	};
+}
+
+describe('cloned connected groups', () => {
+	it('points typed connector references at the cloned children', () => {
+		const source = connectedGroup();
+		const clone = cloneElementForPaste(source);
+		if (clone.type !== 'group') {
+			throw new Error('expected cloned group');
+		}
+		const connector = clone.children.find((element) => element.type === 'connector');
+		expect(connector?.shapeStyle?.connectorStartConnection?.shapeId).toBe(clone.children[0].id);
+		expect(connector?.shapeStyle?.connectorEndConnection?.shapeId).toBe(clone.children[1].id);
+	});
+
+	it('handles connector-before-target nesting, native references, and external references', () => {
+		const source = connectedGroup();
+		if (source.type !== 'group') {
+			throw new Error('expected group');
+		}
+		const [left, right, connector] = source.children;
+		if (connector.type !== 'connector' || !connector.shapeStyle) {
+			throw new Error('expected connector');
+		}
+		connector.shapeStyle.connectorStartConnection = { shapeId: '11', connectionSiteIndex: 3 };
+		connector.shapeStyle.connectorEndConnection = { shapeId: 'outside', connectionSiteIndex: 7 };
+		source.children = [
+			connector,
+			{ type: 'group', id: 'nested', x: 0, y: 0, width: 400, height: 100, children: [left, right] },
+		];
+		const original = structuredClone(source);
+		const clone = cloneElementForPaste(source, { intoTemplate: true });
+		if (
+			clone.type !== 'group' ||
+			clone.children[0].type !== 'connector' ||
+			clone.children[1].type !== 'group'
+		) {
+			throw new Error('expected nested connected group');
+		}
+		expect(clone.children[0].shapeStyle?.connectorStartConnection).toStrictEqual({
+			shapeId: clone.children[1].children[0].id,
+			connectionSiteIndex: 3,
+		});
+		expect(clone.children[0].shapeStyle?.connectorEndConnection).toStrictEqual({
+			shapeId: 'outside',
+			connectionSiteIndex: 7,
+		});
+		expect(clone.children[1].children[0].shapeId).toBeUndefined();
+		expect(collectIds(clone).every((id) => id.startsWith('layout-el-'))).toBeTruthy();
+		expect(source).toStrictEqual(original);
+	});
+
+	it.each([false, true])(
+		'keeps loaded cloned bindings on save with pasted-first=%s',
+		async (pastedFirst) => {
+			const created = await PptxHandler.create({ initialSlideCount: 1 });
+			const source = connectedGroup();
+			if (source.type !== 'group') {
+				throw new Error('expected group');
+			}
+			const connector = source.children.find((element) => element.type === 'connector');
+			if (!connector?.shapeStyle) {
+				throw new Error('expected connector style');
+			}
+			connector.shapeStyle.connectorStartConnection = { shapeId: '11', connectionSiteIndex: 3 };
+			connector.shapeStyle.connectorEndConnection = { shapeId: '12', connectionSiteIndex: 1 };
+			created.data.slides[0].elements = [source];
+			const original = await created.handler.save(created.data.slides);
+			const handler = new PptxHandler();
+			const reloader = new PptxHandler();
+			try {
+				const loaded = await handler.load(
+					original.buffer.slice(
+						original.byteOffset,
+						original.byteOffset + original.byteLength,
+					) as ArrayBuffer,
+				);
+				const originalGroup = loaded.slides[0].elements.find((element) => element.type === 'group');
+				if (!originalGroup) {
+					throw new Error('expected loaded group');
+				}
+				const originalConnector = originalGroup.children.find(
+					(element) => element.type === 'connector',
+				);
+				expect(originalConnector?.shapeStyle?.connectorStartConnection?.shapeId).toBe(
+					originalGroup.children[0].shapeId,
+				);
+				const unchanged = await handler.save(loaded.slides);
+				await expect(
+					(await JSZip.loadAsync(unchanged)).file('ppt/slides/slide1.xml')?.async('string'),
+				).resolves.toBe(
+					await (await JSZip.loadAsync(original)).file('ppt/slides/slide1.xml')?.async('string'),
+				);
+				const clone = cloneElementForPaste(originalGroup);
+				clone.name = 'Pasted group';
+				loaded.slides[0].elements.push({
+					type: 'connector',
+					id: 'outside',
+					name: 'Outside connection',
+					x: 0,
+					y: 0,
+					width: 60,
+					height: 80,
+					shapeStyle: {
+						connectorEndConnection: { shapeId: originalGroup.id, connectionSiteIndex: 0 },
+					},
+				});
+				if (pastedFirst) {
+					loaded.slides[0].elements.unshift(clone);
+				} else {
+					loaded.slides[0].elements.push(clone);
+				}
+				const saved = await handler.save(loaded.slides);
+				const reloaded = await reloader.load(
+					saved.buffer.slice(saved.byteOffset, saved.byteOffset + saved.byteLength) as ArrayBuffer,
+				);
+				const pasted = reloaded.slides[0].elements.find(
+					(element) => element.name === 'Pasted group',
+				);
+				if (pasted?.type !== 'group') {
+					throw new Error('expected saved pasted group');
+				}
+				const pastedConnector = pasted.children.find((element) => element.type === 'connector');
+				expect(pastedConnector?.shapeStyle?.connectorStartConnection?.shapeId).toBe(
+					pasted.children[0].shapeId,
+				);
+				expect(pastedConnector?.shapeStyle?.connectorEndConnection?.shapeId).toBe(
+					pasted.children[1].shapeId,
+				);
+				const kept = reloaded.slides[0].elements.find(
+					(element) => element.name === 'Connected group',
+				);
+				if (kept?.type !== 'group') {
+					throw new Error('expected original group');
+				}
+				expect(kept.children[0].shapeId).toBe(originalGroup.children[0].shapeId);
+				expect(kept.shapeId).toBe(originalGroup.shapeId);
+				const outside = reloaded.slides[0].elements.find(
+					(element) => element.name === 'Outside connection',
+				);
+				expect(
+					outside?.type === 'connector' && outside.shapeStyle?.connectorEndConnection?.shapeId,
+				).toBe(kept.shapeId);
+				expect(pasted.children[0].shapeId).not.toBe(kept.children[0].shapeId);
+				const repeated = await handler.save(loaded.slides);
+				await expect(
+					(await JSZip.loadAsync(repeated)).file('ppt/slides/slide1.xml')?.async('string'),
+				).resolves.toBe(
+					await (await JSZip.loadAsync(saved)).file('ppt/slides/slide1.xml')?.async('string'),
+				);
+			} finally {
+				created.handler.dispose();
+				handler.dispose();
+				reloader.dispose();
+			}
+		},
+	);
+});
 
 // The clipboard used to carry its own copies of these two, so a paste and a
 // duplicate/ungroup could drift apart in how they mint ids. Core owns them now;

--- a/packages/shared/src/render/element-clipboard.ts
+++ b/packages/shared/src/render/element-clipboard.ts
@@ -124,10 +124,40 @@ export function cloneElementForPaste(
 ): PptxElement {
 	const clone = structuredClone(element);
 	const intoTemplate = options.intoTemplate ?? false;
-	clone.id = makeCloneId(intoTemplate, element.id);
+	const modelIds = new Map<string, string>();
+	const nativeIds = new Map<string, string>();
+	const mintId = (node: PptxElement): string => {
+		const id = makeCloneId(intoTemplate, element.id);
+		modelIds.set(node.id, id);
+		if (node.shapeId !== undefined) {
+			nativeIds.set(node.shapeId, id);
+		}
+		// A clone is a new native shape too; save allocates IDs for its targets.
+		delete node.shapeId;
+		return id;
+	};
+	clone.id = mintId(clone);
 	// The root's ORIGINAL id decides the template store for the whole subtree,
 	// so a descendant that carries no prefix of its own cannot vote it elsewhere.
-	reassignDescendantIds(clone, () => makeCloneId(intoTemplate, element.id));
+	reassignDescendantIds(clone, mintId);
+	const remapConnections = (node: PptxElement): void => {
+		if (node.type === 'group') {
+			node.children.forEach(remapConnections);
+		}
+		if (node.type !== 'connector') {
+			return;
+		}
+		for (const ref of [
+			node.shapeStyle?.connectorStartConnection,
+			node.shapeStyle?.connectorEndConnection,
+		]) {
+			if (!ref?.shapeId) {
+				continue;
+			}
+			ref.shapeId = modelIds.get(ref.shapeId) ?? nativeIds.get(ref.shapeId) ?? ref.shapeId;
+		}
+	};
+	remapConnections(clone);
 	clone.x += options.offsetX ?? PASTE_OFFSET_PX;
 	clone.y += options.offsetY ?? PASTE_OFFSET_PX;
 	return clone;


### PR DESCRIPTION
## Summary

Duplicating or copying a group containing connected shapes gives the copied
elements fresh IDs, but currently leaves the connector attached to the original
shapes. Saving and reopening the file preserves that wrong attachment.

This change remaps internal connector references while cloning and writes their
resolved native shape IDs when saving. The original group and references outside
the copied subtree retain their identities.

## Approach

- Keep the existing fresh-descendant-ID behavior, with a second pass for internal
  connector references (both runtime IDs and loaded numeric shape IDs).
- Reuse the existing animation ID allocator to assign missing native identities
  before serialization. This prevents copied shapes from taking an original
  group's ID when the copy appears first in the element list.
- Preserve loaded native identities in auxiliary master/layout/notes/handout
  models using the existing load reconciliation helper.
- Retain authored XML, connection-site indexes, unknown endpoint properties and
  unresolved native endpoint data. No new public model fields or APIs.

The shared clone helper and core writer are used by all five bindings; no
framework-specific clipboard behavior is added.

## Validation

- 138 focused core tests and 26 shared clipboard tests passed.
- Public load/save tests cover copied groups before and after the originals,
  nested and connector-before-target ordering, external references, repeated
  saves, animation/native-ID allocation, and auxiliary native identity stability.
- Actual browser Duplicate and Copy/Paste flows, Undo/Redo, native serialization
  and reopen were checked in React. The baseline copy remains attached to the
  original shapes; the fixed copy attaches to its own shapes.
- Core typecheck, scoped lint, formatting and whitespace checks passed.

This does not change explicit-detachment semantics, remap arbitrary references
across multiple separate clipboard roots, or import cross-document assets.
Native PPTX XML/readback was checked; desktop PowerPoint and the full cross-binding
browser suite were not run for this change.
