### PR TITLE
fix(svelte): preserve unsaved state when notifying content changes

### DIFF
--- a/packages/svelte/src/viewer/editor/editor-document-lifecycle.ts
+++ b/packages/svelte/src/viewer/editor/editor-document-lifecycle.ts
@@ -195,11 +195,21 @@ export async function saveEditorState(
 	state: EditorState,
 	format: PptxSaveFormat = 'pptx',
 ): Promise<Uint8Array> {
+	const bytes = await serializeEditorState(state, format);
+	state.dirty = false;
+	return bytes;
+}
+
+/** Serialize a notification snapshot without acknowledging persistence. */
+export async function serializeEditorState(
+	state: EditorState,
+	format: PptxSaveFormat = 'pptx',
+): Promise<Uint8Array> {
 	const handler = state.getHandler();
 	if (!handler) {
 		throw new Error('No presentation is loaded.');
 	}
-	const bytes = await saveEditorDocument(
+	return saveEditorDocument(
 		handler,
 		{ ...state.snapshot(), slides: state.renderedSlides },
 		format,
@@ -216,6 +226,4 @@ export async function saveEditorState(
 		// `ppt/tableStyles.xml`. Outside the undo-tracked snapshot, like slide size.
 		state.getTableStyleOptions(),
 	);
-	state.dirty = false;
-	return bytes;
 }

--- a/packages/svelte/src/viewer/state/CreateViewerStateHarness.svelte
+++ b/packages/svelte/src/viewer/state/CreateViewerStateHarness.svelte
@@ -22,6 +22,8 @@
 		filePath,
 		editable = false,
 		onautosavetoggle,
+		oncontentchange,
+		onerror,
 		viewport,
 		fitOptions,
 	}: {
@@ -36,6 +38,8 @@
 		filePath?: string;
 		editable?: boolean;
 		onautosavetoggle?: (enabled: boolean) => void;
+		oncontentchange?: (content: Uint8Array) => void;
+		onerror?: (message: string) => void;
 		viewport?: { width: number; height: number };
 		fitOptions?: ViewportFitOptions;
 	} = $props();
@@ -54,6 +58,12 @@
 		getPieChart3D: () => false,
 		getEditable: () => editable,
 		onautosavetoggle: (enabled) => onautosavetoggle?.(enabled),
+		get oncontentchange() {
+			return oncontentchange;
+		},
+		get onerror() {
+			return onerror;
+		},
 		getStageHolderEl: () => undefined,
 		getRootEl: () => undefined,
 		getViewportWidth: () => viewport?.width ?? 0,

--- a/packages/svelte/src/viewer/state/create-viewer-state.svelte.ts
+++ b/packages/svelte/src/viewer/state/create-viewer-state.svelte.ts
@@ -14,6 +14,7 @@ import type { FieldSubstitutionContext } from 'pptx-viewer-shared';
 import { provideTranslator } from '../../i18n/context';
 import { createDeckApi } from '../editor/deck-api';
 import { createEditingApi } from '../editor/editing-api';
+import { serializeEditorState } from '../editor/editor-document-lifecycle';
 import { EditorState } from '../editor/editor-state.svelte';
 import { createExportingApi } from '../export/exporting-api';
 import { provideAreaChart3D } from './area-chart-3d-context';
@@ -137,7 +138,12 @@ export function createViewerState(options: CreateViewerStateOptions): ViewerStat
 			}),
 		onChange: () => {
 			options.onchange?.();
-			void editor.save().then((bytes) => options.oncontentchange?.(bytes));
+			const oncontentchange = options.oncontentchange;
+			if (oncontentchange) {
+				void serializeEditorState(editor).then(oncontentchange, (error: unknown) =>
+					options.onerror?.(error instanceof Error ? error.message : String(error)),
+				);
+			}
 		},
 	});
 	// Deck-level inspector actions (Properties tab, no selection), via context.

--- a/packages/svelte/src/viewer/state/view-preferences-roundtrip.svelte.test.ts
+++ b/packages/svelte/src/viewer/state/view-preferences-roundtrip.svelte.test.ts
@@ -40,13 +40,21 @@ async function buildDeck(): Promise<Uint8Array> {
 }
 
 /** Mount the real factory over `source` and wait for the load to commit. */
-async function loadHarness(source: Uint8Array): Promise<ViewerStateBag> {
+async function loadHarness(
+	source: Uint8Array,
+	callbacks: {
+		oncontentchange?: (bytes: Uint8Array) => void;
+		onerror?: (message: string) => void;
+	} = {},
+): Promise<ViewerStateBag> {
 	let captured: ViewerStateBag | undefined;
 	const target = document.createElement('div');
 	const instance = mount(CreateViewerStateHarness, {
 		target,
 		props: {
+			...callbacks,
 			source,
+			autosave: false,
 			editable: true,
 			onready: (state: ViewerStateBag) => {
 				captured = state;
@@ -70,6 +78,82 @@ async function loadHarness(source: Uint8Array): Promise<ViewerStateBag> {
 }
 
 describe('svelte deck view preferences', () => {
+	it('keeps dirty and reports a failed content serialization without emitting bytes', async () => {
+		const oncontentchange = vi.fn();
+		const onerror = vi.fn();
+		const state = await loadHarness(await buildDeck(), { oncontentchange, onerror });
+		vi.spyOn(state.loader.handler!, 'save').mockRejectedValueOnce(
+			new Error('serialization failed'),
+		);
+		state.editor.insertElement({ type: 'shape', id: '', x: 10, y: 20, width: 100, height: 50 });
+		await vi.waitFor(() => expect(onerror).toHaveBeenCalledWith('serialization failed'));
+		expect(oncontentchange).not.toHaveBeenCalled();
+		expect(state.editor.dirty).toBeTruthy();
+		expect(state.editor.canUndo).toBeTruthy();
+	}, 60_000);
+
+	it('does not clear a newer edit when a notification finishes', async () => {
+		const oncontentchange = vi.fn();
+		const state = await loadHarness(await buildDeck(), { oncontentchange });
+		const bytes = await state.editor.save();
+		let finish!: (bytes: Uint8Array) => void;
+		const pending = new Promise<Uint8Array>((resolve) => {
+			finish = resolve;
+		});
+		vi.spyOn(state.loader.handler!, 'save').mockReturnValue(pending);
+		state.editor.insertElement({ type: 'shape', id: '', x: 10, y: 20, width: 100, height: 50 });
+		state.editor.commitInlineText(state.editor.slides[0].elements[0].id, 'Newer body');
+		finish(bytes);
+		await vi.waitFor(() => expect(oncontentchange).toHaveBeenCalledTimes(2));
+		expect(state.editor.dirty).toBeTruthy();
+		expect(state.editor.slides[0].elements[0].text).toBe('Newer body');
+	}, 60_000);
+
+	it('keeps committed edits dirty without serializing an absent content callback', async () => {
+		const state = await loadHarness(await buildDeck());
+		const serialize = vi.spyOn(state.loader.handler!, 'save');
+		state.editor.insertElement({ type: 'shape', id: '', x: 10, y: 20, width: 100, height: 50 });
+		flushSync();
+		expect(state.autosaveEnabled).toBeFalsy();
+		await Promise.all(serialize.mock.results.map((result) => result.value));
+		expect(serialize).not.toHaveBeenCalled();
+		expect(state.editor.dirty).toBeTruthy();
+	}, 60_000);
+
+	it('notifies committed inline content without acknowledging a save', async () => {
+		const oncontentchange = vi.fn<(bytes: Uint8Array) => void>();
+		const state = await loadHarness(await buildDeck(), { oncontentchange });
+		state.editor.insertElement({
+			type: 'shape',
+			id: '',
+			x: 10,
+			y: 20,
+			width: 100,
+			height: 50,
+			text: 'Before',
+		});
+		await vi.waitFor(() => expect(oncontentchange).toHaveBeenCalledOnce());
+		const id = state.editor.slides[0].elements[0].id;
+		state.editor.commitInlineText(id, 'Committed body');
+		await vi.waitFor(() => expect(oncontentchange).toHaveBeenCalledTimes(2));
+		expect(state.editor.dirty).toBeTruthy();
+		expect(state.editor.canUndo).toBeTruthy();
+		const handler = new PptxHandler();
+		try {
+			const bytes = oncontentchange.mock.calls[1][0];
+			const saved = await handler.load(bytes.buffer as ArrayBuffer);
+			expect(saved.slides[0].elements[0].text).toBe('Committed body');
+			expect(saved.viewProperties?.slideViewPr).toMatchObject({
+				snapToGrid: false,
+				showGuides: true,
+			});
+		} finally {
+			handler.dispose();
+		}
+		await state.editingApi.save();
+		expect(state.editor.dirty).toBeFalsy();
+	}, 60_000);
+
 	it('seeds snapToGrid/snapToShape/showGuides from ppt/viewProps.xml on load', async () => {
 		const state = await loadHarness(await buildDeck());
 


### PR DESCRIPTION
## Summary

Keep Svelte edits dirty when producing `oncontentchange` notification bytes.
The callback is a change notification, not confirmation that a host saved the
document. Without a callback, skip the unnecessary serialization altogether.

Previously every change called `editor.save()`, even with AutoSave off and no
`oncontentchange` callback. That method cleared dirty after serialization, so
ordinary unsaved text edits could immediately appear saved.

## Minimal fix

- Reuse the existing serialization path and all its save options through a
  small internal helper that does not clear dirty.
- Call it only when byte notifications are requested; report serialization
  errors through the existing error callback.
- Preserve explicit save/getContent, download, AutoSave and history behavior.

This route was introduced with Svelte's canonical callbacks. The issue is in
that binding's notification wiring, so no other binding or public API changes
are needed. No new UI or unrelated orchestrator refactor is included.

## Validation

- Two mounted regressions fail before the fix: absent callback still saves,
  and a present callback clears dirty after an ordinary text edit.
- 70 focused tests pass, including callback bytes, failure, a newer edit during
  serialization, explicit save, native view settings, read-only and AutoSave.
- Source typecheck reports zero errors and five existing warnings in untouched
  files; changed-code lint, formatting and whitespace checks pass.
- Actual browser text edits with AutoSave off remain dirty with callback off
  and on. Undo/Redo still work and notify; explicit save clears dirty and
  reopen preserves the edited text.
- Independent code and saved-file review confirmed notification and explicit
  save bytes contain the same edited shape content and preserve neighboring
  list text and paragraph metadata. No desktop PowerPoint validation claimed.

Refreshed to main 1eb52738 after the empty-paragraph fix merged. The four-file
patch reapplied unchanged; all 70 tests and typecheck passed again, and a fresh
browser edit plus callback Undo/Redo retained dirty on the combined source.
