### PR TITLE
fix(vue,angular): honor public edit and preview mode switches

### DIFF
--- a/packages/angular/src/viewer/power-point-viewer-api.test.ts
+++ b/packages/angular/src/viewer/power-point-viewer-api.test.ts
@@ -13,9 +13,18 @@
  * since this package has no TestBed) and enumerates the members, so deleting the
  * clause to "fix" a build fails loudly instead of silently.
  */
-import { describe, expect, it } from 'vitest';
+import { computed, signal, Injector, runInInjectionContext } from '@angular/core';
+import { PptxHandler, createTextElement } from 'pptx-viewer-core';
+import type { PptxSlide } from 'pptx-viewer-core';
+import { describe, expect, it, vi } from 'vitest';
 
+import { buildInlineTextCommitPatch } from '../internal/shared';
 import { componentSource } from './component-source.test-support';
+import { EditorStateService } from './editor-state.service';
+import { ExportService } from './export.service';
+import { LoadContentService } from './load-content.service';
+import { PowerPointViewerComponent } from './power-point-viewer.component';
+import { ViewerFileIOService } from './viewer-file-io.service';
 
 const source = componentSource(import.meta.dirname, 'power-point-viewer.component.ts');
 
@@ -79,5 +88,133 @@ describe('powerPointViewerComponent API conformance', () => {
 		expect(source).toContain('getMode(): ViewerMode {');
 		expect(source).toContain('setMode(mode: ViewerMode): void {');
 		expect(source).toContain('readonly modeChange = output<ViewerMode>();');
+	});
+});
+
+describe('public viewer mode transitions', () => {
+	function harness() {
+		const permission = signal(true);
+		const editingRequested = signal(true);
+		const presenting = signal(false);
+		const showMasterView = signal(false);
+		const blur = vi.fn();
+		const state = {
+			editingRequested,
+			canEdit: computed(() => permission() && editingRequested()),
+			presentationMode: { presenting, present: () => presenting.set(true) },
+			showMasterView,
+			editor: { editTemplateMode: signal(false), setEditTemplateMode: vi.fn() },
+			mainEl: () => ({ nativeElement: { querySelector: () => ({ blur }) } }),
+			openMasterView: () => showMasterView.set(true),
+			modeChange: { emit: vi.fn() },
+		};
+		const target = state as unknown as PowerPointViewerComponent;
+		const getMode = () => PowerPointViewerComponent.prototype.getMode.call(target);
+		return {
+			state,
+			permission,
+			blur,
+			getMode,
+			setMode: (mode: 'edit' | 'preview' | 'present' | 'master') =>
+				PowerPointViewerComponent.prototype.setMode.call(target, mode),
+		};
+	}
+
+	it('switches edit to preview and back without changing host permission', () => {
+		const h = harness();
+		h.setMode('preview');
+		expect(h.getMode()).toBe('preview');
+		expect(h.state.canEdit()).toBeFalsy();
+		expect(h.permission()).toBeTruthy();
+		h.setMode('edit');
+		expect(h.getMode()).toBe('edit');
+	});
+
+	it('commits the current inline editor before disabling editing', () => {
+		const h = harness();
+		h.blur.mockImplementation(() => {
+			expect(h.state.canEdit()).toBeTruthy();
+		});
+		h.setMode('preview');
+		expect(h.blur).toHaveBeenCalledOnce();
+	});
+
+	it('does not bypass effective permission when entering edit', () => {
+		const h = harness();
+		h.permission.set(false);
+		h.setMode('edit');
+		expect(h.getMode()).toBe('preview');
+	});
+
+	it.each(['present', 'master'] as const)('returns from %s to preview', (mode) => {
+		const h = harness();
+		h.setMode(mode);
+		expect(h.getMode()).toBe(mode);
+		h.setMode('preview');
+		expect(h.getMode()).toBe('preview');
+	});
+
+	it('uses permission, not interaction mode, to select the edited display and native save', () => {
+		expect(source).toContain(
+			'this.hasEditPermission() ? this.editor.slides() : this.loader.slides()',
+		);
+		const fileIoBinding = source.slice(source.indexOf('this.fileIO.bind({'));
+		expect(fileIoBinding).toMatch(/canEdit: \(\) => this\.hasEditPermission\(\)/u);
+	});
+
+	it('saves committed text from the editor in preview, retaining Undo/Redo', async () => {
+		const { handler, data } = await PptxHandler.create({ initialSlideCount: 1 });
+		const target = createTextElement('Original mode text', {
+			x: 20,
+			y: 30,
+			width: 200,
+			height: 50,
+		});
+		data.slides[0].elements.push(target);
+		const originalBytes = await handler.save(data.slides);
+		const editor = new EditorStateService();
+		editor.setSlides(data.slides);
+		const h = harness();
+		h.blur.mockImplementation(() => {
+			editor.updateElement(0, target.id, buildInlineTextCommitPatch(target, 'Pending mode text')!);
+		});
+		const loader = {
+			saveSlides: vi.fn((slides: PptxSlide[]) => handler.save(slides)),
+			getContent: vi.fn(async () => originalBytes),
+		};
+		const injector = Injector.create({
+			providers: [
+				{ provide: LoadContentService, useValue: loader },
+				{ provide: ExportService, useValue: {} },
+				ViewerFileIOService,
+			],
+		});
+		const fileIO = runInInjectionContext(injector, () => injector.get(ViewerFileIOService));
+		fileIO.bind({
+			canEdit: h.permission,
+			content: () => originalBytes,
+			onOpenFile: () => undefined,
+			slides: editor.slides,
+			sections: editor.sections,
+			templateElementsBySlideId: editor.templateElementsBySlideId,
+			emitContentChange: vi.fn(),
+			saveIntent: () => ({}),
+			afterSuccessfulSave: vi.fn(),
+		});
+		h.setMode('preview');
+		expect(h.getMode()).toBe('preview');
+		const saved = await fileIO.getContent();
+		expect(loader.getContent).not.toHaveBeenCalled();
+		const reopened = await new PptxHandler().load(saved);
+		expect(
+			reopened.slides[0].elements.some(
+				(element) => 'text' in element && element.text === 'Pending mode text',
+			),
+		).toBeTruthy();
+		h.setMode('edit');
+		editor.undo();
+		expect(editor.slides()[0].elements[0]).toMatchObject({ text: 'Original mode text' });
+		editor.redo();
+		expect(editor.slides()[0].elements[0]).toMatchObject({ text: 'Pending mode text' });
 	});
 });

--- a/packages/angular/src/viewer/power-point-viewer.component.ts
+++ b/packages/angular/src/viewer/power-point-viewer.component.ts
@@ -1519,12 +1519,14 @@ export class PowerPointViewerComponent implements PowerPointViewerAPI {
 	 * read-only recommendation (`p:modifyVerifier` / "Mark as Final"; lifted by
 	 * the read-only banner's "Edit anyway", see {@link LoadNoticesService}).
 	 */
-	protected readonly canEdit = computed(
+	protected readonly hasEditPermission = computed(
 		() =>
 			this.canEditInput() &&
 			(!this.viewerOpts.options().trust.openInProtectedView || this.protectedViewDismissed()) &&
 			!this.loadNotices.lockActive(),
 	);
+	private readonly editingRequested = signal(true);
+	protected readonly canEdit = computed(() => this.hasEditPermission() && this.editingRequested());
 
 	/** Whether the Protected View banner should show: host allows editing, the option still blocks it, and the user hasn't dismissed it yet. */
 	protected readonly protectedViewActive = computed(
@@ -1571,9 +1573,9 @@ export class PowerPointViewerComponent implements PowerPointViewerAPI {
 	 * end-of-slide-show screen rather than falling back to the editor.
 	 */
 	protected readonly audienceSessionEnded = signal(false);
-	/** Slides to display: the editable deck when `canEdit`, else the loaded deck. */
+	/** Preview changes interaction, not which permitted live deck is displayed. */
 	protected readonly displaySlides = computed(() =>
-		this.canEdit() ? this.editor.slides() : this.loader.slides(),
+		this.hasEditPermission() ? this.editor.slides() : this.loader.slides(),
 	);
 	protected readonly slideCount = computed(() => this.displaySlides().length);
 	/**
@@ -1583,7 +1585,7 @@ export class PowerPointViewerComponent implements PowerPointViewerAPI {
 	 * accessibility) renders this instead so template elements are not lost.
 	 */
 	protected readonly mergedSlides = computed<readonly PptxSlide[]>(() =>
-		this.canEdit()
+		this.hasEditPermission()
 			? buildSaveSlides(this.editor.slides(), this.editor.templateElementsBySlideId())
 			: this.loader.slides(),
 	);
@@ -1593,7 +1595,7 @@ export class PowerPointViewerComponent implements PowerPointViewerAPI {
 	/** Inherited template (master/layout) elements for the active slide, when editing. */
 	protected readonly activeTemplateElements = computed<readonly PptxElement[]>(() => {
 		const slide = this.activeSlide();
-		if (!this.canEdit() || !slide) {
+		if (!this.hasEditPermission() || !slide) {
 			return [];
 		}
 		return this.editor.templateElementsBySlideId()[slide.id] ?? [];
@@ -2423,7 +2425,7 @@ export class PowerPointViewerComponent implements PowerPointViewerAPI {
 		// component (canEdit, the host `content` input, the File ▸ Open override,
 		// the editor's slides + template elements, and the contentChange emitter).
 		this.fileIO.bind({
-			canEdit: () => this.canEdit(),
+			canEdit: () => this.hasEditPermission(),
 			content: () => this.content(),
 			onOpenFile: () => this.onOpenFile(),
 			slides: () => this.editor.slides(),
@@ -2896,6 +2898,12 @@ export class PowerPointViewerComponent implements PowerPointViewerAPI {
 	}
 	/** Switch the viewer mode (e.g. 'edit', 'preview', 'present'). */
 	setMode(mode: ViewerMode): void {
+		if (mode === 'preview' && this.canEdit()) {
+			this.mainEl()?.nativeElement.querySelector<HTMLElement>('[data-inline-editor]')?.blur();
+		}
+		if (mode !== 'present') {
+			this.editingRequested.set(mode !== 'preview');
+		}
 		if (mode === 'present') {
 			this.presentationMode.present();
 		} else if (mode === 'master') {

--- a/packages/vue/src/viewer/PowerPointViewer.vue
+++ b/packages/vue/src/viewer/PowerPointViewer.vue
@@ -283,8 +283,14 @@ const protectedViewActive = computed(
 // same way Protected View does, so its lock feeds the SAME gate rather than a
 // second mechanism.
 const readOnlyRec = useReadOnlyRecommendation({ modifyVerifier, customProperties });
+// A requested preview disables interaction without changing host permission or the live deck.
+const editingRequested = ref(true);
 const canEditEffective = computed(
-	() => props.canEdit && !protectedViewActive.value && !readOnlyRec.locked.value,
+	() =>
+		editingRequested.value &&
+		props.canEdit &&
+		!protectedViewActive.value &&
+		!readOnlyRec.locked.value,
 );
 function enableEditing(): void {
 	protectedViewDismissed.value = true;
@@ -1474,6 +1480,10 @@ defineExpose<PowerPointViewerExpose>(
 		presenting: presentation.presenting,
 		showMasterView: masterView.showMasterView,
 		mode: ribbonMode,
+		setEditingRequested: (editable) => {
+			editingRequested.value = editable;
+		},
+		commitPendingText: inlineEdit.commitInlineEdit,
 		getContent,
 		goTo,
 		goPrev,

--- a/packages/vue/src/viewer/composables/useViewerApi.test.ts
+++ b/packages/vue/src/viewer/composables/useViewerApi.test.ts
@@ -1,0 +1,152 @@
+import { PptxHandler, createTextElement } from 'pptx-viewer-core';
+import type { PptxSlide } from 'pptx-viewer-core';
+import { describe, expect, it, vi } from 'vitest';
+import { computed, ref, shallowRef } from 'vue';
+
+import { useEditorHistory } from './useEditorHistory';
+import { useEditorOperations } from './useEditorOperations';
+import { useInlineEditing } from './useInlineEditing';
+import { useViewerApi } from './useViewerApi';
+
+function useHarness(initialSlides: PptxSlide[] = []) {
+	const slides = shallowRef(initialSlides);
+	const permission = ref(true);
+	const editingRequested = ref(true);
+	const presenting = ref(false);
+	const showMasterView = ref(false);
+	const canEdit = computed(() => permission.value && editingRequested.value);
+	const mode = computed(() =>
+		presenting.value
+			? 'present'
+			: showMasterView.value
+				? 'master'
+				: canEdit.value
+					? 'edit'
+					: 'preview',
+	);
+	const commitPendingText = vi.fn();
+	const history = useEditorHistory(slides);
+	const elementOps = useEditorOperations({
+		slides,
+		activeSlideIndex: ref(0),
+		pushHistory: history.pushHistory,
+	});
+	const options = {
+		slides,
+		activeSlide: computed(() => slides.value[0]),
+		activeSlideIndex: ref(0),
+		slideCount: computed(() => slides.value.length),
+		selectedElementIds: ref<string[]>([]),
+		zoom: ref(1),
+		isDirty: ref(false),
+		presenting,
+		showMasterView,
+		mode,
+		setEditingRequested: (value: boolean) => {
+			editingRequested.value = value;
+		},
+		commitPendingText,
+		getContent: vi.fn<() => Promise<Uint8Array>>(async () => new Uint8Array()),
+		goTo: vi.fn(),
+		goPrev: vi.fn(),
+		goNext: vi.fn(),
+		zoomIn: vi.fn(),
+		zoomOut: vi.fn(),
+		zoomReset: vi.fn(),
+		startPresenting: () => {
+			presenting.value = true;
+		},
+		history,
+		slideOps: {
+			addSlide: vi.fn(),
+			deleteSlide: vi.fn(),
+			duplicateSlide: vi.fn(),
+			moveSlide: vi.fn(),
+		},
+		toggleSlideHidden: vi.fn(),
+		elementOps,
+	};
+	return { api: useViewerApi(options), options, permission, canEdit, slides, commitPendingText };
+}
+
+describe('public viewer mode', () => {
+	it('switches permitted edit and preview without a host prop update', () => {
+		const { api, canEdit } = useHarness();
+		expect(api.getMode()).toBe('edit');
+		api.setMode('preview');
+		expect(api.getMode()).toBe('preview');
+		expect(canEdit.value).toBeFalsy();
+		api.setMode('preview');
+		api.setMode('edit');
+		expect(api.getMode()).toBe('edit');
+		expect(canEdit.value).toBeTruthy();
+	});
+
+	it('does not lift a host or document permission lock', () => {
+		const { api, permission, canEdit } = useHarness();
+		permission.value = false;
+		api.setMode('edit');
+		expect(api.getMode()).toBe('preview');
+		expect(canEdit.value).toBeFalsy();
+		permission.value = true;
+		api.setMode('preview');
+		permission.value = false;
+		permission.value = true;
+		expect(api.getMode()).toBe('preview');
+	});
+
+	it.each(['present', 'master'] as const)('leaves %s for actual preview, then edit', (mode) => {
+		const { api } = useHarness();
+		api.setMode(mode);
+		expect(api.getMode()).toBe(mode);
+		api.setMode('preview');
+		expect(api.getMode()).toBe('preview');
+		api.setMode('edit');
+		expect(api.getMode()).toBe('edit');
+	});
+
+	it.each(['edit', 'master'] as const)(
+		'commits pending text from %s before preview and exports the live edited deck',
+		async (mode) => {
+			const { handler, data } = await PptxHandler.create({ initialSlideCount: 1 });
+			data.slides[0].elements.push(
+				createTextElement('Original mode text', { x: 20, y: 30, width: 200, height: 50 }),
+			);
+			const h = useHarness(data.slides);
+			h.api.setMode(mode);
+			const target = h.slides.value[0].elements[0];
+			const editing = useInlineEditing({
+				canEdit: () => h.canEdit.value,
+				findActiveElement: (id) => h.slides.value[0].elements.find((element) => element.id === id),
+				ops: h.options.elementOps,
+			});
+			editing.enterInlineEdit(target.id);
+			editing.updateInlineText('Pending mode text');
+			h.commitPendingText.mockImplementation(() => {
+				expect(h.canEdit.value).toBeTruthy();
+				editing.commitInlineEdit();
+			});
+			h.options.getContent.mockImplementation(() => {
+				const slides = h.slides.value;
+				return handler.save(slides);
+			});
+			h.api.setMode('preview');
+			expect(h.commitPendingText).toHaveBeenCalledOnce();
+			expect(h.api.getMode()).toBe('preview');
+			const saved = await h.api.getContent();
+			const reopened = await new PptxHandler().load(saved);
+			expect(
+				reopened.slides[0].elements.some(
+					(element) => 'text' in element && element.text === 'Pending mode text',
+				),
+			).toBeTruthy();
+			expect(h.api.getElements()).toHaveLength(h.slides.value[0].elements.length);
+			h.api.setMode('edit');
+			expect(h.api.canUndo()).toBeTruthy();
+			h.api.undo();
+			expect(h.api.getElements()[0]).toMatchObject({ text: 'Original mode text' });
+			h.api.redo();
+			expect(h.api.getElements()[0]).toMatchObject({ text: 'Pending mode text' });
+		},
+	);
+});

--- a/packages/vue/src/viewer/composables/useViewerApi.ts
+++ b/packages/vue/src/viewer/composables/useViewerApi.ts
@@ -26,6 +26,8 @@ export interface UseViewerApiOptions {
 	presenting: Ref<boolean>;
 	showMasterView: Ref<boolean>;
 	mode: Ref<ViewerMode> | ComputedRef<ViewerMode>;
+	setEditingRequested: (editable: boolean) => void;
+	commitPendingText: () => void;
 	getContent: () => Promise<Uint8Array>;
 	goTo: (index: number) => void;
 	goPrev: () => void;
@@ -91,6 +93,15 @@ export function useViewerApi(options: UseViewerApiOptions): PowerPointViewerExpo
 		zoomReset: options.zoomReset,
 		getMode: () => options.mode.value,
 		setMode: (newMode) => {
+			if (
+				newMode === 'preview' &&
+				(options.mode.value === 'edit' || options.mode.value === 'master')
+			) {
+				options.commitPendingText();
+			}
+			if (newMode !== 'present') {
+				options.setEditingRequested(newMode !== 'preview');
+			}
 			if (newMode === 'present') {
 				options.startPresenting();
 			} else if (newMode === 'master') {


### PR DESCRIPTION
## Summary

Make the existing public `setMode('preview')` and `setMode('edit')` methods
actually switch interaction mode in Vue and Angular. Previously both branches
only exited master/presentation state; an editable viewer stayed editable.

## Minimal fix

- Keep a local requested editing flag, bounded by existing host, trust and
  document permissions. A mode request cannot unlock a restricted document.
- Commit pending inline text before entering preview.
- In Angular, keep live document rendering and serialization independent from
  the requested interaction mode. Preview must not fall back to the original
  loaded slide and omit unsaved edits.
- Preserve existing master/presentation cleanup, history, and public mutation
  policy. React, Svelte and Vanilla already implement ordinary edit/preview
  switching; their production code is unchanged.

The missing branches date to the canonical imperative API introduction, rather
than an intentional documented preview no-op. This patch adds no shared mode
framework and does not refactor the pre-existing large root components.

## Validation

- New tests fail before the fix; 33 Vue and 60 Angular focused tests pass on
  main 1eb52738, including native pending-text save/reload and Undo/Redo.
- Typechecks, fresh Angular build, changed-code lint and formatting pass.
- Actual browser public API calls in both bindings switch edit/preview, retain
  unsaved movement and pending text, preserve Undo/Redo, and respect host locks.
- Independent native XML review verifies that preview exports contain the
  moved shape and pending text; saved files reopen with those edits intact.
- Proven-invocation master exits and a visible host action calling present then
  preview verify fullscreen entry and cleanup in the real browser.

Angular unit tests call actual public methods on a signal-backed host, not a
full TestBed mount; the separate browser checks verify component wiring. The
existing API has no permanent public-ref E2E host, so these checks use temporary
visible host controls plus committed unit/native tests. Inherited-layer data
selection is covered by source/tests, not a special inherited-slide browser
fixture. No desktop PowerPoint validation claimed.
