### PR TITLE
fix(shared): leave empty clipboard paste shortcuts unclaimed

### DIFF
--- a/e2e/keyboard-shortcuts.spec.ts
+++ b/e2e/keyboard-shortcuts.spec.ts
@@ -114,6 +114,33 @@ test.describe('editor keyboard shortcuts', () => {
 		await expect(slideElements(page), 'one copy pasted onto a two-shape slide').toHaveCount(3);
 	});
 
+	test('paste yields an empty clipboard shortcut and claims a populated internal clipboard', async ({
+		page,
+	}) => {
+		await openWithSelection(page);
+		await page.evaluate(() => {
+			document.addEventListener(
+				'keydown',
+				(event) => {
+					if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'v') {
+						queueMicrotask(() => {
+							document.body.dataset.pasteKeyPrevented = String(event.defaultPrevented);
+						});
+					}
+				},
+				true,
+			);
+		});
+		await pressShortcut(page, 'ControlOrMeta+v', 300);
+		await expect(page.locator('body')).toHaveAttribute('data-paste-key-prevented', 'false');
+		await expect(slideElements(page)).toHaveCount(2);
+
+		await pressShortcut(page, 'ControlOrMeta+c', 300);
+		await pressShortcut(page, 'ControlOrMeta+v', 800);
+		await expect(page.locator('body')).toHaveAttribute('data-paste-key-prevented', 'true');
+		await expect(slideElements(page)).toHaveCount(3);
+	});
+
 	test('Ctrl+X removes the selected element and Ctrl+V puts it back', async ({ page }) => {
 		await openWithSelection(page);
 		await pressShortcut(page, 'ControlOrMeta+x', 700);

--- a/packages/angular/src/viewer/viewer-keyboard.service.test.ts
+++ b/packages/angular/src/viewer/viewer-keyboard.service.test.ts
@@ -26,6 +26,7 @@ import { ViewerPresentationModeService } from './viewer-presentation-mode.servic
 function editorStub(hasSelection: boolean) {
 	return {
 		hasSelection: () => hasSelection,
+		hasClipboard: signal(true),
 		undo: vi.fn(),
 		redo: vi.fn(),
 		duplicateSelected: vi.fn(),
@@ -133,6 +134,19 @@ function harness(
 }
 
 describe('viewerKeyboardService: the shortcut cheat sheet', () => {
+	it.each([{ ctrlKey: true }, { metaKey: true }])(
+		'does not prevent unavailable paste: %j',
+		(modifiers) => {
+			const h = harness({ hasSelection: false });
+			h.editor.hasClipboard.set(false);
+			expect(h.press('v', modifiers).defaultPrevented).toBeFalsy();
+			expect(h.editor.paste).not.toHaveBeenCalled();
+			h.editor.hasClipboard.set(true);
+			expect(h.press('v', modifiers).defaultPrevented).toBeTruthy();
+			expect(h.editor.paste).toHaveBeenCalledOnce();
+		},
+	);
+
 	it('opens on "?"', () => {
 		const h = harness();
 		h.press('?', { shiftKey: true });

--- a/packages/angular/src/viewer/viewer-keyboard.service.ts
+++ b/packages/angular/src/viewer/viewer-keyboard.service.ts
@@ -86,6 +86,7 @@ export class ViewerKeyboardService {
 
 		const { action, dx, dy } = mapEditorKey(event, {
 			canEdit: host.canEdit(),
+			canPaste: this.editor.hasClipboard(),
 			isPresenting: host.presenting(),
 			hasSelection: this.editor.hasSelection(),
 			isDrawing: host.isDrawing?.() ?? false,

--- a/packages/react/src/viewer/hooks/useKeyboardShortcutWiring.ts
+++ b/packages/react/src/viewer/hooks/useKeyboardShortcutWiring.ts
@@ -63,6 +63,7 @@ export function useKeyboardShortcutWiring(input: UseKeyboardShortcutWiringInput)
 		mode,
 		canEdit,
 		inlineEditingElementId: state.inlineEditingElementId,
+		canPaste: Boolean(state.clipboardPayload && activeSlide),
 		tableEditorState: state.tableEditorState,
 		activeTool: state.activeTool,
 		hasSelection: state.effectiveSelectedIds.length > 0,

--- a/packages/react/src/viewer/hooks/useKeyboardShortcuts.listener.test.ts
+++ b/packages/react/src/viewer/hooks/useKeyboardShortcuts.listener.test.ts
@@ -79,6 +79,34 @@ afterEach(() => {
 });
 
 describe('useKeyboardShortcuts listener registration', () => {
+	it.each([{ ctrlKey: true }, { metaKey: true }])(
+		'does not prevent unavailable paste: %j',
+		(modifiers) => {
+			const onPaste = vi.fn();
+			const input = inputWith(container, { canPaste: false, hasSelection: false, onPaste });
+			mount(input);
+			const empty = new KeyboardEvent('keydown', {
+				key: 'v',
+				...modifiers,
+				bubbles: true,
+				cancelable: true,
+			});
+			container.dispatchEvent(empty);
+			expect(empty.defaultPrevented).toBeFalsy();
+			expect(onPaste).not.toHaveBeenCalled();
+			input.canPaste = true;
+			const populated = new KeyboardEvent('keydown', {
+				key: 'v',
+				...modifiers,
+				bubbles: true,
+				cancelable: true,
+			});
+			container.dispatchEvent(populated);
+			expect(populated.defaultPrevented).toBeTruthy();
+			expect(onPaste).toHaveBeenCalledOnce();
+		},
+	);
+
 	it('registers keydown once, on window, and never on the container', () => {
 		const containerAdd = vi.spyOn(container, 'addEventListener');
 		const windowAdd = vi.spyOn(window, 'addEventListener');

--- a/packages/react/src/viewer/hooks/useKeyboardShortcuts.ts
+++ b/packages/react/src/viewer/hooks/useKeyboardShortcuts.ts
@@ -36,6 +36,8 @@ export interface UseKeyboardShortcutsInput {
 
 	mode: ViewerMode;
 	canEdit: boolean;
+	/** Omitted preserves custom callers; false leaves native paste unclaimed. */
+	canPaste?: boolean;
 
 	/** Whether any element is currently being inline-edited (text box). */
 	inlineEditingElementId: string | null;
@@ -114,6 +116,7 @@ export function useKeyboardShortcuts(input: UseKeyboardShortcutsInput): void {
 
 		const { action, dx, dy } = mapEditorKey(e, {
 			canEdit: current.canEdit,
+			canPaste: current.canPaste,
 			// The Slide Master view is an editing surface, not a viewing one.
 			// Gating on `mode !== 'edit'` alone made `mapEditorKey` return
 			// NO_ACTION there, so Delete, the arrow-key nudges and the clipboard

--- a/packages/shared/src/render/editor-keymap.test.ts
+++ b/packages/shared/src/render/editor-keymap.test.ts
@@ -55,6 +55,16 @@ describe('mapEditorKey guards', () => {
 });
 
 describe('mapEditorKey clipboard and history', () => {
+	it.each([{ ctrlKey: true }, { metaKey: true }])(
+		'leaves paste unclaimed when unavailable: %j',
+		(modifiers) => {
+			expect(mapEditorKey(press('v', modifiers), { canPaste: false }).action).toBeNull();
+			expect(
+				mapEditorKey(press('v', modifiers), { canPaste: true, hasSelection: false }).action,
+			).toBe('paste');
+		},
+	);
+
 	it('resolves the Ctrl chords', () => {
 		expect(mapEditorKey(press('c', { ctrlKey: true }), SELECTED).action).toBe('copy');
 		expect(mapEditorKey(press('x', { metaKey: true }), SELECTED).action).toBe('cut');

--- a/packages/shared/src/render/editor-keymap.ts
+++ b/packages/shared/src/render/editor-keymap.ts
@@ -89,6 +89,8 @@ export interface EditorKeyGuard {
 	isPresenting: boolean;
 	/** At least one element is selected. */
 	hasSelection: boolean;
+	/** False leaves paste to the browser/host when no internal paste is available. */
+	canPaste?: boolean;
 	/** An inline text or table-cell editor is open. */
 	isEditingText: boolean;
 	/** A drawing tool other than the selection arrow is armed. */
@@ -102,6 +104,7 @@ const GUARD_DEFAULTS: EditorKeyGuard = {
 	canEdit: true,
 	isPresenting: false,
 	hasSelection: false,
+	canPaste: true,
 	isEditingText: false,
 	isDrawing: false,
 	isTextInputTarget: false,
@@ -222,6 +225,9 @@ export function mapEditorKey(
 	if (mod && !alt) {
 		const chord = resolveChord(key, Boolean(input.shiftKey), state.hasSelection);
 		if (chord) {
+			if (chord.action === 'paste' && state.canPaste === false) {
+				return NO_ACTION;
+			}
 			return chord;
 		}
 	}

--- a/packages/svelte/src/viewer/editor/editor-controller-wiring.svelte.test.ts
+++ b/packages/svelte/src/viewer/editor/editor-controller-wiring.svelte.test.ts
@@ -2,7 +2,11 @@ import type { PptxElement } from 'pptx-viewer-core';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { EditorControllerDeps } from './editor-controller-deps';
-import { createTransformGestures, rerouteConnectorsAfterGesture } from './editor-controller-wiring';
+import {
+	createEditorKeydown,
+	createTransformGestures,
+	rerouteConnectorsAfterGesture,
+} from './editor-controller-wiring';
 import type { EditorControllerHost } from './editor-controller-wiring';
 import { EditorState } from './editor-state.svelte';
 
@@ -77,6 +81,26 @@ function connectorOf(editor: EditorState, id: string): PptxElement {
 }
 
 describe('rerouteConnectorsAfterGesture', () => {
+	it('reads the real clipboard for native handoff and still pastes copied elements', () => {
+		const { host, editor } = makeHost([shape('box', 0, 0)]);
+		const handler = createEditorKeydown(host);
+		const empty = new KeyboardEvent('keydown', { key: 'v', metaKey: true, cancelable: true });
+		handler(empty);
+		expect(empty.defaultPrevented).toBeFalsy();
+		expect(editor.activeElements).toHaveLength(1);
+		editor.select('box');
+		editor.clipboardOps.copySelected();
+		editor.select(null);
+		const populated = new KeyboardEvent('keydown', { key: 'v', metaKey: true, cancelable: true });
+		handler(populated);
+		expect(populated.defaultPrevented).toBeTruthy();
+		expect(editor.activeElements).toHaveLength(2);
+		editor.undo();
+		expect(editor.activeElements).toHaveLength(1);
+		editor.redo();
+		expect(editor.activeElements).toHaveLength(2);
+	});
+
 	it('re-lays a connector whose bound shape moved', () => {
 		const { host, editor } = makeHost([
 			shape('box-a', 0, 0),

--- a/packages/svelte/src/viewer/editor/editor-controller-wiring.ts
+++ b/packages/svelte/src/viewer/editor/editor-controller-wiring.ts
@@ -175,6 +175,7 @@ export function createEditorKeydown(host: EditorControllerHost): (event: Keyboar
 		copySelected: () => editor.clipboardOps.copySelected(),
 		cutSelected: () => editor.clipboardOps.cutSelected(),
 		paste: () => void editor.clipboardOps.pasteClipboard(),
+		canPaste: () => editor.hasClipboard,
 		selectAll: () => {
 			// Template-owned elements are only selectable while edit-template mode
 			// is on, so the same interactivity rule the pointer uses applies here.

--- a/packages/svelte/src/viewer/editor/editor-keyboard.test.ts
+++ b/packages/svelte/src/viewer/editor/editor-keyboard.test.ts
@@ -32,6 +32,24 @@ function key(init: KeyboardEventInit): KeyboardEvent {
 }
 
 describe('createEditorKeydownHandler', () => {
+	it.each([{ ctrlKey: true }, { metaKey: true }])(
+		'does not prevent unavailable paste: %j',
+		(modifiers) => {
+			let available = false;
+			const deps = makeDeps({ canPaste: () => available, getSelectedId: () => null });
+			const handler = createEditorKeydownHandler(deps);
+			const empty = new KeyboardEvent('keydown', { key: 'v', ...modifiers, cancelable: true });
+			handler(empty);
+			expect(empty.defaultPrevented).toBeFalsy();
+			expect(deps.paste).not.toHaveBeenCalled();
+			available = true;
+			const populated = new KeyboardEvent('keydown', { key: 'v', ...modifiers, cancelable: true });
+			handler(populated);
+			expect(populated.defaultPrevented).toBeTruthy();
+			expect(deps.paste).toHaveBeenCalledOnce();
+		},
+	);
+
 	it('does nothing when inactive', () => {
 		const deps = makeDeps({ isActive: () => false });
 		createEditorKeydownHandler(deps)(key({ key: 'Delete' }));

--- a/packages/svelte/src/viewer/editor/editor-keyboard.ts
+++ b/packages/svelte/src/viewer/editor/editor-keyboard.ts
@@ -24,6 +24,8 @@ export interface EditorKeyboardDeps {
 	copySelected(): void;
 	cutSelected(): void;
 	paste(): void;
+	/** Omitted preserves custom callers that own their paste command. */
+	canPaste?(): boolean;
 	/** Select every interactive element on the active slide (Ctrl+A). */
 	selectAll(): void;
 	/** Group the multi-selection into one group element (Ctrl+G). */
@@ -52,6 +54,7 @@ export function createEditorKeydownHandler(
 			return;
 		}
 		const { action, dx, dy } = mapEditorKey(event, {
+			canPaste: deps.canPaste?.(),
 			hasSelection: deps.getSelectedId() !== null,
 			isTextInputTarget: isEditorTextInputTarget(event.target),
 		});

--- a/packages/vanilla/src/viewer/editor/editor-controller.ts
+++ b/packages/vanilla/src/viewer/editor/editor-controller.ts
@@ -299,6 +299,10 @@ export function createEditorController(deps: EditorControllerDeps): EditorContro
 		copySelected: () => editActions.copy(),
 		cutSelected: () => editActions.cut(),
 		paste: () => editActions.paste(),
+		canPaste: () => {
+			const state = store.get();
+			return Boolean(state.clipboardPayload && state.slides[state.currentSlide]);
+		},
 		selectAll: () => editActions.selectAll(),
 		groupSelected: () => editActions.groupSelected(),
 		ungroupSelected: () => editActions.ungroupSelected(),

--- a/packages/vanilla/src/viewer/editor/editor-keyboard.test.ts
+++ b/packages/vanilla/src/viewer/editor/editor-keyboard.test.ts
@@ -31,6 +31,24 @@ function keydown(key: string, opts: Partial<KeyboardEventInit> = {}): KeyboardEv
 }
 
 describe('createEditorKeydownHandler clipboard shortcuts', () => {
+	it.each([{ ctrlKey: true }, { metaKey: true }])(
+		'does not prevent unavailable paste: %j',
+		(modifiers) => {
+			let available = false;
+			const deps = makeDeps({ canPaste: () => available, getSelectedId: () => null });
+			const handler = createEditorKeydownHandler(deps);
+			const empty = new KeyboardEvent('keydown', { key: 'v', ...modifiers, cancelable: true });
+			handler(empty);
+			expect(empty.defaultPrevented).toBeFalsy();
+			expect(deps.paste).not.toHaveBeenCalled();
+			available = true;
+			const populated = new KeyboardEvent('keydown', { key: 'v', ...modifiers, cancelable: true });
+			handler(populated);
+			expect(populated.defaultPrevented).toBeTruthy();
+			expect(deps.paste).toHaveBeenCalledOnce();
+		},
+	);
+
 	it('fires copySelected on Ctrl+C when something is selected', () => {
 		const deps = makeDeps();
 		const handler = createEditorKeydownHandler(deps);

--- a/packages/vanilla/src/viewer/editor/editor-keyboard.ts
+++ b/packages/vanilla/src/viewer/editor/editor-keyboard.ts
@@ -21,6 +21,8 @@ export interface EditorKeyboardDeps {
 	cutSelected(): void;
 	/** Paste isn't selection-gated: it targets the current slide regardless of selection. */
 	paste(): void;
+	/** Omitted preserves custom callers that own their paste command. */
+	canPaste?(): boolean;
 	/** Select every interactive element on the active slide (Ctrl+A). */
 	selectAll(): void;
 	/** Group the multi-selection into one group element (Ctrl+G). */
@@ -52,6 +54,7 @@ export function createEditorKeydownHandler(
 			return;
 		}
 		const { action, dx, dy } = mapEditorKey(event, {
+			canPaste: deps.canPaste?.(),
 			hasSelection: deps.getSelectedId() !== null,
 			isTextInputTarget: isEditorTextInputTarget(event.target),
 		});

--- a/packages/vue/src/viewer/PowerPointViewer.vue
+++ b/packages/vue/src/viewer/PowerPointViewer.vue
@@ -1078,6 +1078,7 @@ const mobileChrome = useMobileChrome({
 const { showShortcuts, onEditorKeydown, copySelected, cutSelected, selectAllElements } =
 	useEditorKeyboard({
 		canEdit: () => canEditEffective.value,
+		canPaste: () => clipboard.hasClipboard.value && Boolean(activeSlide.value),
 		hasSelection: selection.hasSelection,
 		presenting: presentation.presenting,
 		findOpen,

--- a/packages/vue/src/viewer/composables/useEditorKeyboard.test.ts
+++ b/packages/vue/src/viewer/composables/useEditorKeyboard.test.ts
@@ -56,6 +56,20 @@ function setup(overrides: Partial<UseEditorKeyboardInput> = {}) {
 }
 
 describe('useEditorKeyboard - F5 / Shift+F5 start-show keys', () => {
+	it('forwards live paste readiness without consuming an empty clipboard chord', () => {
+		const available = ref(false);
+		const { onEditorKeydown, input } = setup({ canPaste: () => available.value });
+		const empty = new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, cancelable: true });
+		onEditorKeydown(empty);
+		expect(empty.defaultPrevented).toBeFalsy();
+		expect(input.pasteElement).not.toHaveBeenCalled();
+		available.value = true;
+		const populated = new KeyboardEvent('keydown', { key: 'v', ctrlKey: true, cancelable: true });
+		onEditorKeydown(populated);
+		expect(populated.defaultPrevented).toBeTruthy();
+		expect(input.pasteElement).toHaveBeenCalledOnce();
+	});
+
 	it('f5 calls presentFromBeginning and prevents default', () => {
 		const { onEditorKeydown, presentFromBeginning, startPresenting } = setup();
 		const event = makeKeyEvent({ key: 'F5' });

--- a/packages/vue/src/viewer/composables/useEditorKeyboard.ts
+++ b/packages/vue/src/viewer/composables/useEditorKeyboard.ts
@@ -12,6 +12,7 @@ import type { UseKeyboardShortcutsResult } from './useKeyboardShortcuts';
 
 export interface UseEditorKeyboardInput {
 	canEdit: () => boolean;
+	canPaste?: () => boolean;
 	hasSelection: ComputedRef<boolean>;
 	/** A slide show (or rehearsal) is actually running, not merely previewing. */
 	presenting: Ref<boolean>;
@@ -176,6 +177,7 @@ export function useEditorKeyboard(input: UseEditorKeyboardInput): UseEditorKeybo
 	}
 
 	const shortcuts = useKeyboardShortcuts({
+		canPaste: input.canPaste,
 		actions: {
 			undo,
 			redo,

--- a/packages/vue/src/viewer/composables/useKeyboardShortcuts.test.ts
+++ b/packages/vue/src/viewer/composables/useKeyboardShortcuts.test.ts
@@ -45,6 +45,23 @@ function defaultGuard(overrides: Partial<ShortcutGuardState> = {}): ShortcutGuar
 }
 
 describe('resolveShortcutAction - pure dispatch logic', () => {
+	it.each([{ ctrlKey: true }, { metaKey: true }])(
+		'does not prevent unavailable paste: %j',
+		(modifiers) => {
+			const canPaste = ref(false);
+			const paste = vi.fn();
+			const keys = useKeyboardShortcuts({ canPaste, hasSelection: false, actions: { paste } });
+			const empty = new KeyboardEvent('keydown', { key: 'v', ...modifiers, cancelable: true });
+			keys.handleKeyDown(empty);
+			expect(empty.defaultPrevented).toBeFalsy();
+			expect(paste).not.toHaveBeenCalled();
+			canPaste.value = true;
+			const populated = new KeyboardEvent('keydown', { key: 'v', ...modifiers, cancelable: true });
+			keys.handleKeyDown(populated);
+			expect(populated.defaultPrevented).toBeTruthy();
+			expect(paste).toHaveBeenCalledOnce();
+		},
+	);
 	describe('guard conditions', () => {
 		it('returns null in present mode', () => {
 			expect(

--- a/packages/vue/src/viewer/composables/useKeyboardShortcuts.ts
+++ b/packages/vue/src/viewer/composables/useKeyboardShortcuts.ts
@@ -128,6 +128,8 @@ export interface UseKeyboardShortcutsOptions {
 
 	/** Whether at least one element is selected. */
 	hasSelection?: MaybeRefOrGetter<boolean>;
+	/** False leaves native paste unclaimed; omitted preserves custom callbacks. */
+	canPaste?: MaybeRefOrGetter<boolean>;
 	/** Id of the element being inline-edited, or `null`. Suppresses shortcuts. */
 	inlineEditingElementId?: MaybeRefOrGetter<string | null>;
 	/** Whether a table cell is actively being edited. Suppresses shortcuts. */
@@ -330,6 +332,7 @@ export function groupShortcutCatalog(
 /** Resolved guard state: the plain (de-reffed) snapshot the matcher reads. */
 export interface ShortcutGuardState {
 	canEdit: boolean;
+	canPaste?: boolean;
 	isPresenting: boolean;
 	hasSelection: boolean;
 	inlineEditingElementId: string | null;
@@ -357,6 +360,7 @@ export function resolveShortcutAction(
 		{ key, ctrlKey: mod, shiftKey },
 		{
 			canEdit: guard.canEdit,
+			canPaste: guard.canPaste,
 			isPresenting: guard.isPresenting,
 			hasSelection: guard.hasSelection,
 			isEditingText: Boolean(guard.inlineEditingElementId || guard.tableEditorIsEditing),
@@ -384,6 +388,7 @@ export function useKeyboardShortcuts(
 	function readGuard(event: KeyboardEvent): ShortcutGuardState {
 		return {
 			canEdit: resolveFlag(options.canEdit, true),
+			canPaste: resolveFlag(options.canPaste, true),
 			isPresenting: resolveFlag(options.isPresenting, false),
 			hasSelection: resolveFlag(options.hasSelection, false),
 			inlineEditingElementId: resolveFlag(options.inlineEditingElementId, null),


### PR DESCRIPTION
## What does this change?

Leave Ctrl/Cmd+V unclaimed when the viewer has no internal clipboard payload, instead of preventing the shortcut and doing nothing. An optional shared guard reads current clipboard readiness in all five bindings; omitted custom callers and populated internal-clipboard priority retain their existing behavior.

This does not add external image import, change inline text editing, or alter read-only permissions.

## Type of change

- [x] Bug fix (non-breaking)

## Cross-binding parity

| Binding | Affected? | Fixed here? | Automated checks |
| --- | --- | --- | --- |
| React | Yes | Yes | Mounted keyboard listener, 11 tests |
| Vue | Yes | Yes | Shortcut and reactive higher-level wiring, 45 tests |
| Angular | Yes | Yes | Actual keyboard service, 20 tests |
| Svelte | Yes | Yes | Keyboard and real controller/history wiring, 23 tests |
| Vanilla | Yes | Yes | Keyboard handler, 16 tests |

### UI fix

- [x] Reproduced the cancellation bug in tests for every binding before changing production.
- [x] Every affected binding is wired to the shared guard.

## Testing

- [x] Unit tests added or updated for each binding.
- [x] Twelve Ctrl/Cmd regressions failed before the fix.
- [x] 142 tests pass across eight suites, including 27 shared keymap tests.
- [x] Independent review and rerun of the original 129-test set, followed by independent review and rerun of the additional Vue/Svelte wiring suites (13 tests). The Vue getter stays reactive; the Svelte real controller preserves internal copy/paste and history.
- [x] Actual toolbar Copy/Paste/Undo/Redo in all five demos, with independently checked element counts 2 -> 3 -> 2 -> 3 and matching dirty/Undo/Redo state.
- [x] Framework-neutral regression added to existing `e2e/keyboard-shortcuts.spec.ts`.
- [ ] Playwright regression executed.
- [ ] Native Ctrl/Cmd+V handoff verified across all five demos.

**Draft gate:** the available browser-control bridge synthesizes a paste event without delivering the relevant native keydown, and rejects the attempted physical-key forms. Those attempts do not validate this shortcut fix. The permanent E2E regression is also unrun. Keep this PR in draft until keyboard/runtime validation and normal CI gates are complete.

The toolbar checks exercise populated internal clipboard and history, not Ctrl/Cmd+V event ownership. They do not satisfy the still-pending native shortcut gate.

The tests preserve populated internal paste, input/read-only suppression, and ordinary history behavior. No clipboard payload is collected by the temporary metadata-only QA harness; the harness is not included in this PR.

## Checks run locally

- [x] Changed-file lint with warnings denied, formatting, and `git diff --check`
- [x] E2E framework-neutrality check
- [x] Focused tests; React, Vue, and shared source-aliased typechecks
- [x] Svelte check: zero errors, five existing warnings
- [x] Own core/shared builds and fresh Angular build
- [ ] Full repository lint/typecheck/test and E2E suite

Vanilla's source-aliased typecheck exposes an unchanged shared animation helper's unused parameter; the same check with only `noUnusedParameters` disabled passes. No unrelated source suppression is included.

## Conventional Commits

- [x] Commit message uses `fix(shared): leave empty clipboard paste shortcuts unclaimed`.

## Screenshots / recordings

This changes event ownership rather than appearance. Automated listener assertions are recorded above; no native OS clipboard success is claimed.
