### PR TITLE
fix(vanilla): preserve split paragraph boundaries through native undo

### DIFF
--- a/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-editor.test.ts
@@ -9,6 +9,7 @@ import type { PptxElement } from 'pptx-viewer-core';
 import { describe, expect, it, vi } from 'vitest';
 
 import { openInlineEditor, readEditableText } from './inline-text-editor';
+import { markInsertedParagraph } from './inline-text-paragraph-marker';
 
 function textElement(): PptxElement {
 	return {
@@ -24,6 +25,97 @@ function textElement(): PptxElement {
 }
 
 describe('openInlineEditor caret placement', () => {
+	it.each([
+		{
+			html: '<div data-pptx-text-flow id="boundary"><span data-pptx-bullet-marker>1.</span><span data-seg-idx="0"><br></span></div><div data-pptx-text-flow><span data-seg-idx="0" id="caret">TARGET</span></div>',
+			text: '\nTARGET',
+		},
+		{
+			html: '<div data-pptx-text-flow>TARGET</div><div data-pptx-text-flow data-pptx-paragraph-start><span data-seg-idx="0">SECOND</span><span data-seg-idx="0" id="boundary"><span id="caret"><br></span></span></div>',
+			text: 'TARGET\nSECOND\n',
+		},
+	])('preserves an intentional empty paragraph: $text', ({ html, text }) => {
+		const surface = document.createElement('div');
+		surface.innerHTML = html;
+		document.body.append(surface);
+		const range = document.createRange();
+		range.setStart(surface.querySelector('#caret')!, 0);
+		range.collapse(true);
+		const selection = window.getSelection()!;
+		selection.removeAllRanges();
+		selection.addRange(range);
+		markInsertedParagraph(document, surface);
+		expect(
+			surface.querySelector('#boundary')!.hasAttribute('data-pptx-paragraph-start'),
+		).toBeTruthy();
+		expect(readEditableText(surface)).toBe(text);
+		surface.remove();
+	});
+
+	it('marks a native split text-flow block without leaving a run annotation after undo', () => {
+		const overlayRoot = document.createElement('div');
+		document.body.appendChild(overlayRoot);
+		const onInput = vi.fn();
+		const onCommit = vi.fn();
+		const session = openInlineEditor({
+			doc: document,
+			overlayRoot,
+			box: { x: 0, y: 0, width: 200, height: 50, rotation: 0 },
+			scale: 1,
+			element: textElement(),
+			onInput,
+			onCommit,
+			onClose: () => {},
+		});
+		// Recorded Chromium structure after splitting a rich text-flow wrapper.
+		const secondFlow = document.createElement('div');
+		secondFlow.dataset.pptxTextFlow = '';
+		const marker = document.createElement('span');
+		marker.dataset.pptxBulletMarker = '';
+		marker.textContent = '1. ';
+		secondFlow.append(marker);
+		const inserted = document.createElement('span');
+		inserted.dataset.segIdx = '1';
+		inserted.textContent = '\n';
+		const suffix = document.createElement('span');
+		suffix.textContent = 'NEXT';
+		secondFlow.append(inserted, suffix);
+		session.el.append(secondFlow);
+		const range = document.createRange();
+		range.setStart(inserted.firstChild!, 0);
+		range.collapse(true);
+		const selection = window.getSelection()!;
+		selection.removeAllRanges();
+		selection.addRange(range);
+		session.el.dispatchEvent(
+			new InputEvent('input', { bubbles: true, inputType: 'insertParagraph' }),
+		);
+		expect(secondFlow.hasAttribute('data-pptx-paragraph-start')).toBeTruthy();
+		expect(inserted.hasAttribute('data-pptx-paragraph-start')).toBeFalsy();
+		inserted.textContent = 'INSERTED\n';
+		session.el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }));
+		expect(onInput).toHaveBeenLastCalledWith('TARGET\nINSERTED\nNEXT');
+		// Native history restores the delimiter, then rejoins the original runs.
+		inserted.textContent = '\n';
+		session.el.dispatchEvent(new InputEvent('input', { inputType: 'historyUndo' }));
+		expect(onInput).toHaveBeenLastCalledWith('TARGET\n\nNEXT');
+		const originalFlow = session.el.querySelector<HTMLElement>('[data-pptx-text-flow]')!;
+		originalFlow.append(inserted, suffix);
+		secondFlow.remove();
+		session.el.dispatchEvent(new InputEvent('input', { inputType: 'historyUndo' }));
+		expect(onInput).toHaveBeenLastCalledWith('TARGET\nNEXT');
+		secondFlow.append(inserted, suffix);
+		session.el.append(secondFlow);
+		session.el.dispatchEvent(new InputEvent('input', { inputType: 'historyRedo' }));
+		expect(onInput).toHaveBeenLastCalledWith('TARGET\n\nNEXT');
+		inserted.textContent = 'INSERTED\n';
+		session.el.dispatchEvent(new InputEvent('input', { inputType: 'historyRedo' }));
+		expect(onInput).toHaveBeenLastCalledWith('TARGET\nINSERTED\nNEXT');
+		session.commit();
+		expect(onCommit).toHaveBeenCalledExactlyOnceWith('TARGET\nINSERTED\nNEXT');
+		overlayRoot.remove();
+	});
+
 	it('collapses the selection to the end of the seeded text', () => {
 		const overlayRoot = document.createElement('div');
 		document.body.appendChild(overlayRoot);

--- a/packages/vanilla/src/viewer/editor/inline-text-paragraph-marker.ts
+++ b/packages/vanilla/src/viewer/editor/inline-text-paragraph-marker.ts
@@ -31,8 +31,16 @@ export function markInsertedParagraph(doc: Document, surface: HTMLElement): void
 	}
 	const block = insertedRun.closest<HTMLElement>('div, p');
 	const isTextFlow = block?.hasAttribute('data-pptx-text-flow');
+	// A split flow owns its boundary. Marking a surviving authored run would
+	// leave an extra break after native undo rejoins it into the original flow.
+	const isSplitTextFlow =
+		isTextFlow &&
+		block?.previousElementSibling?.hasAttribute('data-pptx-text-flow') &&
+		block.querySelector('[data-seg-idx]:not([data-pptx-bullet-marker])') === insertedRun;
 	const caretParagraph =
-		block && block !== surface && !isTextFlow && surface.contains(block) ? block : insertedRun;
+		block && block !== surface && (!isTextFlow || isSplitTextFlow) && surface.contains(block)
+			? block
+			: insertedRun;
 	const previous = caretParagraph.previousElementSibling;
 	const paragraph =
 		previous instanceof HTMLElement &&


### PR DESCRIPTION
## Summary

Fix an extra blank paragraph when plain Enter splits a rich-text flow in the Vanilla inline editor.

The editor annotated the first run of the new block. That duplicated the block boundary during text extraction. It also left the annotation on an original delimiter run when native Undo rejoined the flow, so undoing Enter could still commit an extra blank paragraph.

When the caret is in the first editable run of a new sibling text-flow block, annotate that block instead. Keep the existing run annotation for Enter within a single flow, including the leading-placeholder handling from #211 and #223. The shared reader and the other four bindings are unchanged.

### Cross-binding scope

This corrects Vanilla's `markInsertedParagraph` producer, not shared newline policy. The React, Vue, Svelte, and Angular editor paths do not invoke this producer or attach its inserted-run boundary annotation. Their input/commit paths were checked; they do not have this specific double-counted annotation or native Undo residue. Angular's textarea also deliberately commits on plain Enter. Other live-list behavior is separate work, not claimed fixed here.

## Validation

- Regression added to the existing mounted Vanilla inline-editor test file, including the recorded split structure, typing, reconstructed Undo/Redo structure, exact committed text, list-marker chrome, and intentional empty-paragraph controls.
- 66 tests pass across the inline editor, inline autofit, paragraph mutations, format mutations, and edit operations.
- Independent code review reran 15 inline-editor tests and 14 unchanged shared-reader tests.
- Scoped strict TypeScript, lint, formatting, and diff checks pass.
- Actual Chromium keyboard testing confirmed that Enter and typing produce six intended paragraphs; undoing typing keeps the intentional blank paragraph; undoing Enter restores the original five paragraphs with no residual annotation; Redo restores the edited six paragraphs.
- A matched untouched-main browser control produced seven paragraphs after typing and still retained an unwanted sixth paragraph after undoing Enter. This verifies the same ordinary flow fails before the change.
- Actual leading and trailing empty-paragraph controls retain exactly one blank through native Undo/Redo.
- Native save and reopen retain the six intended bodies without a spurious blank. Independent ZIP review confirmed all five surviving original paragraph-properties nodes are unchanged and no generated marker was added to authored body text.

The committed history regression reconstructs browser-produced DOM and does not substitute for the actual native keyboard check. No new framework-neutral browser test is claimed: Angular intentionally uses plain Enter to commit, while substituting the common Shift+Enter would miss this specific native split-flow path. No framework-specific test fallback or custom undo implementation was added.

This fixes paragraph-boundary ownership only. The separate nested-list inheritance/numbering correction in #263 is not included in this checkout and is not claimed by this PR. This is not a claim of complete list-editing parity or coverage of every browser engine.
